### PR TITLE
Add DeepJump DevOps toolkit and integrity workflows

### DIFF
--- a/.github/workflows/deepjump-ci.yml
+++ b/.github/workflows/deepjump-ci.yml
@@ -1,0 +1,40 @@
+name: DeepJump CI
+
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  deepjump-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Verify Logic (P9 Check)
+        run: make verify-json
+      - name: Emit & Verify Status Integrity
+        env:
+          CI_SECRET: ${{ secrets.CI_SECRET }}
+        run: make status-verify STATUS=PASS H=0.85 DMI=4.8 PHI=0.75
+      - name: Generate Snapshot Manifest
+        run: make snapshot SNAPSHOT_INPUTS='"seeds/*.yaml" "audit/*.yaml"'
+      - name: Upload Audit Artifacts
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepjump-audit-trail
+          path: |
+            out/status/deepjump_status.json
+            out/badges/deepjump.svg
+            out/verify.json
+            out/snapshot_manifest.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+PY ?= python3
+OUT ?= out
+RECEIPT ?= receipts/arc_sample.json
+SNAPSHOT_INPUTS ?= "seeds/*.yaml" "audit/*.yaml"
+STATUS ?= PASS
+H ?= 0.84
+DMI ?= 4.7
+PHI ?= 0.72
+REFRACTORY ?= 120
+
+.PHONY: verify-json status status-verify snapshot clean all
+
+all: verify-json status-verify snapshot
+
+verify-json:
+	@mkdir -p $(OUT)
+	@$(PY) tests/verify_deep_jump.py --receipt $(RECEIPT) --json > $(OUT)/verify.json
+
+status:
+	@mkdir -p $(OUT)
+	@$(PY) tools/status_emit.py \
+		--outdir $(OUT) \
+		--status $(STATUS) \
+		--H $(H) \
+		--dmi $(DMI) \
+		--phi $(PHI) \
+		--refractory $(REFRACTORY)
+
+status-verify: status
+	@$(PY) tools/status_verify.py $(OUT)/status/deepjump_status.json
+
+snapshot:
+	@mkdir -p $(OUT)
+	@$(PY) tools/snapshot_guard.py $(OUT)/snapshot_manifest.json $(SNAPSHOT_INPUTS) --strict
+
+clean:
+	rm -rf $(OUT)

--- a/audit/audit_matrix.yaml
+++ b/audit/audit_matrix.yaml
@@ -1,0 +1,14 @@
+# Audit matrix for DeepJump controls
+controls:
+  FIX_PATH_DRIFT:
+    owner: devops
+    evidence: out/snapshot_manifest.json
+  FREEZE_SEEDS:
+    owner: reliability
+    evidence: out/snapshot_manifest.json
+  FIX_STATUS_INTEGRITY:
+    owner: security
+    evidence: out/status/deepjump_status.json
+  P9_RUNBOOK_CHECK:
+    owner: governance
+    evidence: out/verify.json

--- a/audit/audit_scope.yaml
+++ b/audit/audit_scope.yaml
@@ -1,0 +1,10 @@
+# Scope definition for DeepJump audit trail
+service: entaENGELment
+module_refs:
+  - MOD_6_RECEIPTS_CORE
+  - MOD_15_STATS_TESTS
+artifacts:
+  - out/verify.json
+  - out/status/deepjump_status.json
+  - out/snapshot_manifest.json
+notes: Ensure uploads occur only on successful CI runs.

--- a/docs/devops_tooling_kit.md
+++ b/docs/devops_tooling_kit.md
@@ -1,0 +1,140 @@
+# EntaENGELment DevOps Tooling Kit
+
+Dieses Dokument beschreibt das vollständige DevOps‑Kit für das EntaENGELment‑Projekt. Es ergänzt den Kernindex durch eine technische Annex‑Ebene: der Code und die Konfigurationen werden ausgelagert, während der Index nur auf diese Dateien verweist. Das Kit gewährleistet Reproduzierbarkeit, Governance und kryptographische Integrität.
+
+## Repository‑Layout
+
+Die folgende Baumstruktur spiegelt den Standardaufbau wider und definiert, wo sich die relevanten Artefakte befinden. Sie dient als Referenz für die Module innerhalb des Kernindex.
+
+```
+entaengelment-core/
+├── index/                       # Kernindex (Tier‑0/1/2) und Modul‑Metadaten
+│   ├── COMPACT_INDEX_v3.yaml
+│   └── modules/
+│       ├── MOD_6_RECEIPTS_CORE.yaml
+│       └── MOD_15_STATS_TESTS.yaml
+├── docs/                        # Annex‑Dokumente
+│   └── devops_tooling_kit.md    # dieses Dokument
+├── tools/                       # operative Skripte
+│   ├── snapshot_guard.py        # Manifest‑Generator mit relativen Pfaden
+│   ├── status_emit.py           # Status‑Emitter mit HMAC‑Signierung
+│   └── status_verify.py         # Verifikationswerkzeug für den Status
+├── tests/                       # Verifikations‑Skripte (Beispiele)
+│   ├── test_snapshot_guard.py   # Testet Portabilität und Determinismus
+│   ├── test_status_emit.py      # Testet HMAC‑Einbindung
+│   └── verify_deep_jump.py      # P9‑Runbook‑Logik (Referenz)
+├── receipts/                    # Beispiel‑Quittungen (JSON)
+├── seeds/                       # Konfigurations‑Seeds (müssen ins Manifest)
+├── audit/                       # Audit‑Logs und Governance‑Tabellen
+├── .github/workflows/           # CI‑Konfigurationen
+│   └── deepjump-ci.yml
+└── Makefile                     # zentraler Entry‑Point für Tasks
+```
+
+## Snapshot Guard
+
+`tools/snapshot_guard.py` erstellt ein JSON‑Manifest mit SHA‑256‑Hashes aller vom Benutzer angegebenen Eingabedateien. Um Portabilität zu garantieren, werden Pfade relativ zum Repository‑Root angegeben; Dateien außerhalb des Repos werden übersprungen. Über die Option `--strict` kann der Vorgang abbrechen, wenn keine Seed‑Dateien im Manifest auftauchen. Dies erfüllt die Anforderungen aus `MOD_6_RECEIPTS_CORE` (`FIX_PATH_DRIFT` und `FREEZE_SEEDS`).
+
+```python
+#!/usr/bin/env python3
+"""EntaENGELment Snapshot Guard (Final Hardened)
+Zweck: Erstellt Manifest mit SHA‑256 Hashes.
+Härtung: commonpath‑Check, Root‑Globbing, Strict‑Mode."""
+```
+
+### Nutzung
+
+```bash
+# Erstellung eines Manifests für Seeds und Audit‑Konfigurationen
+python tools/snapshot_guard.py out/snapshot_manifest.json "seeds/*.yaml" "audit/*.yaml" --strict
+```
+
+## Status Emit
+
+`tools/status_emit.py` erzeugt eine Statusdatei (`deepjump_status.json`) sowie ein visuelles Badge (`deepjump.svg`). Die Nutzdaten (Status, Metriken, Zeitstempel) werden canonicalisiert und mittels HMAC‑SHA256 signiert. Das Geheimnis wird vorzugsweise aus der Umgebungsvariable `CI_SECRET` (oder `ENTA_HMAC_SECRET`) gelesen; eine CLI‑Option existiert für Fallback‑Szenarien. Dies entspricht der Spezifikation `FIX_STATUS_INTEGRITY` aus `MOD_15_STATS_TESTS`.
+
+```python
+#!/usr/bin/env python3
+"""EntaENGELment Status Emitter (Final Hardened)
+Zweck: Erzeugt status.json mit HMAC‑Signatur.
+Härtung: ENV‑Secrets, Canonical JSON."""
+```
+
+### Nutzung
+
+```bash
+CI_SECRET="my-secret" python tools/status_emit.py --outdir out --status PASS --H 0.85 --dmi 4.8 --phi 0.75 --refractory 120
+```
+
+## Status Verify
+
+Um sicherzustellen, dass die HMAC‑Signatur korrekt ist, bietet `tools/status_verify.py` ein Prüfwerkzeug. Es entfernt die Signatur aus der Datei, canonicalisiert den Rest und berechnet den erwarteten HMAC. Stimmen Werte nicht überein, liefert das Tool einen Fehlercode ungleich 0.
+
+```python
+#!/usr/bin/env python3
+"""EntaENGELment Status Verifier
+Zweck: Prüft HMAC‑SHA256 Signatur eines status.json."""
+```
+
+## Makefile
+
+Die Makefile definiert die zentralen Aufgaben: Verifikation, Status‑Emit, HMAC‑Verifikation und Snapshot. Pattern‑Globbing wird in Anführungszeichen übergeben, sodass Python die Muster verarbeitet und nicht die Shell. Ein integriertes `status-verify`‑Target führt den Self‑Check direkt aus.
+
+```Makefile
+PY ?= python3
+OUT ?= out
+RECEIPT ?= receipts/arc_sample.json
+SNAPSHOT_INPUTS ?= "seeds/*.yaml" "audit/*.yaml"
+STATUS ?= PASS
+H ?= 0.84
+DMI ?= 4.7
+PHI ?= 0.72
+REFRACTORY ?= 120
+```
+
+## CI‑Workflow
+
+Das GitHub‑Workflow `deepjump-ci.yml` automatisiert die Abfolge aus Verifikation, Status‑Emission, HMAC‑Überprüfung, Snapshot und Artefakt‑Upload. Durch die Bedingung `if: ${{ success() }}` wird ein Upload nur durchgeführt, wenn alle vorherigen Schritte fehlerfrei abgeschlossen wurden.
+
+```yaml
+name: DeepJump CI
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+jobs:
+  deepjump-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Verify Logic (P9 Check)
+        run: make verify-json
+      - name: Emit & Verify Status Integrity
+        env:
+          CI_SECRET: ${{ secrets.CI_SECRET }}
+        run: make status-verify STATUS=PASS H=0.85 DMI=4.8 PHI=0.75
+      - name: Generate Snapshot Manifest
+        run: make snapshot SNAPSHOT_INPUTS='"seeds/*.yaml" "audit/*.yaml"'
+      - name: Upload Audit Artifacts
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepjump-audit-trail
+          path: |
+            out/status/deepjump_status.json
+            out/badges/deepjump.svg
+            out/verify.json
+            out/snapshot_manifest.json
+```
+
+Dieses DevOps‑Kit bildet die operative Grundlage für das EntaENGELment‑Projekt. Es trennt den Kernindex von der technischen Implementierung und stellt sicher, dass jede Aussage oder Metrik durch entsprechende Tests und Quittungen abgesichert ist. Die Härtungsspezifikationen aus den Modul‑Metadaten sind vollständig implementiert und werden sowohl lokal als auch in der CI durchgesetzt.

--- a/index/COMPACT_INDEX_v3.yaml
+++ b/index/COMPACT_INDEX_v3.yaml
@@ -1,0 +1,17 @@
+version: 3
+description: >
+  Compact index for EntaENGELment DevOps kit (Tier-0/1/2).
+  References hardened controls and their module descriptors.
+modules:
+  - id: MOD_6_RECEIPTS_CORE
+    path: modules/MOD_6_RECEIPTS_CORE.yaml
+    summary: Receipts core, snapshot controls, seed freezing.
+  - id: MOD_15_STATS_TESTS
+    path: modules/MOD_15_STATS_TESTS.yaml
+    summary: Status emission integrity and DeepJump verification.
+integrity:
+  hash_algo: sha256
+  governance: immutable-index
+metadata:
+  maintainer: entaENGELment
+  last_review: 2024-06-30

--- a/index/modules/MOD_15_STATS_TESTS.yaml
+++ b/index/modules/MOD_15_STATS_TESTS.yaml
@@ -1,0 +1,24 @@
+id: MOD_15_STATS_TESTS
+title: DeepJump Status Integrity & Tests
+version: 1
+controls:
+  - id: FIX_STATUS_INTEGRITY
+    description: >
+      Status payloads must be canonicalized and HMAC signed using env-provided
+      secrets; unsigned payloads are marked as untrusted.
+    implemented_by: tools/status_emit.py
+  - id: VERIFY_STATUS_CHAIN
+    description: >
+      HMAC signature verification is required for published status artifacts.
+    implemented_by: tools/status_verify.py
+  - id: P9_RUNBOOK_CHECK
+    description: >
+      DeepJump receipts must validate proofs and metrics before publication.
+    implemented_by: tests/verify_deep_jump.py
+artifacts:
+  status_json: out/status/deepjump_status.json
+  status_badge: out/badges/deepjump.svg
+  verify_report: out/verify.json
+notes: |
+  CI workflow deepjump-ci.yml runs status emission, verification, and snapshot
+  generation. Secrets are read from CI_SECRET or ENTA_HMAC_SECRET.

--- a/index/modules/MOD_6_RECEIPTS_CORE.yaml
+++ b/index/modules/MOD_6_RECEIPTS_CORE.yaml
@@ -1,0 +1,27 @@
+id: MOD_6_RECEIPTS_CORE
+title: Receipts Core / Snapshot Integrity
+version: 1
+controls:
+  - id: FIX_PATH_DRIFT
+    description: >
+      Snapshot manifest must only include files within repo root using relative
+      paths; outside files are skipped with warnings.
+    implemented_by: tools/snapshot_guard.py
+  - id: FREEZE_SEEDS
+    description: >
+      Seed configurations must always be present in manifests; strict mode fails
+      when missing.
+    implemented_by: tools/snapshot_guard.py --strict
+artifacts:
+  manifest: out/snapshot_manifest.json
+  receipts:
+    sample: receipts/arc_sample.json
+  seeds:
+    - seeds/seed_config.yaml
+    - seeds/seed_extras.yaml
+  audit:
+    - audit/audit_matrix.yaml
+    - audit/audit_scope.yaml
+notes: |
+  The snapshot guard enforces deterministic hashing using SHA-256 with
+  canonical ordering. Relative path anchoring prevents host leakage.

--- a/receipts/arc_sample.json
+++ b/receipts/arc_sample.json
@@ -1,0 +1,16 @@
+{
+  "id": "arc-sample-001",
+  "status": "valid",
+  "proofs": {
+    "receipt_proof": "dual-receipt-v1",
+    "context_signature": "context-signed"
+  },
+  "metrics": {
+    "H": 0.84,
+    "dmi_score": 4.7,
+    "phi_integrity": 0.72,
+    "refractory_ms": 120
+  },
+  "seed_snapshot": "out/snapshot_manifest.json",
+  "notes": "Sample receipt for DeepJump verification pipeline."
+}

--- a/seeds/seed_config.yaml
+++ b/seeds/seed_config.yaml
@@ -1,0 +1,9 @@
+# Seed configuration for EntaENGELment DeepJump
+version: 1
+profile: default
+metrics:
+  H: 0.84
+  dmi_score: 4.7
+  phi_integrity: 0.72
+  refractory_ms: 120
+notes: Anchored seed ensures deterministic baseline for snapshots.

--- a/seeds/seed_extras.yaml
+++ b/seeds/seed_extras.yaml
@@ -1,0 +1,7 @@
+# Secondary seed values used for drift detection
+version: 1
+audit_scope: deepjump
+controls:
+  - FIX_PATH_DRIFT
+  - FREEZE_SEEDS
+comments: Keep aligned with MOD_6_RECEIPTS_CORE.

--- a/tests/test_snapshot_guard.py
+++ b/tests/test_snapshot_guard.py
@@ -1,0 +1,49 @@
+import json
+import os
+import subprocess
+import sys
+
+
+def run_guard(out_path, *patterns):
+    cmd = [
+        sys.executable,
+        "tools/snapshot_guard.py",
+        str(out_path),
+        *patterns,
+        "--strict",
+    ]
+    return subprocess.run(cmd, check=True, capture_output=True, text=True)
+
+
+def test_snapshot_guard_includes_seeds_and_rel_paths(tmp_path):
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("external")
+
+    manifest_path = tmp_path / "snapshot_manifest.json"
+    run_guard(manifest_path, "seeds/*.yaml", "audit/*.yaml", str(outside_file))
+
+    with open(manifest_path, "r") as f:
+        manifest = json.load(f)
+
+    assert any(key.startswith("seeds/") for key in manifest["files"].keys())
+    assert "seeds/seed_config.yaml" in manifest["files"]
+    assert "seeds/seed_extras.yaml" in manifest["files"]
+    assert all(not os.path.isabs(key) for key in manifest["files"])
+    assert not any("outside.txt" in key for key in manifest["files"])
+
+
+def test_snapshot_guard_warns_without_seeds(tmp_path):
+    manifest_path = tmp_path / "snapshot_manifest.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "tools/snapshot_guard.py",
+            str(manifest_path),
+            "audit/*.yaml",
+            "--strict",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "No seeds/" in result.stdout or "No seeds/" in result.stderr

--- a/tests/test_status_emit.py
+++ b/tests/test_status_emit.py
@@ -1,0 +1,42 @@
+import json
+import os
+import subprocess
+import sys
+
+
+def test_status_emit_and_verify(tmp_path):
+    env = os.environ.copy()
+    env["CI_SECRET"] = "super-secret"
+
+    out_dir = tmp_path
+    status_cmd = [
+        sys.executable,
+        "tools/status_emit.py",
+        "--outdir",
+        str(out_dir),
+        "--status",
+        "PASS",
+        "--H",
+        "0.85",
+        "--dmi",
+        "4.8",
+        "--phi",
+        "0.75",
+        "--refractory",
+        "120",
+    ]
+    subprocess.run(status_cmd, check=True, env=env)
+
+    status_path = out_dir / "status" / "deepjump_status.json"
+    assert status_path.exists()
+
+    with open(status_path, "r") as f:
+        payload = json.load(f)
+    assert payload["signatures"]["hmac"] != "UNSIGNED"
+
+    verify_cmd = [
+        sys.executable,
+        "tools/status_verify.py",
+        str(status_path),
+    ]
+    subprocess.run(verify_cmd, check=True, env=env)

--- a/tests/verify_deep_jump.py
+++ b/tests/verify_deep_jump.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""DeepJump verification utility (P9 Runbook reference)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Dict, List, Tuple
+
+
+def load_receipt(path: str) -> Dict:
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Receipt not found: {path}")
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def validate_receipt(data: Dict) -> Tuple[str, List[str]]:
+    issues: List[str] = []
+
+    status_ok = data.get("status") == "valid"
+    if not status_ok:
+        issues.append("status not valid")
+
+    proofs = data.get("proofs", {})
+    proofs_ok = {"receipt_proof", "context_signature"}.issubset(set(proofs.keys()))
+    if not proofs_ok:
+        issues.append("missing proofs")
+
+    metrics = data.get("metrics", {})
+    required_metrics = {"H", "dmi_score", "phi_integrity", "refractory_ms"}
+    metrics_ok = required_metrics.issubset(set(metrics.keys()))
+    if metrics_ok:
+        numeric_ok = all(isinstance(metrics[k], (int, float)) for k in required_metrics)
+        metrics_ok = metrics_ok and numeric_ok
+    else:
+        issues.append("missing metrics")
+
+    seed_ref = bool(data.get("seed_snapshot"))
+    if not seed_ref:
+        issues.append("missing seed snapshot reference")
+
+    all_ok = status_ok and proofs_ok and metrics_ok and seed_ref
+    verdict = "pass" if all_ok else "fail"
+    return verdict, issues
+
+
+def build_report(data: Dict) -> Dict:
+    verdict, issues = validate_receipt(data)
+    return {
+        "receipt_id": data.get("id"),
+        "status": data.get("status"),
+        "verdict": verdict,
+        "issues": issues,
+        "proofs_present": {"receipt_proof", "context_signature"}.issubset(set(data.get("proofs", {}).keys())),
+        "metrics_keys": sorted(list(data.get("metrics", {}).keys())),
+        "seed_snapshot": data.get("seed_snapshot"),
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="DeepJump verification runner.")
+    parser.add_argument("--receipt", required=True, help="Path to receipt JSON")
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        data = load_receipt(args.receipt)
+    except FileNotFoundError as exc:
+        print(f"[FAIL] {exc}")
+        sys.exit(1)
+
+    report = build_report(data)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"[REPORT] receipt={report['receipt_id']} verdict={report['verdict']}")
+        if report["issues"]:
+            print("Issues:", ", ".join(report["issues"]))
+
+    if report["verdict"] != "pass":
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/snapshot_guard.py
+++ b/tools/snapshot_guard.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""EntaENGELment Snapshot Guard (Final Hardened)
+
+Zweck: Erstellt Manifest mit SHA-256 Hashes.
+Härtung: commonpath-Check, Root-Globbing, Strict-Mode.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List
+
+
+def hash_file(path: str) -> str:
+    sha256 = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            while True:
+                data = f.read(65536)
+                if not data:
+                    break
+                sha256.update(data)
+        return sha256.hexdigest()
+    except FileNotFoundError:
+        return "MISSING"
+
+
+def get_repo_root() -> str:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.abspath(os.path.join(script_dir, ".."))
+
+
+def is_within_root(abs_path: str, repo_root: str) -> bool:
+    try:
+        return os.path.commonpath([abs_path, repo_root]) == repo_root
+    except ValueError:
+        return False
+
+
+def build_file_list(repo_root: str, patterns: Iterable[str]) -> List[str]:
+    files_to_process: List[str] = []
+    for pattern in patterns:
+        search_pattern = pattern if os.path.isabs(pattern) else os.path.join(repo_root, pattern)
+        files_to_process.extend(glob.glob(search_pattern, recursive=True))
+    return sorted(list(set(files_to_process)))
+
+
+def create_manifest(repo_root: str, files: Iterable[str]) -> Dict[str, str]:
+    manifest_files: Dict[str, str] = {}
+    for fpath in files:
+        if os.path.isfile(fpath):
+            abs_path = os.path.abspath(fpath)
+            if not is_within_root(abs_path, repo_root):
+                print(f"[WARN] Skipping file outside repo root: {fpath}")
+                continue
+            rel_path = os.path.relpath(abs_path, start=repo_root).replace("\\", "/")
+            manifest_files[rel_path] = hash_file(abs_path)
+    return manifest_files
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("manifest_out", help="Path to output manifest.json")
+    parser.add_argument("inputs", nargs="+", help="Input patterns (globs)")
+    parser.add_argument("--strict", action="store_true", help="Fail if critical seeds are missing")
+    args = parser.parse_args()
+
+    repo_root = get_repo_root()
+    manifest = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "repo_root_anchor": "REL_TO_ROOT",
+        "files": {},
+    }
+
+    files_to_process = build_file_list(repo_root, args.inputs)
+    manifest["files"] = create_manifest(repo_root, files_to_process)
+
+    has_seeds = any(k.startswith("seeds/") for k in manifest["files"].keys())
+    if not has_seeds:
+        msg = "[WARN] No seeds/ detected in snapshot! Config drift risk."
+        print(msg)
+        if args.strict:
+            print("[FAIL] Strict mode active. Aborting.")
+            sys.exit(1)
+
+    out_dir = os.path.dirname(os.path.abspath(args.manifest_out))
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.manifest_out, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+    print(f"[SNAPSHOT] Generated at {args.manifest_out} ({len(manifest['files'])} files)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/status_emit.py
+++ b/tools/status_emit.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""EntaENGELment Status Emitter (Final Hardened)
+
+Zweck: Erzeugt status.json mit HMAC-Signatur.
+Härtung: ENV-Secrets, Canonical JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+from datetime import datetime, timezone
+from typing import Dict, Tuple
+
+
+def sign_payload(payload: Dict, secret: str) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    signature = hmac.new(secret.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    return signature
+
+
+def emit_badge(status: str, out_dir: str) -> None:
+    color = {"PASS": "#4c1", "FAIL": "#e05d44", "WARN": "#dfb317"}.get(status, "#999")
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="20">'
+        f'<rect width="100" height="20" fill="#555"/>'
+        f'<rect x="55" width="45" height="20" fill="{color}"/>'
+        f'<g fill="#fff" text-anchor="middle" font-family="Verdana" font-size="11">'
+        f'<text x="27.5" y="14">DeepJump</text>'
+        f'<text x="77.5" y="14">{status}</text>'
+        f'</g>'
+        f'</svg>'
+    )
+    with open(os.path.join(out_dir, "deepjump.svg"), "w") as f:
+        f.write(svg)
+
+
+def build_payload(args: argparse.Namespace) -> Tuple[Dict, str]:
+    secret = os.environ.get("CI_SECRET") or os.environ.get("ENTA_HMAC_SECRET") or args.secret
+    payload = {
+        "system": "EntaENGELment DeepJump",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "status": args.status,
+        "metrics": {
+            "H": args.H,
+            "dmi_score": args.dmi,
+            "phi_integrity": args.phi,
+            "refractory_ms": args.refractory,
+        },
+        "signature_type": "hmac-sha256",
+    }
+
+    if secret:
+        sig = sign_payload(payload, secret)
+        payload["signatures"] = {"hmac": sig, "key_id": "ci-primary"}
+    else:
+        payload["signatures"] = {
+            "hmac": "UNSIGNED",
+            "warning": "No secret provided. Untrusted status.",
+        }
+    return payload, secret
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--outdir", required=True)
+    parser.add_argument("--status", default="PASS")
+    parser.add_argument("--secret", help="Optional CLI secret (ENV preferred)", default="")
+    parser.add_argument("--H", type=float, default=0.0)
+    parser.add_argument("--dmi", type=float, default=0.0)
+    parser.add_argument("--phi", type=float, default=0.0)
+    parser.add_argument("--refractory", type=int, default=0)
+    args = parser.parse_args()
+
+    status_dir = os.path.join(args.outdir, "status")
+    badges_dir = os.path.join(args.outdir, "badges")
+    os.makedirs(status_dir, exist_ok=True)
+    os.makedirs(badges_dir, exist_ok=True)
+
+    payload, secret = build_payload(args)
+    json_path = os.path.join(status_dir, "deepjump_status.json")
+    with open(json_path, "w") as f:
+        json.dump(payload, f, indent=2)
+
+    emit_badge(args.status, badges_dir)
+    print(f"[STATUS] Emitted (Signed: {bool(secret)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/status_verify.py
+++ b/tools/status_verify.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""EntaENGELment Status Verifier
+
+Zweck: Prüft HMAC-SHA256 Signatur eines status.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import sys
+from typing import Dict, Tuple
+
+
+def verify_payload(data: Dict, secret: str) -> Tuple[bool, str]:
+    signatures = data.pop("signatures", None)
+    if not signatures or "hmac" not in signatures:
+        return False, "No signature found"
+
+    target_hmac = signatures["hmac"]
+    canonical = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    computed_hmac = hmac.new(secret.encode("utf-8"), canonical.encode("utf-8"), hashlib.sha256).hexdigest()
+    if hmac.compare_digest(target_hmac, computed_hmac):
+        return True, "OK"
+    return False, f"Mismatch: {computed_hmac} != {target_hmac}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("json_file", help="Path to deepjump_status.json")
+    parser.add_argument("--secret", help="HMAC secret (ENV preferred)")
+    args = parser.parse_args()
+
+    secret = os.environ.get("CI_SECRET") or os.environ.get("ENTA_HMAC_SECRET") or args.secret
+    if not secret:
+        print("[ERR] Cannot verify: No secret provided.")
+        sys.exit(2)
+
+    with open(args.json_file, "r") as f:
+        data = json.load(f)
+
+    valid, msg = verify_payload(data, secret)
+    if valid:
+        print(f"[OK] Signature verified for {args.json_file}")
+        sys.exit(0)
+
+    print(f"[FAIL] Integrity Check Failed: {msg}")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add compact index and module descriptors for receipts core and stats integrity controls
- add hardened snapshot/status utilities with supporting seeds, receipts, and audit annex docs
- add Makefile, CI workflow, and tests for DeepJump verification, status emission, and snapshots

## Testing
- python -m pytest tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948887498988325b646be3baba7c7b9)