### PR TITLE
Fix smoke workflow to fail on pytest errors

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -8,4 +8,4 @@ jobs:
       - name: Install pytest
         run: pip install pytest
       - name: Run tests
-        run: pytest tests || true
+        run: pytest tests


### PR DESCRIPTION
### Motivation
- The smoke GitHub Action was masking `pytest` failures by appending `|| true`, so test failures never caused the job to fail.
- This allowed regressions to pass push/pull_request gates and defeated the purpose of the smoke pipeline.

### Description
- Updated `.github/workflows/ci-smoke.yml` to remove the `|| true` from the `Run tests` step so that `pytest tests` returns a non‑zero exit code on failures.
- The `Run tests` step now runs `pytest tests` directly, causing the job to fail when tests fail.

### Testing
- No automated tests were executed as this is a workflow-only change and requires GitHub Actions to run on the next push or PR.
- Once the workflow runs, the smoke job will fail on non‑zero `pytest` exit codes as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f0544dc083259c2910bcaca27f8a)