### PR TITLE
Fix ci-smoke.yml: Install pytest-cov for coverage flags

Problem: pytest fails with unrecognized coverage arguments because
pyproject.toml configures --cov flags in addopts, but pytest-cov
is not installed in the smoke test workflow.

Solution: Install pytest-cov alongside pytest to support the coverage
flags configured in pyproject.toml:65-69.

Fixes CI smoke test failures related to coverage arguments.

### DIFF
--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install pytest and pytest-cov
+        run: pip install pytest pytest-cov
       - name: Run tests
         run: pytest tests


### PR DESCRIPTION
# PR

## Ziel
Kurzbeschreibung der Änderung.

## Änderungen
- …

## Auswirkungen
- Policy?
- Spec?
- Runtime?

## Unterschriften
- Kevin
- Companion-A
- GPT
