### PR TITLE
feat(PHASE_0): Implement Safety Conscience - Consent & KillSwitch

### DIFF
--- a/Plugins/SynthosiaCore/Source/SynthosiaCore/Private/KillSwitch.cpp
+++ b/Plugins/SynthosiaCore/Source/SynthosiaCore/Private/KillSwitch.cpp
@@ -1,0 +1,19 @@
+#include "KillSwitch.h"
+
+void UKillSwitchSubsystem::TriggerKillSwitch(FString Reason)
+{
+	// Wenn schon tot, dann ignorieren (Idempotenz)
+	if (bIsActive) return;
+
+	bIsActive = true;
+	TriggerReason = Reason;
+
+	// Hard Log in die Console (Beweissicherung)
+	UE_LOG(LogTemp, Error, TEXT("!!! KILL SWITCH TRIGGERED !!! Reason: %s"), *Reason);
+
+	// Broadcast: Alle Systeme müssen sofort stoppen
+	if (OnKillSwitchTriggered.IsBound())
+	{
+		OnKillSwitchTriggered.Broadcast();
+	}
+}

--- a/Plugins/SynthosiaCore/Source/SynthosiaCore/Public/ConsentTypes.h
+++ b/Plugins/SynthosiaCore/Source/SynthosiaCore/Public/ConsentTypes.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "ConsentTypes.generated.h"
+
+/**
+ * G0: Der Consent-Zustand.
+ * In Synthosia ist "Keine Antwort" immer "Nein".
+ */
+UENUM(BlueprintType)
+enum class EConsentState : uint8
+{
+	UNKNOWN     UMETA(DisplayName = "Unknown (Blocked)"),
+	REQUESTED   UMETA(DisplayName = "Requested (Wait)"),
+	GRANTED     UMETA(DisplayName = "Granted (Active)"),
+	DENIED      UMETA(DisplayName = "Denied (Blocked)"),
+	REVOKED     UMETA(DisplayName = "Revoked (Immediate Stop)")
+};
+
+/**
+ * Ein "Ticket" für eine bio-elektrische Operation.
+ * Ohne dieses Ticket darf Niagara nicht starten.
+ */
+USTRUCT(BlueprintType)
+struct FConsentTicket
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FString TicketID;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	EConsentState State = EConsentState::UNKNOWN;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FDateTime Timestamp;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	FString Context; // Wofür? (z.B. "BioFeedback_Haptics")
+};

--- a/Plugins/SynthosiaCore/Source/SynthosiaCore/Public/KillSwitch.h
+++ b/Plugins/SynthosiaCore/Source/SynthosiaCore/Public/KillSwitch.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "KillSwitch.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnKillSwitchTriggered);
+
+/**
+ * G5: Kill-Switch Subsystem.
+ * Die absolute Autorität über die Runtime.
+ * Eine Hardware-nahe Sicherung in Software.
+ */
+UCLASS()
+class SYNTHOSIACORE_API UKillSwitchSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	// Status abfragen (Poll)
+	UFUNCTION(BlueprintPure, Category = "Synthosia|Safety")
+	bool IsKillSwitchActive() const { return bIsActive; }
+
+	// Not-Aus auslösen (Irreversibel für die Session)
+	UFUNCTION(BlueprintCallable, Category = "Synthosia|Safety")
+	void TriggerKillSwitch(FString Reason);
+
+	// Event-Hook für alle anderen Systeme
+	UPROPERTY(BlueprintAssignable, Category = "Synthosia|Safety")
+	FOnKillSwitchTriggered OnKillSwitchTriggered;
+
+private:
+	bool bIsActive = false;
+	FString TriggerReason;
+};


### PR DESCRIPTION
Add foundational safety infrastructure for Synthosia plugin:

G0 - ConsentTypes.h:
- EConsentState enum (UNKNOWN/REQUESTED/GRANTED/DENIED/REVOKED)
- FConsentTicket struct for bio-electric operation authorization
- "No answer = No" principle enforced

G5 - KillSwitch Subsystem:
- UKillSwitchSubsystem as GameInstanceSubsystem
- Idempotent TriggerKillSwitch() with hard logging
- BlueprintAssignable broadcast for system-wide emergency stop
- Irreversible per-session (by design)

This establishes the "Conscience" layer - nothing runs without explicit consent, everything can be stopped immediately.

