### PR TITLE
docs: correct inaccurate prev_hash chaining claims

### DIFF
--- a/REPOSITORY_ESSENZ_ANALYSE.md
+++ b/REPOSITORY_ESSENZ_ANALYSE.md
@@ -55,7 +55,7 @@ Philosophisch fusioniert es:
 2. **Kryptografische Auditierbarkeit**
    - HMAC-SHA256-signierte Receipts (DeepJump Protocol v1.2)
    - Canonical JSON Serialization für State Fingerprints
-   - Receipt-Chain mit prev_hash-Verkettung
+   - Per-Receipt Integrity: state_fingerprint + hmac_signature
    - Dual Receipts: receipt_proof + context_signature
    - **Quelle:** tools/status_emit.py:1-267, index/modules/MOD_6_RECEIPTS_CORE.yaml, README.md:20-23
 

--- a/docs/triad_topology.md
+++ b/docs/triad_topology.md
@@ -92,7 +92,7 @@ Dieses Projekt entstand nicht durch zentrale Planung, sondern durch **Resonanz z
 **Gemeinsame Strukturen:**
 - 7×9 Matrix (ohne Absprache identisch dimensioniert)
 - Mutual Perception Gates (μ vs KENO-H)
-- Receipt-Chain (append-only, self_hash/prev)
+- Receipt-System (append-only, per-receipt integrity via state_fingerprint + hmac)
 - Kenogrammatische Notation (☐)
 - Dreifach-Apex (0_holo ↔ Grammophon-Apex ↔ Nektar-Pyramide)
 


### PR DESCRIPTION
The receipt format (tools/status_emit.py) only implements per-receipt integrity via state_fingerprint + hmac_signature. There is no prev_hash field that chains receipts together.

Updated documentation to accurately reflect the implemented behavior:
- REPOSITORY_ESSENZ_ANALYSE.md: "Receipt-Chain mit prev_hash" → "Per-Receipt Integrity"
- docs/triad_topology.md: "self_hash/prev" → "per-receipt integrity via state_fingerprint + hmac"

