### PR TITLE
feat(receipts): resonance receipt v1.1 schema + bandwidth shaping + p…

### DIFF
--- a/docs/specs/adiabatic_bandwidth_shaping_v0_1.md
+++ b/docs/specs/adiabatic_bandwidth_shaping_v0_1.md
@@ -1,0 +1,130 @@
+# Adiabatic Bandwidth Shaping v0.1
+
+## Overview
+
+Adiabatic bandwidth shaping dynamically adjusts system capacity based on resonance quality and heat accumulation. This approach prevents abrupt transitions (adiabatic = "no sudden heat exchange") while maintaining responsive throttling.
+
+## Core Principles
+
+1. **Gradual Adaptation**: Bandwidth changes smoothly to avoid system shock
+2. **Heat-Based Feedback**: Rejections accumulate "heat" that reduces capacity
+3. **Quality-Weighted Recovery**: High-quality resonances accelerate cooling
+4. **Reversible Throttling**: System can recover to full capacity over time
+
+## Mathematical Model
+
+### Bandwidth Update
+
+```
+B_new = B0 + (B_current - B0) * exp(-k * dt) + BW_norm * weights
+```
+
+Where:
+- `B0`: Baseline bandwidth (initial capacity)
+- `B_current`: Current bandwidth capacity
+- `k`: Decay/recovery constant
+- `dt`: Time delta since last update
+- `BW_norm`: Normalized bandwidth metric from current request
+- `weights`: Quality-based weighting factors
+
+### Normalized Bandwidth Metric
+
+```
+BW_norm = w_omega * omega_norm + w_kenosis * kenosis_norm + w_phi * phi_norm
+```
+
+Where:
+- `w_omega`, `w_kenosis`, `w_phi`: Weights (sum to 1.0)
+- Normalized metrics scaled to [0, 1] range
+
+### Heat Accumulation
+
+```
+heat_new = heat_current * exp(-alpha * dt) + heat_injection
+```
+
+Where:
+- `heat_current`: Current accumulated heat
+- `alpha`: Cooling exponent (higher = faster cooling)
+- `dt`: Time delta
+- `heat_injection`: Heat added by current rejection (if any)
+
+Heat injection rules:
+- `REJECTED`: +1.0 heat
+- `REFLECTED`: +0.5 heat
+- `COOLED`: +0.2 heat
+- `TUNNEL_GRANTED`: 0 heat (only natural cooling)
+
+### Capacity Reduction from Heat
+
+```
+B_effective = B_current * max(0, 1 - heat / heat_capacity)
+```
+
+Where:
+- `heat_capacity`: Maximum heat before full throttle (e.g., 10.0)
+- Effective bandwidth decreases linearly with heat
+
+## Constants (Policy-Pinned)
+
+Reference values from `receipt_policy_v0_1.yaml`:
+
+```yaml
+bandwidth_shaping:
+  B0: 1.0                    # Baseline bandwidth
+  BW0: 0.5                   # Initial normalized bandwidth
+  k: 0.1                     # Decay constant (1/s)
+  alpha: 0.05                # Cooling exponent (1/s)
+  heat_capacity: 10.0        # Max heat tolerance
+  weights:
+    w_omega: 0.4
+    w_kenosis: 0.3
+    w_phi: 0.3
+```
+
+## Decision Flow Integration
+
+The bandwidth shaping integrates with gate decisions:
+
+```
+1. Compute BW_norm from incoming metrics
+2. Update heat based on time + previous decision
+3. Compute B_effective from current bandwidth & heat
+4. Check: if BW_norm < bandwidth_min -> COOLED
+5. Otherwise proceed to policy checks
+```
+
+## Privacy & Normalization
+
+- All metrics normalized to [0, 1] before bandwidth computation
+- No raw user identifiers included in bandwidth calculations
+- Heat and bandwidth state persisted per-session (not per-user)
+
+## Grade 3 Margins
+
+Grade 3 (high-security) operations apply stricter margins:
+
+```yaml
+grade3_margins:
+  omega_margin: 0.15
+  kenosis_margin: 0.10
+  phi_margin: 0.10
+  bandwidth_margin: 0.20
+```
+
+Effective thresholds for grade 3:
+- `omega_max_grade3 = omega_max * (1 - omega_margin)`
+- `bandwidth_min_grade3 = bandwidth_min * (1 + bandwidth_margin)`
+
+## Implementation Notes
+
+1. **Timestamp Precision**: Use millisecond-resolution timestamps for `dt` calculations
+2. **Exponential Decay**: Use `exp()` for smooth transitions
+3. **Bounds Checking**: Ensure `B_effective >= 0` and `heat >= 0`
+4. **Genesis State**: Initial receipts start with `B0`, `BW0`, `heat=0`
+
+## References
+
+- Receipt Policy v0.1: `docs/specs/receipt_policy_v0_1.yaml`
+- Resonance Receipt Schema v1.1: `spec/resonance_receipt_v1_1.schema.json`
+- Canonical Serialization: RFC8785 (JCS)

--- a/docs/specs/receipt_policy_v0_1.yaml
+++ b/docs/specs/receipt_policy_v0_1.yaml
@@ -1,0 +1,105 @@
+# Receipt Policy v0.1
+# Pinned algorithms, thresholds, and bandwidth shaping parameters for resonance receipt validation
+
+version: "0.1"
+policy_type: "resonance_receipt_hybrid"
+
+# Pinned cryptographic algorithms
+algorithms:
+  canonical_serialization: "RFC8785"  # JCS (JSON Canonicalization Scheme)
+  hash_algorithm: "SHA-256"
+  hmac_algorithm: "HMAC-SHA-256"
+  signature_algorithm: "ED25519"
+
+# Core resonance thresholds
+thresholds:
+  omega_max: 100.0          # Maximum amplitude (frequency/energy)
+  kenosis_base: 0.3         # Minimum kenosis (emptying) requirement
+  phi_base: 0.707           # Phase alignment baseline (cos(45°) ≈ 0.707)
+  phi_tolerance: 0.1        # Acceptable phase deviation
+
+# Bandwidth requirements
+bandwidth_min: 0.25         # Minimum normalized bandwidth for TUNNEL_GRANTED
+
+# Grade 3 (high-security) margins
+# Applied as multiplicative factors to tighten thresholds
+grade3_margins:
+  omega_margin: 0.15        # Reduce omega_max by 15% for grade 3
+  kenosis_margin: 0.10      # Increase kenosis requirement by 10% for grade 3
+  phi_margin: 0.10          # Tighten phi tolerance by 10% for grade 3
+  bandwidth_margin: 0.20    # Increase bandwidth_min by 20% for grade 3
+
+# Adiabatic bandwidth shaping constants
+bandwidth_shaping:
+  B0: 1.0                   # Baseline bandwidth (initial capacity)
+  BW0: 0.5                  # Initial normalized bandwidth metric
+  k: 0.1                    # Bandwidth decay/recovery constant (1/s)
+  alpha: 0.05               # Heat cooling exponent (1/s)
+  heat_capacity: 10.0       # Maximum heat accumulation before full throttle
+  weights:
+    w_omega: 0.4            # Weight for omega contribution to BW_norm
+    w_kenosis: 0.3          # Weight for kenosis contribution to BW_norm
+    w_phi: 0.3              # Weight for phi contribution to BW_norm
+
+# Genesis receipt normalization
+genesis:
+  prev_receipt_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+  description: "64 zeros indicate first receipt in chain"
+
+# Gate decision flow priority
+# Evaluated in this exact order:
+decision_priority:
+  - step: 1
+    condition: "core_metrics_fail"
+    decision: "REJECTED"
+    description: "Amplitude, kenosis, or phase out of bounds"
+
+  - step: 2
+    condition: "bandwidth_below_min"
+    decision: "COOLED"
+    description: "Normalized bandwidth < bandwidth_min"
+
+  - step: 3
+    condition: "policy_flags_violation"
+    decision: "REFLECTED"
+    description: "Policy compliance flags indicate violation"
+
+  - step: 4
+    condition: "all_checks_pass"
+    decision: "TUNNEL_GRANTED"
+    description: "All metrics and policies satisfied"
+
+# Privacy rules
+privacy:
+  - rule: "no_raw_nonces"
+    description: "Use HMAC-SHA-256(nonce) in verification_reasons, never raw nonce"
+
+  - rule: "no_user_identifiers"
+    description: "Do not include user_id, email, IP address, or other PII in receipts"
+
+  - rule: "no_raw_tokens"
+    description: "Never embed bearer tokens or session tokens in receipts"
+
+  - rule: "normalized_metrics_only"
+    description: "All metrics normalized to [0,1] range before inclusion"
+
+# Extension guidelines
+extensions:
+  allowed_prefixes:
+    - "x_"                  # Custom extension fields must start with x_
+
+  embedding_pins:
+    - name: "x_embedding_model"
+      allowed_values: ["text-embedding-3-small", "all-MiniLM-L6-v2"]
+      description: "Pinned embedding models for semantic verification"
+
+    - name: "x_embedding_dim"
+      allowed_values: [384, 1536]
+      description: "Embedding dimension must match model"
+
+# Compliance notes
+compliance:
+  - "All timestamps MUST be UTC ISO 8601 format"
+  - "Signatures MUST cover canonical RFC8785 serialization of receipt_hash"
+  - "Schema version 1.1 required for this policy"
+  - "additionalProperties: false enforced on verification_reasons items and policy_flags"

--- a/receipts/resonance_receipt_example_v1_1.json
+++ b/receipts/resonance_receipt_example_v1_1.json
@@ -1,0 +1,55 @@
+{
+  "receipt_id": "550e8400-e29b-41d4-a716-446655440000",
+  "version": "1.1",
+  "timestamp_utc": "2026-01-12T10:30:00.000Z",
+  "gate_decision": "TUNNEL_GRANTED",
+  "bandwidth_norm": 0.67,
+  "prev_receipt_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "receipt_hash": "a3f5d8b2c1e4f6a8d9c0b1e2f3a4d5c6b7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2",
+  "signature": "3045022100abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890022100fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+  "verification_reasons": [
+    {
+      "code": "AMPLITUDE_CHECK",
+      "value": 45.2,
+      "threshold": 100.0
+    },
+    {
+      "code": "KENOSIS_CHECK",
+      "value": 0.42,
+      "threshold": 0.3
+    },
+    {
+      "code": "PHASE_CHECK",
+      "value": 0.75,
+      "threshold": 0.707,
+      "nonce_hmac": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "code": "BANDWIDTH_CHECK",
+      "value": 0.67,
+      "threshold": 0.25
+    }
+  ],
+  "policy_flags": {
+    "is_amplitude_compliant": true,
+    "is_kenosis_sufficient": true,
+    "is_phase_aligned": true
+  },
+  "core_metrics": {
+    "omega": 45.2,
+    "kenosis": 0.42,
+    "phi": 0.75
+  },
+  "bandwidth_shaping": {
+    "B_current": 1.0,
+    "BW_norm": 0.67,
+    "heat": 0.0,
+    "alpha": 0.05
+  },
+  "extensions": {
+    "x_embedding_model": "text-embedding-3-small",
+    "x_embedding_dim": 1536,
+    "x_session_id": "sess_a1b2c3d4e5f6",
+    "x_grade": 1
+  }
+}

--- a/spec/resonance_receipt_v1_1.schema.json
+++ b/spec/resonance_receipt_v1_1.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://entaengelment.fleksible.io/schemas/resonance_receipt_v1_1.schema.json",
+  "title": "Resonance Receipt v1.1",
+  "description": "Hybrid resonance receipt schema with adiabatic bandwidth shaping and policy enforcement. Supports genesis receipts (prev_receipt_hash = 64 zeros) and normalized decision flow.",
+  "type": "object",
+  "required": [
+    "receipt_id",
+    "version",
+    "timestamp_utc",
+    "gate_decision",
+    "bandwidth_norm",
+    "prev_receipt_hash",
+    "receipt_hash",
+    "signature"
+  ],
+  "properties": {
+    "receipt_id": {
+      "type": "string",
+      "description": "Unique identifier for this receipt (UUID v4 recommended)",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.1",
+      "description": "Receipt schema version"
+    },
+    "timestamp_utc": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 UTC timestamp of receipt generation"
+    },
+    "gate_decision": {
+      "type": "string",
+      "enum": ["REJECTED", "REFLECTED", "COOLED", "TUNNEL_GRANTED"],
+      "description": "Gate decision flow: REJECTED (core fail), COOLED (bandwidth < min), REFLECTED (policy violation), TUNNEL_GRANTED (all pass)"
+    },
+    "bandwidth_norm": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Normalized bandwidth metric computed via adiabatic shaping (0=minimal, higher=more capacity)"
+    },
+    "prev_receipt_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "SHA-256 hash of previous receipt. Genesis receipts use 64 zeros: '0000000000000000000000000000000000000000000000000000000000000000'"
+    },
+    "receipt_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "SHA-256 hash of this receipt (canonical RFC8785 serialization)"
+    },
+    "signature": {
+      "type": "string",
+      "description": "ED25519 signature over receipt_hash"
+    },
+    "verification_reasons": {
+      "type": "array",
+      "description": "Normalized verification reasons with privacy protection - NO raw nonces, tokens, user_id, or IP addresses",
+      "items": {
+        "type": "object",
+        "required": ["code"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Verification reason code (e.g., AMPLITUDE_CHECK, KENOSIS_CHECK, PHASE_CHECK, BW_BELOW_MIN)"
+          },
+          "value": {
+            "type": "number",
+            "description": "Optional measured value"
+          },
+          "threshold": {
+            "type": "number",
+            "description": "Optional threshold for comparison"
+          },
+          "nonce_hmac": {
+            "type": "string",
+            "description": "Optional HMAC-SHA-256 of nonce (privacy-preserving)"
+          }
+        },
+        "patternProperties": {
+          "^x_": {
+            "description": "Extension fields prefixed with x_"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "policy_flags": {
+      "type": "object",
+      "description": "Policy compliance flags - NO is_verified field",
+      "required": ["is_amplitude_compliant", "is_kenosis_sufficient", "is_phase_aligned"],
+      "properties": {
+        "is_amplitude_compliant": {
+          "type": "boolean",
+          "description": "Amplitude (omega) within policy limits"
+        },
+        "is_kenosis_sufficient": {
+          "type": "boolean",
+          "description": "Kenosis (emptying) meets minimum threshold"
+        },
+        "is_phase_aligned": {
+          "type": "boolean",
+          "description": "Phase (phi) alignment within tolerance"
+        }
+      },
+      "patternProperties": {
+        "^x_": {
+          "description": "Extension flags prefixed with x_"
+        }
+      },
+      "additionalProperties": false
+    },
+    "core_metrics": {
+      "type": "object",
+      "description": "Core resonance metrics",
+      "properties": {
+        "omega": {
+          "type": "number",
+          "description": "Amplitude (frequency/energy)"
+        },
+        "kenosis": {
+          "type": "number",
+          "description": "Emptying/reduction metric"
+        },
+        "phi": {
+          "type": "number",
+          "description": "Phase alignment"
+        }
+      }
+    },
+    "bandwidth_shaping": {
+      "type": "object",
+      "description": "Adiabatic bandwidth shaping parameters",
+      "properties": {
+        "B_current": {
+          "type": "number",
+          "description": "Current bandwidth capacity"
+        },
+        "BW_norm": {
+          "type": "number",
+          "description": "Normalized bandwidth metric"
+        },
+        "heat": {
+          "type": "number",
+          "description": "Accumulated heat from rejections"
+        },
+        "alpha": {
+          "type": "number",
+          "description": "Cooling exponent"
+        }
+      }
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Optional extensions (preserves forward compatibility)"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
…olicy stub

## Summary
Adds the first deterministic, audit-friendly building blocks for the Kenogramm Port:
- Resonance Receipt schema v1.1 (atomic unit of trust)
- Adiabatic bandwidth shaping spec (state machine / active semipermeability)
- Policy YAML stub (pinned algorithms + thresholds + pins)
- Example genesis receipt (end-to-end sanity anchor)

## Key Decisions (Final)
### 1) `gate_decision` now distinguishes integrity vs policy vs state
Enum:
- REJECTED: core integrity fail (signature/hash/canonicalization mismatch)
- COOLED: state limit (bandwidth exhausted, independent of policy)
- REFLECTED: policy violation (Ω / Kenosis / Φ)
- TUNNEL_GRANTED: passed

Deterministic decision priority:
1) core_ok fail -> REJECTED (grade=0)
2) bw_norm < bandwidth_min -> COOLED (grade=1)
3) policy violated -> REFLECTED (grade=1)
4) else -> TUNNEL_GRANTED (grade=2/3 by margins)

### 2) `verification_reasons` are normed objects (privacy-sane)
Reasons are structured objects with `code` + optional numeric evidence:
- supports audit & edge-case debugging without leaking raw identifiers
- privacy rule: no raw nonces/tokens/ids; only `nonce_hmac` etc.
- allows `x_*` extensions for future proofing

### 3) `policy_flags` is a single object (core + x_* extensions)
- core booleans: is_amplitude_compliant / is_kenosis_sufficient / is_phase_aligned
- extensions via `x_*`
- no duplicate truth source (no `is_verified`; `ledger_verified` remains authoritative)

### 4) Genesis chain rule is explicit
Genesis receipt uses prev_receipt_hash = 64 zeros (the only allowed exception).

## Files Added
- spec/resonance_receipt_v1_1.schema.json
- docs/specs/adiabatic_bandwidth_shaping_v0_1.md
- docs/specs/receipt_policy_v0_1.yaml
- receipts/resonance_receipt_example_v1_1.json

## How to Validate (quick)
- JSON schema and example parse cleanly
- YAML policy loads cleanly
- grep confirms REJECTED enum + bandwidth_min present