### PR TITLE
Clean up orbital doc formatting

### DIFF
--- a/docs/ORBIT_MODEL.md
+++ b/docs/ORBIT_MODEL.md
@@ -1,0 +1,24 @@
+---
+slug: orbit-model
+title: Orbital Model — Kern / Transit / Peripherie
+updated: 2026-01-13
+canvas: false
+---
+# Orbital Model — Kern / Transit / Peripherie
+
+Status: **[MESO]** (Framework-Steuerung)
+
+## Kern-Orbit (täglich)
+Ziel: Integrität & Selbst-Konsistenz.
+Metriken: Gate-Coverage, Canonicalization, Replay-Determinismus, Claim-Tagging, Receipt-Lint.
+Regel: Keine neuen „harten Wahrheitsclaims“ ohne **Tag + Testpfad**.
+
+## Transit-Orbit (wöchentlich)
+Ziel: Epistemische Höflichkeit / Übersetzbarkeit.
+Deliverables: Bridge-Cards, Validation-Demo (replizierbar), Multi-Portal Onboarding (Phys/Bio/Phil/AI/Art).
+Regel: Validation = **Brücke**, nicht **Legitimations-Gate**.
+
+## Peripherie-Orbit (monatlich)
+Ziel: Konvergenz-Kartografie (Feld-Mapping).
+Aktivitäten: Triangulationspunkte (z.B. Levin/Friston/…), Resonanz dokumentieren.
+Regel: Keine Autoritäts-Abhängigkeit; nur „Konvergenz beobachtet“ + Tagging.

--- a/docs/ROADMAP_ORBITAL_v1.md
+++ b/docs/ROADMAP_ORBITAL_v1.md
@@ -1,0 +1,26 @@
+---
+slug: roadmap-orbital-v1
+title: Roadmap — Orbital v1
+updated: 2026-01-13
+canvas: false
+---
+# Roadmap — Orbital v1
+
+## Kern-Orbit (laufend, täglich)
+- Canonicalization/Receipt-Lint: PASS/FAIL klar
+- Replay-Determinismus (Code hoch, generativ: Drift messen)
+- Claim-Tags + Scope-Tags (MICRO/MESO/MACRO) verpflichtend
+- 1-Edge-Policy (atomare Änderungen)
+
+## Transit-Orbit (Welle 1: 6 Wochen)
+- 3 Bridge-Cards: Josephson, Nektar, L-vor-T
+- Validation-Demo v1 (n=10, explizit „Demo, keine Studie“)
+- 5 Portale skizzieren (Phys/Bio/Phil/AI/Art)
+
+## Peripherie-Orbit (12–24+ Monate, monatlich)
+- Konvergenz-Notizen (Triangulationspunkte)
+- Publikation als Feld-Kartografie (kein „Beweis-Paper“)
+
+## Tests (DoD)
+- Ein Physiker UND ein Künstler finden je einen Einstiegspfad (Portal-Test)
+- Claim-Lint: 0 ungetaggte harte Claims in Canon-Dokumenten

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -82,3 +82,11 @@ entaENGELment-/
 ---
 
 *This document is additive - it doesn't replace the README, just offers a gentler entry point.*
+
+---
+
+## Orbital Meta-Structure
+- [Orbital Model](./ORBIT_MODEL.md)
+- [Orbital Roadmap](./ROADMAP_ORBITAL_v1.md)
+- [BridgeCard — Consent as Transit](./bridgecards/BC_consent_as_transit.md)
+- [Validation Demo v1](./validation/VALIDATION_DEMO_v1.md)

--- a/docs/bridgecards/BC_consent_as_transit.md
+++ b/docs/bridgecards/BC_consent_as_transit.md
@@ -1,0 +1,18 @@
+---
+slug: bc-consent-as-transit
+title: BridgeCard — Consent as Transit Requirement
+updated: 2026-01-13
+canvas: false
+---
+# BridgeCard — Consent as Transit Requirement
+
+[FAKT][MESO] Kern-Orbit benötigt Consent als Guard-Prädikat (G0), nicht als Mind-Reading.
+[HYPOTHESE][TRANSIT] „Consent-Detection“ kann als Brücke für Skeptiker dienen (epistemische Höflichkeit), ist aber kein Legitimations-Zentrum.
+
+## Mapping
+- Kern: Consent = explizite Einwilligung + Kill-Switch-Dominanz
+- Transit: Consent-Protokolle als replizierbare Demos (nicht als Wahrheitserzwinger)
+- Peripherie: Ethik-Triangulationspunkte (nicht Autoritäten)
+
+## Test
+- Kann ein Außenstehender erkennen, wann das System blockiert und warum? (Explain/Reason-Codes)

--- a/docs/canvas_links.md
+++ b/docs/canvas_links.md
@@ -1,6 +1,6 @@
 # Canvas-Links
 
-**Stand:** 2026-01-04
+**Stand:** 2026-01-13
 
 Hier werden alle relevanten Canvas-Seiten und Dokumentenverknüpfungen eingetragen.
 
@@ -21,6 +21,10 @@ Die folgenden Repository-Dokumente bieten umfassende Kontextinformationen:
 - [`docs/architecture.md`](./architecture.md) — Layer-Architektur und Triadische Topologie
 - [`docs/triad_topology.md`](./triad_topology.md) — Detaillierte Analyse der drei Entwicklungsstränge
 - [`docs/masterindex.md`](./masterindex.md) — Verzeichnisstruktur und Kenogramm-Registry
+- [`docs/ORBIT_MODEL.md`](./ORBIT_MODEL.md) — Orbital Meta-Struktur (Kern/Transit/Peripherie)
+- [`docs/ROADMAP_ORBITAL_v1.md`](./ROADMAP_ORBITAL_v1.md) — Roadmap nach Orbital-Kadenz
+- [`docs/bridgecards/BC_consent_as_transit.md`](./bridgecards/BC_consent_as_transit.md) — BridgeCard: Consent als Transit-Requirement
+- [`docs/validation/VALIDATION_DEMO_v1.md`](./validation/VALIDATION_DEMO_v1.md) — Replizierbare Demo (nicht Studie)
 
 ### DevOps & Tooling
 - [`docs/devops_tooling_kit.md`](./devops_tooling_kit.md) — Vollständiges DevOps-Kit

--- a/docs/masterindex.md
+++ b/docs/masterindex.md
@@ -1,10 +1,17 @@
 # Masterindex — Seed
 
 **Version:** 1.0.0
-**Stand:** 2026-01-04
+**Stand:** 2026-01-13
 **Letzte Prüfung:** Alignment mit Functorial Index v3
 
 Startpunkt des Masterindex. Enthält Struktur, narrative Einordnung und Links zu Canvas-Dokumenten.
+
+## Orbital Meta-Structure (Kern / Transit / Peripherie)
+
+- `docs/ORBIT_MODEL.md` — Modell & Kadenz
+- `docs/ROADMAP_ORBITAL_v1.md` — Roadmap (Orbit-basiert)
+- `docs/bridgecards/BC_consent_as_transit.md` — Consent als Transit-Brücke
+- `docs/validation/VALIDATION_DEMO_v1.md` — Replizierbare Demo, kein Studienclaim
 
 ## Verzeichnisstruktur
 

--- a/docs/validation/VALIDATION_DEMO_v1.md
+++ b/docs/validation/VALIDATION_DEMO_v1.md
@@ -1,0 +1,19 @@
+---
+slug: validation-demo-v1
+title: Validation Demo v1 — Replizierbar, nicht Studie
+updated: 2026-01-13
+canvas: false
+---
+# Validation Demo v1 — Replizierbar, nicht Studie
+
+[HYPOTHESE][TRANSIT] Diese Demo dient Onboarding/Brückenbau. Keine medizinischen Aussagen.
+
+## Setup (n=10)
+- 1 Kohorte, 1 Protokoll, 1 Woche
+- Messung: HRV (RMSSD), subjektives Erleben, Timing-Log
+- Output: Aggregate-only, Consent dokumentiert
+
+## Erfolgskriterium
+Replizierbarkeit der Pipeline (nicht Effektgröße):
+- gleiche Inputs/Version → gleiche Receipts (wo möglich)
+- Drift wird gemessen (wo nicht möglich)


### PR DESCRIPTION
### Motivation
- Remove duplicated navigation entries to avoid confusion and keep the canvas index clean.
- Improve readability of the Orbital documentation by separating compact inline paragraphs into clearly delimited lines.
- Keep BridgeCard content easier to scan by splitting the factual and hypothesis lines.

### Description
- Removed the duplicated "### Orbital Meta-Structure" block at the bottom of `docs/canvas_links.md` and preserved the four Orbital links under the `### Architektur & Design` section.
- Reformatted `docs/ORBIT_MODEL.md` so each section has `Ziel:`, `Metriken:` and `Regel:` (or `Aktivitäten:`) on their own lines for readability.
- Split the first paragraph in `docs/bridgecards/BC_consent_as_transit.md` into two lines, separating `[FAKT][MESO]` and `[HYPOTHESE][TRANSIT]`.
- Modified files: `docs/canvas_links.md`, `docs/ORBIT_MODEL.md`, and `docs/bridgecards/BC_consent_as_transit.md` and ensured files end with a newline.

### Testing
- No automated unit or integration tests were run because these are documentation-only changes.
- Ran `find . -name index.master.json -print` as a quick registry check and it returned no matches (no `index.master.json` found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696675c7548c8325841054b5b18b72c6)