### PR TITLE
fix(ci): harden pointer parsing + add docs-link connectivity test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: Verify (Lint & Type Check)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
@@ -49,6 +50,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 

--- a/VOIDMAP.yml
+++ b/VOIDMAP.yml
@@ -156,8 +156,9 @@ voids:
     symptom: "Kein Port-Linter / keine Marker-Operationalisierung"
     closing_path: "tools/port_lint.py"
     evidence:
-      - "tools/port_lint.py"
-      - "tests/test_port_lint.py"
+      - tools/port_lint.py
+      - tests/test_port_lint.py
+      - audit/port_matrix_audit_2026-01-13.md
     created: "2026-01-13"
     closed: "2026-01-13"
 
@@ -168,7 +169,9 @@ voids:
     priority: med
     symptom: "Semantik/Marker nicht zentral dokumentiert"
     closing_path: "policies/port_codebooks.yaml"
-    evidence: "policies/port_codebooks.yaml"
+    evidence:
+      - policies/port_codebooks.yaml
+      - audit/port_matrix_audit_2026-01-13.md
     created: "2026-01-13"
     closed: "2026-01-13"
 
@@ -179,7 +182,9 @@ voids:
     priority: med
     symptom: "Keine harte Grenze gegen Receipt-Überflutung"
     closing_path: "tools/port_lint.py"
-    evidence: "tools/port_lint.py"
+    evidence:
+      - tools/port_lint.py
+      - audit/port_matrix_audit_2026-01-13.md
     created: "2026-01-13"
     closed: "2026-01-13"
 
@@ -190,5 +195,7 @@ voids:
     priority: low
     symptom: "Scope-Tags nicht überall konsistent"
     closing_path: null
-    evidence: null
+    evidence:
+      - audit/port_matrix_audit_2026-01-13.md
+      - policies/port_codebooks.yaml
     created: "2026-01-13"

--- a/tests/test_verify_docs_links.py
+++ b/tests/test_verify_docs_links.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+
+
+def test_verify_docs_links():
+    result = subprocess.run(
+        [sys.executable, "-m", "tools.verify_docs_links"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tools/port_lint.py
+++ b/tools/port_lint.py
@@ -104,13 +104,18 @@ def lint_file(p: Path) -> list[tuple[str, str]]:
     if found:
         seq_errs = validate_marker_sequence(found)
         if seq_errs:
-            errors.append(("K_MARKER_ORDER", f"{p.as_posix()}: marker order goes backwards: {found}"))
+            errors.append(
+                ("K_MARKER_ORDER", f"{p.as_posix()}: marker order goes backwards: {found}")
+            )
     # Receipt flood heuristic only on JSON/YAML-like files to avoid noisy docs
     if p.suffix.lower() in {".json", ".yaml", ".yml"}:
         flood = validate_receipt_flood(txt)
         if flood:
             errors.append(
-                ("RECEIPT_FLOOD", f"{p.as_posix()}: too many claim tags (> {MAX_CLAIMS_PER_RECEIPT})")
+                (
+                    "RECEIPT_FLOOD",
+                    f"{p.as_posix()}: too many claim tags (> {MAX_CLAIMS_PER_RECEIPT})",
+                )
             )
     return errors
 

--- a/tools/verify_docs_links.py
+++ b/tools/verify_docs_links.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Verify relative markdown links in core docs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+DOC_FILES = [
+    Path("docs/START_HERE.md"),
+    Path("docs/masterindex.md"),
+    Path("docs/canvas_links.md"),
+]
+
+LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def is_ignored_link(target: str) -> bool:
+    lowered = target.lower()
+    return (
+        lowered.startswith("http://")
+        or lowered.startswith("https://")
+        or lowered.startswith("mailto:")
+        or lowered.startswith("#")
+    )
+
+
+def normalize_target(target: str) -> str:
+    trimmed = target.split("#", 1)[0].split("?", 1)[0]
+    return trimmed.strip()
+
+
+def extract_links(text: str) -> list[str]:
+    return [match for match in LINK_RE.findall(text) if match]
+
+
+def looks_like_relative_path(target: str) -> bool:
+    return "/" in target or "." in target
+
+
+def verify_docs_links() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    missing: list[str] = []
+
+    for doc_path in DOC_FILES:
+        full_path = repo_root / doc_path
+        if not full_path.exists():
+            missing.append(f"Missing doc file: {doc_path}")
+            continue
+        content = full_path.read_text(encoding="utf-8")
+        for target in extract_links(content):
+            if is_ignored_link(target):
+                continue
+            normalized = normalize_target(target)
+            if not normalized or not looks_like_relative_path(normalized):
+                continue
+            resolved = (full_path.parent / normalized).resolve()
+            if not resolved.exists():
+                missing.append(f"Broken link in {doc_path}: {target}")
+
+    if missing:
+        for entry in missing:
+            print(f"[verify_docs_links] {entry}", file=sys.stderr)
+        return 1
+
+    print("✅ docs links ok")
+    return 0
+
+
+def main() -> None:
+    sys.exit(verify_docs_links())
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_pointers.py
+++ b/tools/verify_pointers.py
@@ -78,9 +78,31 @@ def extract_paths_from_yaml(yaml_path: Path, repo_root: Path) -> list[PointerRes
     # Keys that typically contain file paths
 
     def clean_path(raw: str) -> str:
-        """Clean a path string by removing CLI arguments and whitespace."""
+        """Clean a path string by removing CLI arguments and punctuation."""
         # Strip CLI arguments (e.g., "tools/foo.py --strict" → "tools/foo.py")
         path = raw.split()[0] if " " in raw else raw
+        path = path.strip().strip("`'\"")
+        path = path.strip("()")
+        if ":" in path:
+            left, _right = path.split(":", 1)
+            if left.endswith(
+                (
+                    ".py",
+                    ".md",
+                    ".yml",
+                    ".yaml",
+                    ".json",
+                    ".toml",
+                    ".txt",
+                    ".sh",
+                    ".c",
+                    ".cpp",
+                    ".h",
+                    ".hpp",
+                )
+            ):
+                path = left
+        path = path.rstrip(",.;:")
         return path.strip()
 
     def looks_like_path(s: str) -> bool:


### PR DESCRIPTION
### Motivation
- Make pointer extraction robust against punctuation and inline function pointers so `tools.verify_pointers` does not mis-parse paths embedded in prose. 
- Ensure VOIDMAP evidence entries are normalized as YAML lists of real repo paths for reliable connectivity checks. 
- Add an automated docs-link connectivity checker so broken relative Markdown links are detected in CI, and keep matrix jobs from cancelling early to surface all diagnostics.

### Description
- Hardened `clean_path()` in `tools/verify_pointers.py` to strip quotes/backticks/parentheses, trim trailing punctuation, and handle `file.ext:func()` tokens by taking the file part. 
- Normalized `evidence` for `VOID-020`..`VOID-023` in `VOIDMAP.yml` to be YAML lists of concrete paths and added an `audit/` entry. 
- Added `tools/verify_docs_links.py` which parses core docs (`docs/START_HERE.md`, `docs/masterindex.md`, `docs/canvas_links.md`) and fails on broken relative links, and added `tests/test_verify_docs_links.py` that invokes it. 
- Disabled `fail-fast` on the GitHub Actions matrices for `verify` and `build` in `.github/workflows/ci.yml` to report all job results; applied small `ruff` formatting adjustments to the changed files (including `tools/port_lint.py`).

### Testing
- Ran `python -m tools.verify_pointers` which completed successfully and reports no core pointer failures. 
- Ran `python -m tools.verify_docs_links` which returned success (`✅ docs links ok`). 
- Ran `ruff check src tests tools` which passed. 
- Ran `ruff format --check src tests tools` which still reports two files would be reformatted (`tests/ethics/test_fail_safe_expired_consent.py`, `tools/mzm/gate_toggle.py`) and therefore returns non-zero. 
- Ran targeted `ruff --fix`/format on modified files which passed for those files. 
- Ran `pytest -q` which passed all tests (`105 passed`). 
- Ran `make port-lint` and `make verify` which completed successfully and show the new checks running in the verify flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966bcb771888325b97653c35d7f4f63)