### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -53,10 +55,12 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -84,7 +88,7 @@ jobs:
           pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238  # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
@@ -104,10 +108,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: 'pip'
@@ -135,10 +141,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: 'pip'


### PR DESCRIPTION
Pin all third-party Actions to their full commit SHAs instead of mutable version tags to prevent supply-chain attacks via tag hijacking.

Actions pinned:
- actions/checkout@v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
- actions/setup-python@v5 → a26af69be951a213d495a4c3e4e4022e16d87065
- codecov/codecov-action@v4 → b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238

Also added fetch-depth: 2 to all checkout steps for shallow clones.

## Intent

<!-- What does this PR accomplish? -->

## Scope

<!-- What areas of the codebase are affected? -->

FOKUS: <!-- Brief task focus (2-5 words) -->

## Test Plan

<!-- How was this tested? -->
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] CI checks pass

## Risk

<!-- What could go wrong? What areas need careful review? -->

---

<!-- Optional: If you switched focus during this work -->
<!--
FOKUS-SWITCH: <old focus> -> <new focus>
Reason: <why the switch happened>
-->
