### PR TITLE
Fix a security issue

### DIFF
--- a/.github/workflows/metatron-guard.yml
+++ b/.github/workflows/metatron-guard.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Pin actions/checkout and actions/setup-python to specific commit SHAs for supply-chain hardening. This prevents potential malicious updates if version tags are moved to point to compromised commits.

Uses the same SHAs as ci.yml for consistency:
- actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 (v4)
- actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 (v5)

FOKUS: Pin unpinned GitHub Actions for security

## Intent

<!-- What does this PR accomplish? -->

## Scope

<!-- What areas of the codebase are affected? -->

FOKUS: <!-- Brief task focus (2-5 words) -->

## Test Plan

<!-- How was this tested? -->
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] CI checks pass

## Risk

<!-- What could go wrong? What areas need careful review? -->

---

<!-- Optional: If you switched focus during this work -->
<!--
FOKUS-SWITCH: <old focus> -> <new focus>
Reason: <why the switch happened>
-->
