### PR TITLE
security(ci): pin actions to SHAs + scrub secret example

### DIFF
--- a/.github/workflows/ci-evidence-bundle.yml
+++ b/.github/workflows/ci-evidence-bundle.yml
@@ -1,10 +1,15 @@
 name: Evidence Bundle
+
 on: [push]
+
+permissions:
+  contents: read
+
 jobs:
   bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Run bundler
         run: |
           bash scripts/evidence_bundle.sh

--- a/.github/workflows/ci-policy-lint.yml
+++ b/.github/workflows/ci-policy-lint.yml
@@ -1,14 +1,19 @@
 name: Policy Lint
+
 on:
   push:
     branches: ["main", "claude/**"]
   pull_request:
     branches: ["main"]
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: JSON lint
         run: |
           python -m json.tool policies/gate_policy_v1.json > /dev/null

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -1,16 +1,21 @@
 name: Smoke Tests
+
 on:
   push:
     branches: ["main", "claude/**"]
   pull_request:
     branches: ["main"]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
           cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test-javascript:
     name: JavaScript Tests
@@ -13,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -31,7 +34,7 @@ jobs:
         run: npm run test:js:coverage
 
       - name: Upload JS coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: js-coverage-report
           path: coverage/js/
@@ -47,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -67,7 +70,7 @@ jobs:
           python -m pytest --cov --cov-report=xml --cov-report=html
 
       - name: Upload Python coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: python-coverage-report-${{ matrix.python-version }}
           path: Fractalsense/htmlcov/

--- a/docs/devops_tooling_kit.md
+++ b/docs/devops_tooling_kit.md
@@ -62,8 +62,10 @@ Härtung: ENV‑Secrets, Canonical JSON."""
 
 ### Nutzung
 
+> **Hinweis:** Never commit real secrets; use GitHub Secrets or environment variables.
+
 ```bash
-CI_SECRET="my-secret" python tools/status_emit.py --outdir out --status PASS --H 0.85 --dmi 4.8 --phi 0.75 --refractory 120
+CI_SECRET="<YOUR_SECRET>" python tools/status_emit.py --outdir out --status PASS --H 0.85 --dmi 4.8 --phi 0.75 --refractory 120
 ```
 
 ## Status Verify


### PR DESCRIPTION
Pin all GitHub Actions to commit SHAs for supply-chain hardening:
- actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 (v4)
- actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 (v5)
- actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 (v4)
- actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 (v4)

Add minimal permissions (contents: read) to all workflows.

Replace hardcoded example secret "my-secret" with placeholder "<YOUR_SECRET>" and add security note in docs/devops_tooling_kit.md.

Affected files:
- ci-evidence-bundle.yml
- ci-smoke.yml
- ci-policy-lint.yml
- test.yml
- docs/devops_tooling_kit.md

FOKUS: Supply-chain hardening for CI workflows

## Intent

<!-- What does this PR accomplish? -->

## Scope

<!-- What areas of the codebase are affected? -->

FOKUS: <!-- Brief task focus (2-5 words) -->

## Test Plan

<!-- How was this tested? -->
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] CI checks pass

## Risk

<!-- What could go wrong? What areas need careful review? -->

---

<!-- Optional: If you switched focus during this work -->
<!--
FOKUS-SWITCH: <old focus> -> <new focus>
Reason: <why the switch happened>
-->
