### PR TITLE
Fix missing numba module import error

### DIFF
--- a/Fractalsense/__init__.py
+++ b/Fractalsense/__init__.py
@@ -8,8 +8,17 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
-from numba import jit
 import time
+
+# Optional numba import for performance optimization
+try:
+    from numba import jit
+except ImportError:
+    # Fallback no-op decorator when numba is not installed
+    def jit(*args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
 from typing import Dict, List, Any, Tuple, Optional
 
 # Importiere das Modul-Interface


### PR DESCRIPTION
Numba is an optional performance dependency that was causing ImportError in CI when not installed. The jit decorator is now wrapped in a try/except that provides a no-op fallback decorator when numba is unavailable.

This allows tests to run without numba while still benefiting from JIT compilation when numba is installed.

## Intent

<!-- What does this PR accomplish? -->

## Scope

<!-- What areas of the codebase are affected? -->

FOKUS: <!-- Brief task focus (2-5 words) -->

## Test Plan

<!-- How was this tested? -->
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] CI checks pass

## Risk

<!-- What could go wrong? What areas need careful review? -->

---

<!-- Optional: If you switched focus during this work -->
<!--
FOKUS-SWITCH: <old focus> -> <new focus>
Reason: <why the switch happened>
-->
