### PR TITLE
fix(p4): align evidence_ref pointers with manifest schema#72

### DIFF
--- a/ark/p4/receipts/ARK_OVL_RO_0001.yaml
+++ b/ark/p4/receipts/ARK_OVL_RO_0001.yaml
@@ -12,17 +12,17 @@ receipt:
     - tag: "FACT"
       reason_code: "RC-PHY-ENFORCE"
       claim: "Optical tap couplers extract a small fraction of light for monitoring without providing a feedback path."
-      evidence_ref: "ark_cephalo_manifest_v2.json:hardware_spec.layers.layer_2_analog_monitoring.tap_couplers"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/hardware_spec/layers/layer_2_analog_monitoring/tap_couplers"
 
     - tag: "SPEC"
       reason_code: "RC-DRIFT-GUARD"
       claim: "Overlay signals (audio, plots, metrics) must never cause changes to Φ, H, ΔMI, τ or twin-pass thresholds."
-      evidence_ref: "ark_cephalo_manifest_v2.json:hardware_spec.layers.layer_2_analog_monitoring"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/hardware_spec/layers/layer_2_analog_monitoring"
 
     - tag: "ACC"
       reason_code: "RC-AUD-TRACE"
       claim: "Acceptance: injecting adversarial overlay stimuli does not alter guard outputs or thresholds."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.overlay_contract"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/overlay_contract"
 
   procedure:
     steps:

--- a/ark/p4/receipts/ARK_P4_CST_0006.yaml
+++ b/ark/p4/receipts/ARK_P4_CST_0006.yaml
@@ -6,7 +6,7 @@ receipt:
     - tag: SPEC
       reason_code: RC-AUD-TRACE
       claim: "Self-test runs every 100 frames using pilot tone with known patterns and logs cryptographic attestation."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.continuous_self_test"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/continuous_self_test"
   procedure:
     steps:
       - "Define pilot-pattern set P (small, fixed, hashed)"

--- a/ark/p4/receipts/ARK_P4_ENT_0002.yaml
+++ b/ark/p4/receipts/ARK_P4_ENT_0002.yaml
@@ -18,17 +18,17 @@ receipt:
     - tag: "FACT"
       reason_code: "RC-PHY-ENFORCE"
       claim: "Entropy gating is enforced by a physical high-pass spectral filter."
-      evidence_ref: "ark_cephalo_manifest_v2.json:hardware_spec.layers.layer_1_optical_core.guards.entropy_guard"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/hardware_spec/layers/layer_1_optical_core/guards/entropy_guard"
 
     - tag: "SPEC"
       reason_code: "RC-SPEC-THRESH"
       claim: "Constraint: H >= 0.78; below threshold signal is blocked."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.entropy"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/entropy"
 
     - tag: "ACC"
       reason_code: "RC-CAL-MAP"
       claim: "Acceptance: low-entropy calset scenes FAIL; high-entropy scenes PASS, with <= 2% false positives."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.calibration_protocol.entropy_guard"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/calibration_protocol/entropy_guard"
 
   procedure:
     setup:

--- a/ark/p4/receipts/ARK_P4_INDEX_0000.yaml
+++ b/ark/p4/receipts/ARK_P4_INDEX_0000.yaml
@@ -6,23 +6,23 @@ receipt:
     - tag: SPEC
       reason_code: RC-SPEC-THRESH
       claim: "Φ* Guard requires Φ* >= 0.72 enforced by saturable absorber."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.phi_star"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/phi_star"
     - tag: SPEC
       reason_code: RC-SPEC-THRESH
       claim: "Entropy guard requires H >= 0.78 enforced by high-pass spectral filter."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.entropy"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/entropy"
     - tag: SPEC
       reason_code: RC-SPEC-THRESH
       claim: "MI constraint uses ΔMI >= 3.0 bit with JTC peak-width proxy sweet spot."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.mutual_information"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/mutual_information"
     - tag: SPEC
       reason_code: RC-SPEC-THRESH
       claim: "Refractory constraint τ >= 120 ms enforced by thermal detuning recovery."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.refractory"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/refractory"
     - tag: SPEC
       reason_code: RC-AUD-TRACE
       claim: "Continuous self-test runs every 100 frames with cryptographic attestation."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.continuous_self_test"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/continuous_self_test"
   tests_required:
     - "ARK-P4-PHI-0001"
     - "ARK-P4-ENT-0002"

--- a/ark/p4/receipts/ARK_P4_MI_0003.yaml
+++ b/ark/p4/receipts/ARK_P4_MI_0003.yaml
@@ -16,7 +16,7 @@ receipt:
     - tag: SPEC
       reason_code: RC-SPEC-THRESH
       claim: "Constraint: ΔMI >= 3.0 bit; violation yields no correlation peak / blocked."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.mutual_information"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/mutual_information"
     - tag: FACT
       reason_code: RC-PHY-ENFORCE
       claim: "Decision logic: sharp peak (<0.2) BLOCK, broad (0.2–0.6) PASS, no peak BLOCK."
@@ -24,7 +24,7 @@ receipt:
     - tag: ACC
       reason_code: RC-AUD-TRACE
       claim: "Acceptance: peak-width classification matches expected for identical/similar/different pairs."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.calibration_protocol.mi_guard"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/calibration_protocol/mi_guard"
   procedure:
     calibration_assets:
       - "CALSET-JTC-IDENT: identical pairs"

--- a/ark/p4/receipts/ARK_P4_PHI_0001.yaml
+++ b/ark/p4/receipts/ARK_P4_PHI_0001.yaml
@@ -22,17 +22,17 @@ receipt:
     - tag: "FACT"
       reason_code: "RC-PHY-ENFORCE"
       claim: "Guard is implemented physically via saturable absorber transmission barrier."
-      evidence_ref: "ark_cephalo_manifest_v2.json:hardware_spec.layers.layer_1_optical_core.guards.phi_star_guard"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/hardware_spec/layers/layer_1_optical_core/guards/phi_star_guard"
 
     - tag: "SPEC"
       reason_code: "RC-SPEC-THRESH"
       claim: "Constraint: Φ* >= 0.72; below threshold light is absorbed."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.phi_star"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/phi_star"
 
     - tag: "ACC"
       reason_code: "RC-CAL-MAP"
       claim: "Acceptance: T_sat reached at I corresponding to Φ* = 0.72 ± 0.02 as defined by ARK-MAP-PHI-0002."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.calibration_protocol.phi_guard"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/calibration_protocol/phi_guard"
 
   procedure:
     setup:

--- a/ark/p4/receipts/ARK_P4_TAU_0004.yaml
+++ b/ark/p4/receipts/ARK_P4_TAU_0004.yaml
@@ -16,7 +16,7 @@ receipt:
     - tag: SPEC
       reason_code: RC-SPEC-THRESH
       claim: "Constraint: τ >= 120ms enforced by thermal detuning recovery."
-      evidence_ref: "ark_cephalo_manifest_v2.json:governance_invariants.refractory"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/governance_invariants/refractory"
     - tag: FACT
       reason_code: RC-PHY-ENFORCE
       claim: "Thermodynamics determines timing; cannot be accelerated without violating physics."
@@ -24,7 +24,7 @@ receipt:
     - tag: ACC
       reason_code: RC-SPEC-THRESH
       claim: "Acceptance: τ = 120ms ± 12ms (10% tolerance)."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.calibration_protocol.refractory"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/calibration_protocol/refractory"
   procedure:
     steps:
       - "Apply heating pulse (2 mW) to detune ring; log transmission vs time"

--- a/ark/p4/receipts/ARK_P4_TWIN_0005.yaml
+++ b/ark/p4/receipts/ARK_P4_TWIN_0005.yaml
@@ -28,12 +28,12 @@ receipt:
     - tag: "FACT"
       reason_code: "RC-PHY-ENFORCE"
       claim: "Decision is physical interference: constructive = PASS, destructive = FAIL."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.calibration_protocol.twin_pass"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/calibration_protocol/twin_pass"
 
     - tag: "ACC"
       reason_code: "RC-SPEC-THRESH"
       claim: "Acceptance: >= 95% correct PASS/FAIL decisions."
-      evidence_ref: "ark_cephalo_manifest_v2.json:validation.calibration_protocol.twin_pass"
+      evidence_ref: "ark_cephalo_manifest_v2.json#/validation/calibration_protocol/twin_pass"
 
   procedure:
     calibration_assets:


### PR DESCRIPTION
### Motivation

- Ensure `evidence_ref` values in P4 receipts use JSON Pointer syntax that matches the manifest schema to remove ambiguity and enable programmatic dereferencing.
- Keep references consistent across P4 guard, overlay, and self-test receipts so downstream tooling and validators can resolve manifest locations reliably.

### Description

- Replace legacy dotted manifest references like `ark_cephalo_manifest_v2.json:governance_invariants.phi_star` with JSON Pointer form `ark_cephalo_manifest_v2.json#/governance_invariants/phi_star` across P4 receipts in `ark/p4/receipts`.
- Files updated: `ARK_P4_INDEX_0000.yaml`, `ARK_P4_ENT_0002.yaml`, `ARK_P4_MI_0003.yaml`, `ARK_P4_PHI_0001.yaml`, `ARK_P4_TAU_0004.yaml`, `ARK_P4_TWIN_0005.yaml`, `ARK_P4_CST_0006.yaml`, and `ARK_OVL_RO_0001.yaml`.
- A small migration script was used to perform the replacements consistently and avoid manual transcription errors.

### Testing

- Located all occurrences with `rg` and verified the old pattern existed, then re-scanned after the migration to confirm all `evidence_ref` values now use the `#/` JSON Pointer form.
- Inspected representative receipts with `sed`/`nl` to validate changes were applied correctly and readable `evidence_ref` targets point into `ark_cephalo_manifest_v2.json` paths.
- Ran a conflict-scan using `rg -n "<<<<<<<|=======|>>>>>>>"` to ensure no merge markers remained in the affected files; the scan returned no unresolved markers in the modified receipts.
- No unit tests were run against runtime code; all file-modification verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f1488ce48325898b59f27238c821)