### PR TITLE
Replace typing.List/Dict/Tuple annotations with built-in generics

### DIFF
--- a/Fractalsense/__init__.py
+++ b/Fractalsense/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
         def decorator(func):
             return func
         return decorator
-from typing import Dict, List, Any, Tuple, Optional
+from typing import Any, Optional
 
 # Importiere das Modul-Interface
 from modular_app_structure import ModuleInterface
@@ -51,7 +51,7 @@ class FractalVisualizationModule(ModuleInterface):
         # Konfigurationsmanager
         self._config_manager = None
     
-    def initialize(self, app_context: Dict[str, Any]) -> bool:
+    def initialize(self, app_context: dict[str, Any]) -> bool:
         """Initialisiert das Modul mit dem App-Kontext.
         
         Args:
@@ -181,18 +181,18 @@ class FractalVisualizationModule(ModuleInterface):
         except Exception as e:
             print(f"Fehler beim Rendern des Fraktals: {str(e)}")
     
-    def _get_extent(self) -> Tuple[float, float, float, float]:
+    def _get_extent(self) -> tuple[float, float, float, float]:
         """Gibt den Darstellungsbereich für imshow zurück.
         
         Returns:
-            Tuple[float, float, float, float]: Darstellungsbereich (links, rechts, unten, oben)
+            tuple[float, float, float, float]: Darstellungsbereich (links, rechts, unten, oben)
         """
         return (-2/self._zoom + self._center.real, 
                 0.8/self._zoom + self._center.real, 
                 -1.4/self._zoom + self._center.imag, 
                 1.4/self._zoom + self._center.imag)
     
-    def _on_sensor_data_updated(self, event_type: str, event_data: Dict[str, Any]) -> None:
+    def _on_sensor_data_updated(self, event_type: str, event_data: dict[str, Any]) -> None:
         """Event-Handler für aktualisierte Sensordaten.
         
         Args:
@@ -217,7 +217,7 @@ class FractalVisualizationModule(ModuleInterface):
         # Fraktal neu rendern
         self._render_fractal()
     
-    def _on_zoom_in(self, event_type: str, event_data: Dict[str, Any]) -> None:
+    def _on_zoom_in(self, event_type: str, event_data: dict[str, Any]) -> None:
         """Event-Handler für Zoom-In.
         
         Args:
@@ -230,7 +230,7 @@ class FractalVisualizationModule(ModuleInterface):
         # Fraktal neu rendern
         self._render_fractal()
     
-    def _on_zoom_out(self, event_type: str, event_data: Dict[str, Any]) -> None:
+    def _on_zoom_out(self, event_type: str, event_data: dict[str, Any]) -> None:
         """Event-Handler für Zoom-Out.
         
         Args:
@@ -243,7 +243,7 @@ class FractalVisualizationModule(ModuleInterface):
         # Fraktal neu rendern
         self._render_fractal()
     
-    def _on_move(self, event_type: str, event_data: Dict[str, Any]) -> None:
+    def _on_move(self, event_type: str, event_data: dict[str, Any]) -> None:
         """Event-Handler für Bewegung.
         
         Args:
@@ -260,14 +260,14 @@ class FractalVisualizationModule(ModuleInterface):
         # Fraktal neu rendern
         self._render_fractal()
     
-    def process(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+    def process(self, input_data: dict[str, Any]) -> dict[str, Any]:
         """Verarbeitet Eingabedaten und gibt Ergebnisse zurück.
         
         Args:
             input_data: Eingabedaten für die Verarbeitung
             
         Returns:
-            Dict[str, Any]: Ergebnisse der Verarbeitung
+            dict[str, Any]: Ergebnisse der Verarbeitung
         """
         # Verarbeite Eingabedaten
         if "center" in input_data:
@@ -298,11 +298,11 @@ class FractalVisualizationModule(ModuleInterface):
             "extent": self._get_extent()
         }
     
-    def get_ui_components(self) -> Dict[str, Any]:
+    def get_ui_components(self) -> dict[str, Any]:
         """Gibt UI-Komponenten des Moduls zurück.
         
         Returns:
-            Dict[str, Any]: UI-Komponenten des Moduls
+            dict[str, Any]: UI-Komponenten des Moduls
         """
         # In einer realen Anwendung würden hier UI-Komponenten zurückgegeben werden
         # Für dieses Beispiel geben wir nur die Figur zurück
@@ -361,6 +361,6 @@ class FractalVisualizationModule(ModuleInterface):
         return self._description
     
     @property
-    def dependencies(self) -> List[str]:
+    def dependencies(self) -> list[str]:
         """Gibt die Abhängigkeiten des Moduls zurück."""
         return self._dependencies

--- a/Fractalsense/color_generator.py
+++ b/Fractalsense/color_generator.py
@@ -5,7 +5,6 @@ Dieses Modul erweitert die Farbfunktionalität des ResonanceEnhancer-Moduls mit 
 """
 
 import colorsys
-from typing import Dict, List, Tuple
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -192,7 +191,7 @@ class ColorGenerator:
         )
 
     def create_dynamic_colormap(
-        self, base_hsv: Tuple[float, float, float], shift_factor: float, name: str = "dynamic"
+        self, base_hsv: tuple[float, float, float], shift_factor: float, name: str = "dynamic"
     ) -> LinearSegmentedColormap:
         """Erstellt eine dynamische Farbkarte basierend auf HSV-Werten.
 
@@ -221,7 +220,7 @@ class ColorGenerator:
         return dynamic_cmap
 
     def create_sensor_based_colormap(
-        self, sensor_data: Dict[str, float], fractal_zoom: float, name: str = "sensor_based"
+        self, sensor_data: dict[str, float], fractal_zoom: float, name: str = "sensor_based"
     ) -> LinearSegmentedColormap:
         """Erstellt eine Farbkarte basierend auf Sensordaten und Fraktal-Zoom.
 
@@ -283,7 +282,7 @@ class ColorGenerator:
 
     def create_resonant_gradient(
         self, base_frequency: float, harmonic_ratio: float, n_colors: int = 256
-    ) -> List[Tuple[float, float, float]]:
+    ) -> list[tuple[float, float, float]]:
         """Erstellt einen resonanten Farbverlauf basierend auf Frequenzverhältnissen.
 
         Args:
@@ -292,7 +291,7 @@ class ColorGenerator:
             n_colors: Anzahl der Farben
 
         Returns:
-            List[Tuple[float, float, float]]: Liste von RGB-Farben
+            list[tuple[float, float, float]]: Liste von RGB-Farben
         """
         colors = []
 

--- a/Fractalsense/integration.py
+++ b/Fractalsense/integration.py
@@ -7,12 +7,12 @@ Dieses Modul integriert den ResonanceEnhancer mit den bestehenden Modulen.
 import os
 import sys
 import importlib
-from typing import Dict, List, Any
+from typing import Any
 
 # Importiere das modulare Framework
 from modular_app_structure import ModuleInterface, EventSystem
 
-def integrate_resonance_enhancer(app_context: Dict[str, Any]) -> bool:
+def integrate_resonance_enhancer(app_context: dict[str, Any]) -> bool:
     """Integriert das ResonanceEnhancer-Modul mit den bestehenden Modulen.
     
     Args:
@@ -73,7 +73,7 @@ def _connect_hypergraph_to_resonance(event_system: EventSystem) -> None:
     # Event-Handler für Hypergraph-Updates registrieren
     event_system.register_handler("hypergraph_updated", _on_hypergraph_updated)
 
-def _on_colormap_updated(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_colormap_updated(event_type: str, event_data: dict[str, Any]) -> None:
     """Event-Handler für aktualisierte Farbkarten.
     
     Args:
@@ -88,7 +88,7 @@ def _on_colormap_updated(event_type: str, event_data: Dict[str, Any]) -> None:
     event_system = EventSystem()
     event_system.emit_event("update_fractal_colormap", {"colormap": colormap})
 
-def _on_fractal_updated_for_sound(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_fractal_updated_for_sound(event_type: str, event_data: dict[str, Any]) -> None:
     """Event-Handler für aktualisiertes Fraktal (für Klangerzeugung).
     
     Args:
@@ -113,7 +113,7 @@ def _on_fractal_updated_for_sound(event_type: str, event_data: Dict[str, Any]) -
         "zoom": zoom
     })
 
-def _on_sensor_data_updated_for_resonance(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_sensor_data_updated_for_resonance(event_type: str, event_data: dict[str, Any]) -> None:
     """Event-Handler für aktualisierte Sensordaten (für ResonanceEnhancer).
     
     Args:
@@ -146,7 +146,7 @@ def _on_sensor_data_updated_for_resonance(event_type: str, event_data: Dict[str,
         "gyro_z": gyro_z
     })
 
-def _on_hypergraph_updated(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_hypergraph_updated(event_type: str, event_data: dict[str, Any]) -> None:
     """Event-Handler für aktualisierten Hypergraphen.
     
     Args:
@@ -280,7 +280,7 @@ from typing import Dict, List, Any
 # Importiere das modulare Framework
 from modular_app_structure import ModuleInterface, EventSystem
 
-def integrate_resonance_enhancer(app_context: Dict[str, Any]) -> bool:
+def integrate_resonance_enhancer(app_context: dict[str, Any]) -> bool:
     \"\"\"Integriert das ResonanceEnhancer-Modul mit den bestehenden Modulen.
     
     Args:
@@ -341,7 +341,7 @@ def _connect_hypergraph_to_resonance(event_system: EventSystem) -> None:
     # Event-Handler für Hypergraph-Updates registrieren
     event_system.register_handler("hypergraph_updated", _on_hypergraph_updated)
 
-def _on_colormap_updated(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_colormap_updated(event_type: str, event_data: dict[str, Any]) -> None:
     \"\"\"Event-Handler für aktualisierte Farbkarten.
     
     Args:
@@ -356,7 +356,7 @@ def _on_colormap_updated(event_type: str, event_data: Dict[str, Any]) -> None:
     event_system = EventSystem()
     event_system.emit_event("update_fractal_colormap", {"colormap": colormap})
 
-def _on_fractal_updated_for_sound(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_fractal_updated_for_sound(event_type: str, event_data: dict[str, Any]) -> None:
     \"\"\"Event-Handler für aktualisiertes Fraktal (für Klangerzeugung).
     
     Args:
@@ -381,7 +381,7 @@ def _on_fractal_updated_for_sound(event_type: str, event_data: Dict[str, Any]) -
         "zoom": zoom
     })
 
-def _on_sensor_data_updated_for_resonance(event_type: str, event_data: Dict[str, Any]) -> None:
+def _on_sensor_data_updated_for_resonance(event_type: str, event_data: dict[str, Any]) -> None:
     \"\"\"Event-Handler für aktualisierte Sensordaten (für ResonanceEnhancer).
     
     Args:

--- a/Fractalsense/modular_app_structure.py
+++ b/Fractalsense/modular_app_structure.py
@@ -12,7 +12,7 @@ import logging
 import os
 import sys
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Type
+from typing import Any, Callable, Optional, Type
 
 # Logging konfigurieren
 logging.basicConfig(
@@ -25,7 +25,7 @@ class ModuleInterface(ABC):
     """Basis-Interface für alle Module."""
 
     @abstractmethod
-    def initialize(self, app_context: Dict[str, Any]) -> bool:
+    def initialize(self, app_context: dict[str, Any]) -> bool:
         """Initialisiert das Modul mit dem App-Kontext.
 
         Args:
@@ -37,23 +37,23 @@ class ModuleInterface(ABC):
         pass
 
     @abstractmethod
-    def process(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+    def process(self, input_data: dict[str, Any]) -> dict[str, Any]:
         """Verarbeitet Eingabedaten und gibt Ergebnisse zurück.
 
         Args:
             input_data: Eingabedaten für die Verarbeitung
 
         Returns:
-            Dict[str, Any]: Ergebnisse der Verarbeitung
+            dict[str, Any]: Ergebnisse der Verarbeitung
         """
         pass
 
     @abstractmethod
-    def get_ui_components(self) -> Dict[str, Any]:
+    def get_ui_components(self) -> dict[str, Any]:
         """Gibt UI-Komponenten des Moduls zurück.
 
         Returns:
-            Dict[str, Any]: UI-Komponenten des Moduls
+            dict[str, Any]: UI-Komponenten des Moduls
         """
         pass
 
@@ -82,7 +82,7 @@ class ModuleInterface(ABC):
 
     @property
     @abstractmethod
-    def dependencies(self) -> List[str]:
+    def dependencies(self) -> list[str]:
         """Gibt die Abhängigkeiten des Moduls zurück."""
         pass
 
@@ -91,11 +91,11 @@ class ModuleRegistry:
     """Verwaltet die Registrierung und Verwaltung von Modulen."""
 
     def __init__(self):
-        self._modules: Dict[str, ModuleInterface] = {}
-        self._module_classes: Dict[str, Type[ModuleInterface]] = {}
-        self._module_paths: Dict[str, str] = {}
-        self._module_dependencies: Dict[str, List[str]] = {}
-        self._module_load_order: List[str] = []
+        self._modules: dict[str, ModuleInterface] = {}
+        self._module_classes: dict[str, Type[ModuleInterface]] = {}
+        self._module_paths: dict[str, str] = {}
+        self._module_dependencies: dict[str, list[str]] = {}
+        self._module_load_order: list[str] = []
 
     def register_module_class(self, module_class: Type[ModuleInterface], module_path: str) -> bool:
         """Registriert eine Modulklasse.
@@ -172,7 +172,7 @@ class ModuleRegistry:
         logger.info(f"{count} Module gefunden und registriert.")
         return count
 
-    def initialize_modules(self, app_context: Dict[str, Any]) -> bool:
+    def initialize_modules(self, app_context: dict[str, Any]) -> bool:
         """Initialisiert alle registrierten Module in der richtigen Reihenfolge.
 
         Args:
@@ -255,11 +255,11 @@ class ModuleRegistry:
         """
         return self._modules.get(module_name)
 
-    def get_all_modules(self) -> Dict[str, ModuleInterface]:
+    def get_all_modules(self) -> dict[str, ModuleInterface]:
         """Gibt alle initialisierten Module zurück.
 
         Returns:
-            Dict[str, ModuleInterface]: Dictionary mit allen Modulen
+            dict[str, ModuleInterface]: Dictionary mit allen Modulen
         """
         return self._modules.copy()
 
@@ -282,7 +282,7 @@ class EventSystem:
     """Implementiert ein Event-System für die Kommunikation zwischen Modulen."""
 
     def __init__(self):
-        self._event_handlers: Dict[str, List[Callable]] = {}
+        self._event_handlers: dict[str, list[Callable]] = {}
 
     def register_handler(self, event_type: str, handler: Callable) -> None:
         """Registriert einen Event-Handler.
@@ -313,7 +313,7 @@ class EventSystem:
             return True
         return False
 
-    def emit_event(self, event_type: str, event_data: Dict[str, Any] = None) -> None:
+    def emit_event(self, event_type: str, event_data: Optional[dict[str, Any]] = None) -> None:
         """Sendet ein Event an alle registrierten Handler.
 
         Args:
@@ -338,7 +338,7 @@ class ConfigManager:
 
     def __init__(self, config_file: str):
         self._config_file = config_file
-        self._config: Dict[str, Any] = {
+        self._config: dict[str, Any] = {
             "app": {
                 "name": "FractalSense EntaENGELment",
                 "version": "1.0.0",
@@ -370,7 +370,7 @@ class ConfigManager:
             logger.error(f"Fehler beim Laden der Konfiguration: {str(e)}")
             return False
 
-    def _update_config(self, target: Dict[str, Any], source: Dict[str, Any]) -> None:
+    def _update_config(self, target: dict[str, Any], source: dict[str, Any]) -> None:
         """Aktualisiert die Konfiguration rekursiv.
 
         Args:
@@ -432,20 +432,20 @@ class ConfigManager:
 
         self._config[section][key] = value
 
-    def get_module_config(self, module_name: str) -> Dict[str, Any]:
+    def get_module_config(self, module_name: str) -> dict[str, Any]:
         """Gibt die Konfiguration eines Moduls zurück.
 
         Args:
             module_name: Name des Moduls
 
         Returns:
-            Dict[str, Any]: Modulkonfiguration oder leeres Dictionary, wenn nicht gefunden
+            dict[str, Any]: Modulkonfiguration oder leeres Dictionary, wenn nicht gefunden
         """
         if "modules" in self._config and module_name in self._config["modules"]:
             return self._config["modules"][module_name]
         return {}
 
-    def set_module_config(self, module_name: str, config: Dict[str, Any]) -> None:
+    def set_module_config(self, module_name: str, config: dict[str, Any]) -> None:
         """Setzt die Konfiguration eines Moduls.
 
         Args:

--- a/Fractalsense/sound_generator.py
+++ b/Fractalsense/sound_generator.py
@@ -6,7 +6,6 @@ Dieses Modul erweitert die Soundfunktionalität des ResonanceEnhancer-Moduls mit
 
 import threading
 import time
-from typing import List, Tuple
 
 import numpy as np
 import pygame
@@ -46,7 +45,7 @@ class SoundGenerator:
         self,
         base_frequency: float,
         duration: float,
-        harmonics: List[Tuple[int, float]] = None,
+        harmonics: list[tuple[int, float]] = None,
         amplitude: float = 1.0,
     ) -> np.ndarray:
         """Generiert eine Welle mit Obertönen.

--- a/ledger/replay_determinism.py
+++ b/ledger/replay_determinism.py
@@ -18,7 +18,7 @@ import json
 import unicodedata
 import uuid
 from dataclasses import dataclass, asdict
-from typing import Any, Dict, List
+from typing import Any
 
 # Namespace for stable UUIDs (UUIDv5) — keep constant for the project.
 NAMESPACE_ENTAENGELMENT = uuid.UUID("12345678-1234-5678-1234-567812345678")
@@ -61,12 +61,12 @@ def hash_canonical(obj: Any) -> str:
 class ReplayableReceipt:
     """Receipt with deterministic replay capability."""
 
-    event: Dict[str, Any]
-    deterministic: Dict[str, Any]
-    input: Dict[str, Any]
-    transforms: List[Dict[str, Any]]
-    output: Dict[str, Any]
-    signatures: Dict[str, Any]
+    event: dict[str, Any]
+    deterministic: dict[str, Any]
+    input: dict[str, Any]
+    transforms: list[dict[str, Any]]
+    output: dict[str, Any]
+    signatures: dict[str, Any]
 
     def compute_replay_hash(self) -> str:
         """Compute deterministic hash over ONLY stable fields.
@@ -112,7 +112,7 @@ class ReplayableReceipt:
         stored = _norm_sha256(self.deterministic.get("replay_hash", ""))
         return computed == stored
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
         return asdict(self)
 
@@ -120,9 +120,9 @@ class ReplayableReceipt:
 def create_receipt(
     text: str,
     seed: int,
-    config: Dict[str, Any],
-    transforms: List[Dict[str, Any]],
-    output: Dict[str, Any],
+    config: dict[str, Any],
+    transforms: list[dict[str, Any]],
+    output: dict[str, Any],
     user_id_hash: str,
     user_consent: str,
     *,
@@ -172,9 +172,9 @@ def create_receipt(
     return receipt
 
 
-def verify_receipt_chain(receipts: List[Dict[str, Any]]) -> Dict[str, bool]:
+def verify_receipt_chain(receipts: list[dict[str, Any]]) -> dict[str, bool]:
     """Verify a list of receipts (dict form) for replay-hash integrity."""
-    results: Dict[str, bool] = {}
+    results: dict[str, bool] = {}
     for i, receipt in enumerate(receipts):
         obj = ReplayableReceipt(**receipt)
         results[f"receipt_{i}"] = obj.verify_replay()

--- a/mapping/tensor_validator.py
+++ b/mapping/tensor_validator.py
@@ -8,7 +8,6 @@ Goal: fail fast on structural issues while keeping authoring ergonomic.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Tuple
 
 import yaml
 
@@ -19,15 +18,15 @@ STATUS = {"defined", "partial", "void"}
 
 @dataclass
 class ValidationResult:
-    errors: List[str]
-    warnings: List[str]
+    errors: list[str]
+    warnings: list[str]
 
     @property
     def ok(self) -> bool:
         return len(self.errors) == 0
 
 
-def _err(errors: List[str], msg: str) -> None:
+def _err(errors: list[str], msg: str) -> None:
     errors.append(msg)
 
 
@@ -37,8 +36,8 @@ def validate_tensor_mapping(filepath: str) -> ValidationResult:
     with open(filepath, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
-    errors: List[str] = []
-    warnings: List[str] = []
+    errors: list[str] = []
+    warnings: list[str] = []
 
     if not isinstance(data, dict):
         return ValidationResult(errors=["Root must be a mapping/object"], warnings=[])


### PR DESCRIPTION
### Motivation
- Address linter suggestions to replace legacy `typing.List`/`typing.Dict`/`typing.Tuple` annotations with the modern built-in generics (`list`/`dict`/`tuple`) to match current type-hinting best practices and resolve CI lint failures.
- Reduce reliance on extra `typing` imports for simple container annotations and improve consistency across FractalSense and ledger code.

### Description
- Rewrote annotations in `mapping/tensor_validator.py` to use `list[str]` for error/warning types and updated helper signatures accordingly.
- Migrated receipt and replay types in `ledger/replay_determinism.py` from `Dict`/`List` to `dict`/`list` generics and adjusted return/type hints (including `to_dict` and `verify_receipt_chain`).
- Updated FractalSense package files (`Fractalsense/__init__.py`, `Fractalsense/modular_app_structure.py`, `Fractalsense/color_generator.py`, `Fractalsense/sound_generator.py`, `Fractalsense/integration.py`) to use built-in `dict`/`list`/`tuple` generics in function signatures, return types, attributes and docstrings, and removed now-unnecessary `typing` imports where applicable.
- Minor docstring/type annotation adjustments to keep the documentation consistent with the new type hints.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740090f0148325be62a98d67005fe6)