### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "FOKUS: deps"
+    labels:
+      - "dependencies"
+      - "security"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/ui-app"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "FOKUS: deps"
+    labels:
+      - "dependencies"
+      - "security"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "FOKUS: deps"
+    labels:
+      - "dependencies"
+      - "ci"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Intent

Enable automated dependency updates across the project using GitHub's Dependabot service. This will help keep Python, Node.js, and GitHub Actions dependencies up-to-date with security patches and new versions.

## Scope

FOKUS: Dependency management automation

- Added `.github/dependabot.yml` configuration file
- Configured Dependabot to check for updates weekly (Mondays) across three package ecosystems:
  - Python dependencies (pip) in root directory
  - Node.js dependencies (npm) in `/ui-app` directory
  - GitHub Actions in workflow files
- Set pull request limits to prevent overwhelming the review queue (5 for pip/npm, 3 for actions)
- Applied consistent labeling ("dependencies", "security", "ci") for easy filtering and triage

## Test Plan

N/A - Configuration file only. Dependabot will validate the configuration syntax upon merge.

## Risk

Low risk. This is a non-breaking configuration change that enables automated PRs. The `open-pull-requests-limit` settings ensure we won't be overwhelmed with dependency updates.

https://claude.ai/code/session_01DYD7AJLoS5nkzHP1UP1Jdj