### PR TITLE
Add pre-commit guard hooks for receipt and claim linting

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+# EntaENGELment Pre-Commit Hook
+# Guards: G1 (Nachvollziehbarkeit), G3 (Receipt-Integrität)
+
+set -euo pipefail
+
+echo "=== EntaENGELment Pre-Commit Guard ==="
+
+# Guard G1: Claim-Lint auf geänderte Dateien
+CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(py|md|yaml|yml|json)$' || true)
+
+if [ -n "$CHANGED_FILES" ]; then
+    echo "Checking claims in staged files..."
+    python3 tools/claim_lint.py --scope index,spec,receipts,tools 2>/dev/null || {
+        echo "Claim-lint warnings detected (non-blocking)"
+    }
+fi
+
+# Guard G3: Receipt-Lint auf geänderte Receipts — BLOCKING
+CHANGED_RECEIPTS=$(git diff --cached --name-only --diff-filter=ACM | grep 'receipts/.*\.json$' || true)
+
+if [ -n "$CHANGED_RECEIPTS" ]; then
+    echo "Linting staged receipts..."
+    for f in $CHANGED_RECEIPTS; do
+        python3 tools/receipt_lint.py "$f" || {
+            echo "Receipt lint FAILED for $f"
+            exit 1
+        }
+    done
+fi
+
+echo "=== Pre-Commit Guard PASS ==="

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,9 @@ Das Framework folgt strengen Invarianten:
 ## Fragen?
 
 Siehe [`./CODEOWNERS`](./CODEOWNERS) für Kontakte.
+
+## Local Guard Enforcement
+
+Run `make install-hooks` to enable pre-commit guards.
+This enforces Receipt-Lint (blocking) and Claim-Lint (warning)
+before every commit. Receipt-lint failures prevent the commit.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DMI ?= 4.7
 PHI ?= 0.72
 REFRACTORY ?= 120
 
-.PHONY: help install install-dev test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -16,6 +16,7 @@ help:
 	@echo "Setup:"
 	@echo "  make install         Install package"
 	@echo "  make install-dev     Install package with dev dependencies"
+	@echo "  make install-hooks   Install pre-commit guard hooks"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test            Run all tests"
@@ -58,6 +59,11 @@ install:
 install-dev:
 	pip install -r requirements-dev.txt
 	pip install -e .
+
+# === Hooks ===
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "Pre-commit hooks installed."
 
 # === Testing ===
 test:


### PR DESCRIPTION
## Intent

Implement local pre-commit guard enforcement to catch receipt and claim integrity issues before commits are pushed. This adds automated validation at the developer's machine level, enforcing Guards G1 (Nachvollziehbarkeit) and G3 (Receipt-Integrität).

## Scope

FOKUS: Pre-commit hook infrastructure

- Added `.githooks/pre-commit` script that runs claim-lint (non-blocking warnings) and receipt-lint (blocking failures) on staged files
- Added `make install-hooks` target to configure git to use the `.githooks` directory
- Updated `CONTRIBUTING.md` with instructions for enabling local guard enforcement
- Updated `Makefile` to document the new hook installation command

## Test Plan

- [ ] `make install-hooks` successfully configures git hooks path
- [ ] Pre-commit hook executes on `git commit` with staged Python/YAML/JSON/Markdown files
- [ ] Receipt-lint failures block commits as expected
- [ ] Claim-lint warnings are reported but don't block commits
- [ ] CI checks pass

## Risk

Low risk. The hook is opt-in via `make install-hooks` and doesn't affect existing workflows unless explicitly enabled. Non-blocking claim-lint warnings ensure developers aren't blocked by informational messages. Receipt-lint blocking is intentional and aligns with existing integrity requirements.

https://claude.ai/code/session_01LiJQV4VBBKqTm3Ruo1BgqW