### PR TITLE
fix(fractalsense): make optional matplotlib/pygame deps non-blocking

### DIFF
--- a/Fractalsense/__init__.py
+++ b/Fractalsense/__init__.py
@@ -4,11 +4,19 @@ FractalSense EntaENGELment - Beispielmodul für Fraktalvisualisierung
 Dieses Modul implementiert die Fraktalvisualisierung für die FractalSense EntaENGELment App.
 """
 
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
-from matplotlib.backends.backend_agg import FigureCanvasAgg
 import time
+from typing import Any, Optional
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_agg import FigureCanvasAgg
+    from matplotlib.figure import Figure
+except ImportError:  # pragma: no cover - exercised in lightweight test environments
+    plt = None
+    Figure = Any
+    FigureCanvasAgg = Any
 
 # Optional numba import for performance optimization
 try:
@@ -19,8 +27,6 @@ except ImportError:
         def decorator(func):
             return func
         return decorator
-from typing import Any, Optional
-
 # Importiere das Modul-Interface
 from modular_app_structure import ModuleInterface
 
@@ -61,6 +67,10 @@ class FractalVisualizationModule(ModuleInterface):
             bool: True, wenn die Initialisierung erfolgreich war, sonst False
         """
         try:
+            if plt is None:
+                print("Fehler: matplotlib ist nicht installiert; Fraktal-Visualisierung nicht verfügbar.")
+                return False
+
             # Event-System aus dem App-Kontext holen
             self._event_system = app_context.get("event_system")
             if self._event_system is None:

--- a/Fractalsense/color_generator.py
+++ b/Fractalsense/color_generator.py
@@ -6,14 +6,43 @@ Dieses Modul erweitert die Farbfunktionalität des ResonanceEnhancer-Moduls mit 
 
 import colorsys
 
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.colors import LinearSegmentedColormap
+try:
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    from matplotlib.colors import LinearSegmentedColormap
+except ImportError:  # pragma: no cover - fallback for lightweight environments
+    mpl = None
+    plt = None
+
+    class LinearSegmentedColormap:  # type: ignore[override]
+        """Minimal fallback replacement used when matplotlib is unavailable."""
+
+        def __init__(self, name: str, colors: list[tuple[float, float, float]]):
+            self.name = name
+            self._colors = list(colors)
+
+        @classmethod
+        def from_list(
+            cls, name: str, colors: list[tuple[float, float, float]]
+        ) -> "LinearSegmentedColormap":
+            return cls(name, colors)
+
+        def __call__(self, value: float) -> tuple[float, float, float, float]:
+            if not self._colors:
+                return (0.0, 0.0, 0.0, 1.0)
+
+            clamped = min(1.0, max(0.0, float(value)))
+            index = int(round(clamped * (len(self._colors) - 1)))
+            r, g, b = self._colors[index]
+            return (float(r), float(g), float(b), 1.0)
 
 
 def _register_colormap(name: str, cmap) -> None:
     """Register a colormap with matplotlib (compatible with old and new API)."""
+    if mpl is None:
+        return
+
     try:
         # New API (matplotlib >= 3.9)
         mpl.colormaps.register(cmap, name=name, force=True)

--- a/Fractalsense/sound_generator.py
+++ b/Fractalsense/sound_generator.py
@@ -8,7 +8,10 @@ import threading
 import time
 
 import numpy as np
-import pygame
+try:
+    import pygame
+except ImportError:  # pragma: no cover - optional for non-audio test environments
+    pygame = None
 
 
 class SoundGenerator:
@@ -375,6 +378,9 @@ class SoundGenerator:
 
         # Sound erstellen und abspielen
         try:
+            if pygame is None:
+                raise RuntimeError("pygame ist nicht installiert")
+
             sound = pygame.mixer.Sound(buffer=wave_int16)
             sound.play()
 
@@ -403,5 +409,6 @@ class SoundGenerator:
 
     def stop_sound(self) -> None:
         """Stoppt den aktuell abgespielten Sound."""
-        pygame.mixer.stop()
+        if pygame is not None:
+            pygame.mixer.stop()
         self.is_playing = False


### PR DESCRIPTION
### Motivation
- Python tests were failing during collection in lightweight environments because `Fractalsense` import-time hard-dependencies (`matplotlib`, `pygame`) are not always present, blocking CI/local test runs.
- Make the visualization and audio code degrade gracefully so the test-suite and tooling can run without these optional packages while preserving full behavior when they are installed.

### Description
- Guarded `matplotlib` imports in `Fractalsense/__init__.py` and fail module initialization early with a clear message when `matplotlib` is not available instead of crashing at import time.
- Added a minimal fallback `LinearSegmentedColormap` and made colormap registration a no-op when `matplotlib` is missing in `Fractalsense/color_generator.py` so color logic remains testable without the real library.
- Made `pygame` optional in `Fractalsense/sound_generator.py`, added an explicit runtime check before playback, and protected `stop_sound()` from unconditional mixer access so audio code fails gracefully when `pygame` is absent.

### Testing
- Ran `npm test` which runs `jest` for JS tests and the Python `Fractalsense` tests; JS suite passed (`36 tests` passed) and the Fractalsense Python unit suite passed after the changes (`140 passed`).
- Ran repository Python tests with `python -m pytest` at repo root and observed the full Python suite passed (`160 passed`).
- Ran `ruff` on the modified files which reported existing style/blank-line issues from legacy code (pre-existing, not introduced by this PR) and therefore was not fully remediated in this scoped fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac75ec4108325aad880d8d18e3de2)