### PR TITLE
fix(ui-app): remove duplicate keys in package.json

### DIFF
--- a/ui-app/package.json
+++ b/ui-app/package.json
@@ -9,9 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "16.1.6",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
     "next": "14.2.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -19,10 +16,6 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
-    "@types/node": "^25.2.3",
-    "@types/react": "^19.2.14",
-    "@types/react-dom": "^19.2.3",
-    "autoprefixer": "^10.4.20",
     "@types/node": "^25.5.0",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",


### PR DESCRIPTION
## Summary
- Removes duplicate entries in `ui-app/package.json` for `next`, `react`, `react-dom`, `@types/node`, `@types/react`, `@types/react-dom`, and `autoprefixer`
- Keeps stable versions (React 18 + Next 14) as clean base
- Unblocks 5 Dependabot PRs (#113, #126, #127, #128, #135) that currently have merge conflicts

## FOKUS: package.json Duplikate bereinigen

## Test plan
- [ ] `ui-app/package.json` is valid JSON with no duplicate keys
- [ ] Dependabot PRs become mergeable after this lands

https://claude.ai/code/session_01Ga4aq8fpdfPpavbdLpTYK5