### PR TITLE
FOKUS: deps: consolidate blocked Dependabot upgrades

### DIFF
--- a/ui-app/package.json
+++ b/ui-app/package.json
@@ -9,21 +9,21 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.2.21",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "next": "15.5.14",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "@tanstack/react-query": "^5.90.21",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "@types/react": "^18.3.18",
-    "@types/react-dom": "^18.3.5",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "autoprefixer": "^10.4.24",
     "eslint": "^10.2.0",
     "eslint-config-next": "16.2.1",
     "postcss": "^8.4.49",
-    "tailwindcss": "^3.4.17",
+    "tailwindcss": "^4.2.1",
     "typescript": "^5.7.3"
   }
 }


### PR DESCRIPTION
## Summary
Manually consolidates 4 blocked Dependabot PRs that had merge conflicts due to duplicate keys in `ui-app/package.json`:

- **#126**: react ^18 → ^19.2.4, @types/react → ^19.2.14, @types/react-dom → ^19.2.3
- **#135**: next 14.2.21 → 15.5.14
- **#127**: tailwindcss ^3.4.17 → ^4.2.1
- **#113**: eslint-config-next already at 16.2.1 (obsolete, no change needed)

## FOKUS: Dependabot-Upgrades konsolidieren

Supersedes #113, #126, #127, #135

## Test plan
- [ ] `ui-app/package.json` valid JSON, no duplicates
- [ ] CI passes
- [ ] Close #113, #126, #127, #135 after merge

## Risk
MEDIUM — Major version upgrades (React 19, Next 15, Tailwind 4). UI may need adjustments.

https://claude.ai/code/session_01Ga4aq8fpdfPpavbdLpTYK5