### PR TITLE
Add RC preflight checklist and clarify release process; update changelog and README links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Release Prep
+- Added a concrete RC preflight checklist for `v0.1.0-rc1` in `docs/release/RC_PRECHECK_v0.1.0-rc1.md`.
+- Clarified release process documentation for RC tags (`-rc`) and pre-release behavior.
+
 ### Added
 - Release workflow with integrated gate checks (INF-4)
 - Dependabot for automated dependency monitoring (INF-2)
@@ -28,7 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] — 2026-02-15
 
-Initial tagged release after hardening sprint.
+> Note: This entry documents planned/reported `0.1.0` contents. In this repository clone, no `v0.1.0` git tag is present.
+
+Documented 0.1.0 release baseline after hardening sprint (tag/publication status must be verified against the canonical remote).
 
 ### Foundation
 - DR-KERNEL v1.5 governance framework

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ npm run dev
 **Mehr:**
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) – Vollständige Guidelines
 - [`CODEOWNERS`](CODEOWNERS) – Kontakte
+- [`docs/governance/RELEASE_PROCESS.md`](docs/governance/RELEASE_PROCESS.md) – Release-Ablauf inkl. RC-Hinweis
+- [`docs/release/RC_PRECHECK_v0.1.0-rc1.md`](docs/release/RC_PRECHECK_v0.1.0-rc1.md) – Konservative RC-Preflight-Checkliste
 - Commit-Konvention: `type(scope): message` (`feat`, `fix`, `docs`, `test`, `refactor`, `chore`)
 
 ---

--- a/docs/governance/RELEASE_PROCESS.md
+++ b/docs/governance/RELEASE_PROCESS.md
@@ -11,12 +11,18 @@ EntaENGELment uses [Semantic Versioning](https://semver.org/):
 
 1. Ensure all CI checks are green on `main`
 2. Update CHANGELOG.md with release notes
-3. Tag: `git tag v0.1.0 -m "EntaENGELment v0.1.0"`
-4. Push tag: `git push origin v0.1.0`
+3. Tag (Beispiel): `git tag vX.Y.Z -m "EntaENGELment vX.Y.Z"`
+4. Push tag: `git push origin vX.Y.Z`
 5. Release workflow runs automatically:
    - All gate checks must PASS
    - GitHub Release created with auto-generated notes
 6. If any gate fails: delete tag, fix, retag
+
+### Release Candidates (RC)
+
+- RC tags follow SemVer pre-release form, e.g. `v0.1.0-rc1`.
+- The existing workflow marks tags containing `-rc` as GitHub pre-release.
+- For the first RC path, use `docs/release/RC_PRECHECK_v0.1.0-rc1.md` before tagging.
 
 ## Gate Checklist (automated)
 

--- a/docs/release/RC_PRECHECK_v0.1.0-rc1.md
+++ b/docs/release/RC_PRECHECK_v0.1.0-rc1.md
@@ -1,0 +1,49 @@
+# RC Preflight — v0.1.0-rc1
+
+Status: Draft checklist for first reproducible release candidate path.  
+Scope: Preparation only (no tag creation, no release trigger).
+
+## Ziel
+
+Einen klar nachvollziehbaren `v0.1.0-rc1`-Kandidaten vorbereiten, sodass ein späteres Tagging (`v0.1.0-rc1`) deterministisch durch die vorhandene Release-Pipeline läuft.
+
+## RC-Scope (konservativ)
+
+- Nur bereits integrierte, verifizierte Änderungen aus `main` seit dem zuletzt bestätigten Release-Tag (falls vorhanden).
+- Keine neue Release-Automatisierung.
+- Keine Verhaltensänderung im Release-Workflow.
+- Dokumentations- und Nachvollziehbarkeits-Verbesserungen sind erlaubt.
+
+## Preflight-Checkliste
+
+### A) Inhalt & Dokumentation
+- [ ] `CHANGELOG.md` unter `Unreleased` enthält einen klaren RC-Hinweis und die erwarteten Punkte für `v0.1.0-rc1`.
+- [ ] `README.md` verweist auf den Release-Prozess bzw. dieses RC-Preflight-Dokument.
+- [ ] Offene Risiken/Unsicherheiten für den RC sind benannt (keine impliziten Annahmen).
+
+### B) Technische Release-Gates (lokal prüfbar)
+- [ ] `python3 tools/verify_pointers.py --strict`
+- [ ] `python3 tools/claim_lint.py --scope index,spec,receipts,tools`
+- [ ] `python3 tools/port_lint.py`
+- [ ] `for f in receipts/*.json; do python3 tools/receipt_lint.py "$f"; done`
+- [ ] `pytest tests/ -x --tb=short`
+- [ ] `grep -r "return 0.5" src/core/` liefert keine Stub-Metriken.
+- [ ] `VOIDMAP.yml` enthält keine ownerlosen `OPEN`/`IN_PROGRESS`-VOIDs.
+
+### C) Workflow-Readiness
+- [ ] `.github/workflows/release.yml` bleibt tag-getrieben (`v*.*.*`) und unverändert bzgl. RC-Logik.
+- [ ] RC-Tag-Konvention bestätigt: `v0.1.0-rc1` (führt zu `prerelease=true` wegen `-rc` im Tag).
+- [ ] Keine lokalen Änderungen mehr offen, die nicht in den RC sollen.
+
+## Explizite Nicht-Ziele in diesem Schritt
+
+- Kein `git tag ...`
+- Kein `git push --tags`
+- Keine GitHub Release-Erstellung
+- Kein Eingriff in Gate- oder Release-Workflow-Logik
+
+## Mögliche Blocker vor echtem RC-Tag
+
+- Fehlende oder unvollständige Changelog-Einträge für RC-relevante Änderungen.
+- Nicht-grüne Gate-Checks (lokal oder CI).
+- Unklare Scope-Abgrenzung zwischen bestätigter Baseline und `v0.1.0-rc1`.


### PR DESCRIPTION
### Motivation
- Provide an explicit, conservative preflight checklist to prepare a reproducible `v0.1.0-rc1` release candidate and reduce accidental tagging mistakes. 
- Clarify release tagging guidance and RC semantics so the release workflow treats `-rc` tags as GitHub pre-releases. 
- Surface the release docs from `README.md` and document the planned `0.1.0` baseline in `CHANGELOG.md` for traceability.

### Description
- Added `docs/release/RC_PRECHECK_v0.1.0-rc1.md` containing a detailed RC preflight checklist and local gate commands such as `python3 tools/verify_pointers.py --strict` and `pytest tests/ -x --tb=short`.
- Updated `docs/governance/RELEASE_PROCESS.md` to generalize the example tagging step to `git tag vX.Y.Z -m "EntaENGELment vX.Y.Z"` and to document RC tag conventions and guidance for using `v0.1.0-rc1`.
- Updated `CHANGELOG.md` under `Unreleased` to include a "Release Prep" section and a note that `0.1.0` contents are documented but the git tag must be verified against the canonical remote.
- Updated `README.md` to add links to the release governance doc and the new RC preflight checklist.

### Testing
- No automated tests were executed as part of this documentation-only PR. 
- The new checklist documents local test commands including `pytest tests/ -x --tb=short` and various lint/verify scripts that should be run prior to tagging. 
- CI gate checks remain unchanged and will run the repository's existing automated gates when a release tag is pushed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d11b067b308325b0888930ca01a280)