### PR TITLE
Rewrite pre-commit hook: consolidate claim lint and blocking receipt lint with directory-based selection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,70 +1,35 @@
 #!/usr/bin/env bash
-# Pre-commit hook: validate receipts before they enter the chain (G3)
-#
-# Ensures all staged receipt files pass receipt_lint before commit.
-# Install via: make install-hooks
-
-set -euo pipefail
-
-RECEIPT_DIRS="receipts data/receipts"
-LINT_CMD="python3 tools/receipt_lint.py"
-
-staged_receipts=()
-for dir in $RECEIPT_DIRS; do
-    while IFS= read -r file; do
-        [ -n "$file" ] && staged_receipts+=("$file")
-    done < <(git diff --cached --name-only --diff-filter=ACM -- "$dir/" 2>/dev/null || true)
-done
-
-if [ ${#staged_receipts[@]} -eq 0 ]; then
-    exit 0
-fi
-
-echo "=== Pre-commit: Validating ${#staged_receipts[@]} receipt(s) ==="
-
-fail=0
-for f in "${staged_receipts[@]}"; do
-    if ! $LINT_CMD "$f"; then
-        echo "FAIL: $f did not pass receipt lint"
-        fail=1
-    fi
-done
-
-if [ $fail -ne 0 ]; then
-    echo ""
-    echo "Commit blocked: invalid receipts detected (G3 enforcement)."
-    echo "Fix the issues above and try again."
-    exit 1
-fi
-
-echo "=== Pre-commit: All receipts valid ==="
-exit 0
-#!/bin/bash
 # EntaENGELment Pre-Commit Hook
-# Guards: G1 (Nachvollziehbarkeit), G3 (Receipt-Integrität)
+# - Claim lint: non-blocking warning
+# - Receipt lint: blocking for staged receipt files
 
 set -euo pipefail
 
 echo "=== EntaENGELment Pre-Commit Guard ==="
 
-# Guard G1: Claim-Lint auf geänderte Dateien
+# Non-blocking claim lint (run only when relevant staged files exist)
 CHANGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(py|md|yaml|yml|json)$' || true)
-
 if [ -n "$CHANGED_FILES" ]; then
-    echo "Checking claims in staged files..."
-    python3 tools/claim_lint.py --scope index,spec,receipts,tools 2>/dev/null || {
-        echo "Claim-lint warnings detected (non-blocking)"
-    }
+    echo "Running claim-lint (non-blocking)..."
+    if ! python3 tools/claim_lint.py --scope index,spec,receipts,tools 2>/dev/null; then
+        echo "Warning: claim-lint reported findings (non-blocking)."
+    fi
 fi
 
-# Guard G3: Receipt-Lint auf geänderte Receipts — BLOCKING
-CHANGED_RECEIPTS=$(git diff --cached --name-only --diff-filter=ACM | grep 'receipts/.*\.json$' || true)
+# Blocking receipt lint for staged receipt files (directory-based selection)
+RECEIPT_DIRS="receipts data/receipts"
+CHANGED_RECEIPTS=()
+for dir in $RECEIPT_DIRS; do
+    while IFS= read -r file; do
+        [ -n "$file" ] && CHANGED_RECEIPTS+=("$file")
+    done < <(git diff --cached --name-only --diff-filter=ACM -- "$dir/" 2>/dev/null || true)
+done
 
-if [ -n "$CHANGED_RECEIPTS" ]; then
-    echo "Linting staged receipts..."
-    for f in $CHANGED_RECEIPTS; do
-        python3 tools/receipt_lint.py "$f" || {
-            echo "Receipt lint FAILED for $f"
+if [ ${#CHANGED_RECEIPTS[@]} -gt 0 ]; then
+    echo "Running receipt-lint (blocking) on staged receipts..."
+    for receipt in "${CHANGED_RECEIPTS[@]}"; do
+        python3 tools/receipt_lint.py "$receipt" || {
+            echo "Receipt lint FAILED for $receipt"
             exit 1
         }
     done

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,6 @@ install-dev:
 	pip install -r requirements-dev.txt
 	pip install -e .
 
-install-hooks:
-	git config core.hooksPath .githooks
-	@echo "Git hooks installed from .githooks/"
 # === Hooks ===
 install-hooks:
 	git config core.hooksPath .githooks


### PR DESCRIPTION
### Motivation
- Replace an older receipt-only pre-commit script with a unified guard that runs both claim linting and receipt linting in a clearer, more maintainable way.
- Ensure receipt validation remains blocking while making claim lint warnings non-blocking and scoped to relevant file types.

### Description
- Rewrote `.githooks/pre-commit` to run a non-blocking `claim_lint` for staged `.(py|md|yaml|yml|json)` files and a blocking `receipt_lint` for staged receipts. 
- Switched receipt discovery to directory-based selection by checking `receipts` and `data/receipts` for staged files instead of a single glob. 
- Improved CLI messages and exit behavior to clearly indicate non-blocking warnings and blocking failures, and kept `set -euo pipefail` for robust error handling. 
- Changed the shebang and header to standardize the script entry and consolidated previous logic into a single, simpler flow.

### Testing
- Performed a syntax check with `bash -n .githooks/pre-commit`, which completed successfully. 
- Ran `shellcheck` against the updated hook script and fixed issues reported, and the linter run passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1324a48ec8325a7f9425585b3c169)