### PR TITLE
docs(coverage): align documented coverage baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           name: codecov-${{ matrix.python-version }}
         continue-on-error: true
 
-      - name: Check coverage threshold
+      - name: Check minimal overall coverage baseline (50%)
         run: |
           coverage report --fail-under=50
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ Das Framework hat drei Test-Kategorien:
 - **Integration Tests**: `make test-integration` - Komponenten-Zusammenspiel
 - **Ethics Tests**: `make test-ethics` - Fail-Safes und Consent-Management
 
-Alle Tests müssen bestehen und Coverage >= 70% sein.
+Alle Tests müssen bestehen. In CI gilt als minimale Overall-Coverage-Baseline `50%` (`coverage report --fail-under=50`).
+Für JavaScript gelten zusätzlich die Jest-Schwellen: `branches: 50` sowie `functions/lines/statements: 60`.
 
 ## Commit-Konventionen
 


### PR DESCRIPTION
## Problem
The repository described a stricter global coverage target in `CONTRIBUTING.md` than the thresholds actually enforced by CI and Jest.

## Changes
- aligned `CONTRIBUTING.md` with the current enforced coverage policy
- clarified that CI enforces a minimum overall coverage baseline of 50%
- documented the additional Jest thresholds for JavaScript
- renamed the CI step label to reflect the actual 50% overall baseline

## Risk
Low. This is a documentation/clarity change only; the underlying coverage enforcement remains unchanged.

## Checks
- reviewed diff
- CI enforcement logic kept unchanged
- Jest config left unchanged