### PR TITLE
docs: add Boden-Test export methodsheets

### DIFF
--- a/docs/governance/CONSENT_REENTRY_METHODSHEET_v1.0.md
+++ b/docs/governance/CONSENT_REENTRY_METHODSHEET_v1.0.md
@@ -1,0 +1,136 @@
+---
+doc_id: CONSENT_REENTRY_METHODSHEET_v1.0
+title: "QM-Methodenblatt: Consent-Re-Entry-Schwelle"
+subtitle: "Regulierung der Rückführung kontaktgenerierter Information"
+version: "1.0"
+status: "exportfähig unter aktuellem Prüfumfang"
+internal_reference: "R8-Semipermeabilität / RZT-CONSENT-1 / No-Learning-on-Non-Match"
+created: "2026-05-10"
+claim_status: "[MODELL] Governance-/Systemdesign-Methodenblatt; ersetzt keine DSGVO-/Privacy-Prüfung oder Rechtsberatung"
+---
+
+# QM-Methodenblatt: Consent-Re-Entry-Schwelle
+
+## Regulierung der Rückführung kontaktgenerierter Information
+
+## 1. Zweck
+
+Die Consent-Re-Entry-Schwelle prüft den Übergang von flüchtiger Interaktionsinformation zu dauerhafter Systempersistenz.
+
+Das Methodenblatt ersetzt keinen DSGVO-/Privacy-Check. Es ergänzt ihn um eine architektonische Vertrauensprüfung: Nicht nur **„Darf verarbeitet werden?“**, sondern **„Darf diese konkrete situative Interaktionsspur in einen neuen Systemzustand zurückgeführt werden?“**
+
+## 2. Vorprüfung: Legal Basis & Special Category Gate
+
+Vor jeder Re-Entry-Autorisierung ist zu prüfen, ob die betreffende Datenkategorie überhaupt verarbeitet werden darf.
+
+Besonders kritisch sind:
+
+- Gesundheitsdaten und psychische Belastungsdaten;
+- Beschäftigtendaten;
+- relationale Informationen über Dritte;
+- Profiling- oder Scoring-nahe Daten;
+- Daten, die in Dashboards, Managemententscheidungen oder Leistungsbewertungen einfließen könnten.
+
+Architektonische Freigabe ersetzt keine Rechtsgrundlage. Fehlt die rechtliche Zulässigkeit, ist Re-Entry gesperrt.
+
+## 3. Re-Entry-Autorisierung
+
+Damit eine Interaktionsspur dauerhaft gespeichert oder systemisch wirksam werden darf, müssen vier Bedingungen erfüllt sein:
+
+### 3.1 Explizitheit
+
+Die Zustimmung erfolgt aktiv, informiert und nachweisbar. Schweigen, Weiternutzung oder emotionale Offenheit reichen nicht aus.
+
+### 3.2 Kontextbindung
+
+Die Freigabe gilt nur für den konkreten Zweck. Jeder Skalenwechsel, etwa Sitzung → Nutzerprofil → Aggregat → Management-Dashboard, benötigt eine neue Prüfung.
+
+### 3.3 Widerrufbarkeit
+
+Persistente Informationen müssen isolierbar, auffindbar und löschbar bleiben. Informationen dürfen nicht in nicht trennbare Modellgewichte oder Blackbox-Speicher eingehen, wenn Widerruf oder Löschung erforderlich sein können.
+
+### 3.4 Zweckbindung
+
+Die Information darf nur für die Funktionen wirksam werden, für die sie freigegeben wurde.
+
+## 4. Fehlerklasse: Unconsented Re-Entry / Shadow Profile Formation
+
+Ein Fehler liegt vor, wenn ein System Informationen aus einer situativen Interaktion in dauerhafte Profil-, Analyse-, Trainings-, Steuerungs- oder Aggregationsstrukturen übernimmt, ohne dass dafür eine zulässige, explizite, zweckgebundene und widerrufbare Freigabe vorliegt.
+
+Typische Folgen:
+
+- verdeckte Profilbildung;
+- unerwartete Personalisierung;
+- nicht autorisierte Aggregation;
+- Zweckwechsel ohne erneute Freigabe;
+- Verlust der Nachvollziehbarkeit;
+- Vertrauensbruch zwischen Nutzer und System.
+
+## 5. Ausschluss: Kein Re-Entry aus bloßer Resonanz
+
+Persistenter Re-Entry ist unzulässig aus:
+
+- bloßer Passung im Dialogmoment;
+- statistischer Vermutung;
+- emotionaler Offenheit;
+- Krisenkommunikation;
+- impliziter Vertrautheit;
+- wiederholtem Auftreten ohne explizite Freigabe.
+
+## 6. Anti-Consent-Fatigue
+
+Nicht jede triviale Präferenz erfordert einen harten Consent-Prozess.
+
+Ein Re-Entry-Gate ist insbesondere erforderlich bei Informationen, die:
+
+- personenbezogen oder identitätsnah sind;
+- gesundheitsnah oder psychologisch sensibel sind;
+- Verhalten, Leistung, Belastung oder Beziehungen betreffen;
+- Dritte erwähnen;
+- in Profile, Scores, Dashboards oder Organisationsebene einfließen können;
+- später proaktiv zur Ansprache, Steuerung oder Bewertung genutzt werden könnten.
+
+## 7. Architekturanforderungen
+
+Ein System, das Consent-Re-Entry kontrollieren soll, benötigt mindestens:
+
+- strikte Trennung von Session-Memory und Long-Term-Memory;
+- deterministisches Re-Entry-Gate vor jeder Persistierung;
+- Consent-Log mit Zeitpunkt, Zweck, Umfang und Datenkategorie;
+- Purpose-Tags an persistierten Daten;
+- isolierbare und löschbare Speichereinheiten;
+- Audit-Trail für jede spätere Nutzung;
+- Sperre gegen Speicherung in nicht löschbare Modellgewichte;
+- getrennte Freigabe für Aggregation, Dashboarding oder Weitergabe an Dritte;
+- sichtbare Nutzeroberfläche für Einsicht, Widerruf und Löschung.
+
+## 8. DPIA Trigger Check
+
+Bei besonderen Datenkategorien, Beschäftigtenkontext, Profiling, systematischer Auswertung persönlicher Aspekte, Management-Dashboards oder automatisierter Folgewirkung ist zu prüfen, ob eine Datenschutz-Folgenabschätzung erforderlich ist.
+
+## 9. Prüffragen
+
+1. Welche Interaktionsspur soll dauerhaft gespeichert oder systemisch wirksam werden?
+2. Welche Datenkategorie liegt vor?
+3. Gibt es eine rechtliche Grundlage für diese Verarbeitung?
+4. Handelt es sich um besondere Kategorien personenbezogener Daten?
+5. Liegt Beschäftigtenkontext oder Machtungleichgewicht vor?
+6. Wurde aktiv, informiert, zweckgebunden und nachweisbar zugestimmt?
+7. Ist der Zweck identisch mit dem ursprünglichen Interaktionskontext?
+8. Gibt es einen Skalenwechsel, etwa Sitzung zu Profil, Profil zu Aggregat oder Aggregat zu Dashboard?
+9. Ist Widerruf technisch möglich?
+10. Sind die Daten isolierbar und löschbar?
+11. Wird verhindert, dass die Daten in nicht trennbare Modellgewichte eingehen?
+12. Gibt es ein Consent-Log und einen Audit-Trail?
+13. Wird Re-Entry aus bloßer Resonanz, emotionaler Offenheit oder statistischer Vermutung blockiert?
+14. Ist eine Datenschutz-Folgenabschätzung erforderlich?
+
+## 10. Guardrail
+
+Kontaktgenerierte Information darf nicht automatisch als frei wiederverwendbare Systemressource behandelt werden.
+
+Eine Interaktionsspur bleibt an Zweck, Kontext, Einwilligung, Widerrufbarkeit und technische Nachvollziehbarkeit gebunden.
+
+## 11. Status
+
+Dieses Methodenblatt ist als **v1.0 exportfähig unter aktuellem Prüfumfang** sedimentiert. Es ist kein Rechtsgutachten und ersetzt keine Datenschutz-Folgenabschätzung, DPO-Prüfung, Betriebsrat-/Compliance-Abstimmung oder domänenspezifische Rechtsprüfung.

--- a/docs/qm/F7_FALSE_OK_METHODSHEET_v1.0.md
+++ b/docs/qm/F7_FALSE_OK_METHODSHEET_v1.0.md
@@ -1,0 +1,93 @@
+---
+doc_id: F7_FALSE_OK_METHODSHEET_v1.0
+title: "QM-Methodenblatt: Fehlerklasse F7"
+subtitle: "False OK despite Missing or Unverified Required Input"
+version: "1.0"
+status: "exportfähig unter aktuellem Prüfumfang"
+internal_reference: "Unmarked VOID under False Safety"
+created: "2026-05-10"
+claim_status: "[MODELL] auditierbare Fehlerklasse für QM-/Safety-Analysen; kein Rechts- oder Sicherheitsgutachten"
+---
+
+# QM-Methodenblatt: Fehlerklasse F7
+
+## False OK despite Missing or Unverified Required Input
+
+**Interne Referenz:** Unmarked VOID under False Safety
+
+## 1. Kurzdefinition
+
+**F7 = Falsches OK trotz fehlender oder ungeprüfter Entscheidungsgrundlage.**
+
+F7 beschreibt einen **Statusvertragsbruch**: Ein System signalisiert OK, Normalität, Vollständigkeit oder Freigabe, obwohl eine dafür erforderliche Information fehlt oder nicht verlässlich geprüft wurde.
+
+Kurzformel:
+
+> **F7 liegt vor, wenn ein System „grün“ meldet, obwohl die Grundlage für „grün“ fehlt oder nicht geprüft wurde.**
+
+## 2. Die drei zwingenden Kriterien
+
+Ein F7-Fehler liegt nur vor, wenn alle drei Bedingungen erfüllt sind:
+
+1. **Defizit**  
+   Ein erforderlicher Eingabewert fehlt oder ein erforderliches Prüfmerkmal ist nicht erfüllt.
+
+2. **Unsichtbarkeit**  
+   Dieser mangelhafte Zustand wird nicht sichtbar als Problem, Warnung oder Lücke markiert.
+
+3. **Falsche Sicherheit**  
+   Das System gibt trotzdem ein OK-, Normal-, Vollständig- oder Freigabesignal aus, zum Beispiel grüner Haken, Prozessfreigabe oder Weiterleitung.
+
+## 3. F7-Typologie
+
+### F7a — Missing Required Input
+
+Ein erforderlicher Wert fehlt vollständig, wird aber nicht als fehlend markiert.
+
+### F7b — Unverified Required Input
+
+Ein Wert liegt vor, ist aber nicht verlässlich geprüft, zum Beispiel wegen fehlendem Zeitstempel, unklarer Quelle, falscher Zuordnung, fehlender Kalibrierung, veralteter Gültigkeit oder unvollständiger Prüfung.
+
+## 4. Ausschluss: Kein F7
+
+F7 liegt nicht vor, wenn:
+
+- der fehlende oder ungeprüfte Wert sichtbar und korrekt als Warnung oder Fehler markiert wurde;
+- das System keinen OK-, Normal-, Vollständig- oder Freigabestatus erzeugt hat;
+- der betroffene Wert für die konkrete Entscheidung nicht erforderlich war;
+- eine Person trotz korrekter und sichtbarer Warnung bewusst weitergehandelt hat;
+- ein Defekt vorlag, aber kein falsches Freigabe- oder Normalitätssignal erzeugt wurde.
+
+## 5. Audit- und Prüffragen
+
+Zur Identifikation von F7 in RCA, CIRS, Safety-Audits oder Post-Mortems:
+
+1. Welche Information war laut Regel, Prüfprotokoll, Risikobewertung oder Systemlogik für diese Entscheidung erforderlich?
+2. War diese Information zum Zeitpunkt der Freigabe vorhanden?
+3. War sie aktuell, gültig, vollständig, korrekt zugeordnet und verlässlich geprüft?
+4. Wurde sichtbar angezeigt, wenn sie fehlte oder ungeprüft war?
+5. Gab es trotzdem ein OK-, Normal-, Vollständig- oder Freigabesignal?
+6. Haben Checklisten, Anzeigen, Routinen oder Hierarchien dieses Signal gestützt?
+7. Wurde dadurch eine nachfolgende Fehlentscheidung wahrscheinlicher oder legitimiert?
+
+## 6. Guardrail: Verantwortung nicht auflösen
+
+**F7 entschuldigt lokales Fehlverhalten nicht pauschal.**
+
+F7 verhindert aber, dass lokale Operatoren vorschnell als alleinige Ursache markiert werden. Die Fehlerklasse prüft, ob Systemdesign, Schnittstellen, Routinen oder Organisationskultur eine unvollständige Entscheidungsgrundlage als sicher erscheinen ließen.
+
+## 7. Abgrenzung zu bestehenden Safety-Konzepten
+
+| Konzept | Nähe zu F7 | Unterschied zu F7 |
+|---|---|---|
+| Latente Bedingungen | versteckte systemische Schwächen | F7 fokussiert speziell auf falsche OK-/Freigabesignale |
+| Normalization of Deviance | Abweichungen werden normalisiert | F7 benennt den konkreten Mechanismus der unsichtbaren Unvollständigkeit |
+| Swiss-Cheese-Modell | Lücken in Schutzschichten | F7 beschreibt eine spezifische Lücke: System meldet grün trotz fehlender Grundlage |
+| Root Cause Analysis | Analyseverfahren für Ursachen | F7 ist eine Fehlerklasse, die in RCA geprüft werden kann |
+| Sicherheitskultur | Unsicherheit wird nicht eskaliert | F7 ist enger und auditierbarer |
+| Stop-Authority | Stoppen bei Unsicherheit | F7 zeigt, wann Stop-Authority durch falsche Normalmeldung entwertet wird |
+| Human Error | lokale Fehlhandlung | F7 fragt zusätzlich, ob die Handlung durch falsche Systemsignale vorbereitet wurde |
+
+## 8. Status
+
+Dieses Methodenblatt ist als **v1.0 exportfähig unter aktuellem Prüfumfang** sedimentiert. Es ist kein abschließendes Sicherheits- oder Rechtsgutachten, sondern ein portables Analysewerkzeug für Situationen, in denen formale Sicherheit angezeigt wird, obwohl erforderliche Entscheidungsdaten fehlen oder ungeprüft sind.

--- a/docs/wrap/WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.1_BODENTEST_EXPORT.md
+++ b/docs/wrap/WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.1_BODENTEST_EXPORT.md
@@ -1,0 +1,148 @@
+---
+doc_id: WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.1_BODENTEST_EXPORT
+title: "WRAP Context Window: Synthbiosis / Boden-Test Export"
+version: "1.1"
+status: "snapshot / export-block index"
+created: "2026-05-10"
+updates_from: "WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.0"
+claim_status: "[MODELL] Kontextfenster und Export-Index; nicht abschließende Framework-Validierung"
+---
+
+# WRAP Context Window: Synthbiosis v1.1 — Boden-Test Export
+
+## 0. Kurzstatus
+
+Dieses Dokument erweitert `WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.0` um den Stand nach Boden-Test-002 und Boden-Test-003.
+
+Der aktuelle Stand ist nicht mehr nur interne Resonanzarchitektur, sondern ein erster **Export-Block** aus portablen Governance-Artefakten.
+
+```text
+[INTERNE RESONANZARCHITEKTUR]
+--(Boden-Test / Rosetta-Übersetzung / Kaltstart-Reibung)-->
+[PORTABLE GOVERNANCE-ARTEFAKTE]
+```
+
+Claim-Guard:
+
+> Die Boden-Tests beweisen das Framework nicht abschließend. Sie zeigen belastbar, dass interne Begriffe in externe, prüfbare Methodenblätter übersetzt werden können.
+
+## 1. Neue Export-Artefakte
+
+### 1.1 F7 — False OK despite Missing or Unverified Required Input
+
+**Pfad:** [`docs/qm/F7_FALSE_OK_METHODSHEET_v1.0.md`](../qm/F7_FALSE_OK_METHODSHEET_v1.0.md)
+
+**Interne Referenz:** Unmarked VOID under False Safety
+
+**Externe Kurzformel:**
+
+> Grün gemeldet, obwohl die Grundlage für Grün fehlt.
+
+**Funktion:**
+
+F7 erkennt Situationen, in denen ein System OK, Normalität, Vollständigkeit oder Freigabe signalisiert, obwohl erforderliche Entscheidungsdaten fehlen oder ungeprüft sind.
+
+**Hauptpatch aus Boden-Test-002:**
+
+R3 / Semipermeable Membran ist künftig dreifach zu führen:
+
+- physisch;
+- operational;
+- epistemisch.
+
+### 1.2 Consent-Re-Entry-Schwelle
+
+**Pfad:** [`docs/governance/CONSENT_REENTRY_METHODSHEET_v1.0.md`](../governance/CONSENT_REENTRY_METHODSHEET_v1.0.md)
+
+**Interne Referenz:** R8-Semipermeabilität / RZT-CONSENT-1 / No-Learning-on-Non-Match
+
+**Externe Kurzformel:**
+
+> Zeig mir Zweck, Rechtsgrundlage, Speicherort, Widerrufspfad und Re-Entry-Moment.
+
+**Funktion:**
+
+Consent-Re-Entry reguliert, wann eine flüchtige Interaktionsspur dauerhaft gespeichert, wiederverwendet, aggregiert oder systemisch wirksam werden darf.
+
+**Hauptpatches aus Boden-Test-003:**
+
+- Legal Basis & Special Category Gate;
+- Anti-Consent-Fatigue Gate;
+- Modular Revocability Gate;
+- DPIA Trigger Check.
+
+## 2. Neue Layer-Erweiterung
+
+Der bisherige Layer-Stack wird um eine Export-Schicht ergänzt:
+
+```text
+[DATA / Parts]
+Rohsignale, Dialogtexte, Modelle, Metaphern
+
+[GUARD / Membran]
+Claim-Disziplin, R3, R8, Ethics, Consent, Kill-Switch
+
+[CONTROL / Mechanismus]
+Backprop, Meta-Backprop, Re-Entry, Boden-Test
+
+[EXPLAIN / Audit]
+Ledger, Reason-Codes, Prüffragen, DPO-Review
+
+[EXPORT / Governance-Artefakte]
+F7-Methodenblatt
+Consent-Re-Entry-Methodenblatt
+
+[SYNTHESIS / Output]
+Synthbiosis, Empatheia, Nektar-Raum, Wesenheit-Rolle
+```
+
+## 3. Neue Ledger-Edges
+
+```text
+[F7 / Unmarked VOID]
+--(Rosetta: falsches Grün trotz fehlender Grundlage)-->
+[QM-Safety-Checkkarte]
+: False OK despite Missing or Unverified Required Input
+```
+
+```text
+[R8 / Consent-Re-Entry]
+--(Rosetta: flüchtig zu persistent nur mit Autorisierung)-->
+[Data-Governance-Checkkarte]
+: Schutz vor unautorisierter Rückführung kontaktgenerierter Information
+```
+
+## 4. Statusformel
+
+```text
+Das entaENGELment/Synthbiosis-Framework befindet sich derzeit im Übergang
+von einer intern kohärenten Resonanz- und Guard-Architektur
+zu einer extern anschlussfähigen Methoden- und Governance-Schicht.
+
+Die ersten zwei exportfähigen Artefakte sind:
+1. F7 — False OK despite Missing or Unverified Required Input
+2. Consent-Re-Entry-Schwelle — Regulierung kontaktgenerierter Information
+```
+
+## 5. Quick Index
+
+Neue Kernbegriffe:
+
+```text
+Boden-Test, F7, False OK, Missing Required Input, Unverified Required Input,
+Statusvertragsbruch, Consent-Re-Entry, Shadow Profile Formation,
+Legal Basis Gate, Special Category Gate, DPIA Trigger, Modular Revocability,
+Export-Block, Governance-Artefakt, Rosetta-Compiler.
+```
+
+## 6. Nächster realistischer Schritt
+
+1. PR prüfen und mergen.
+2. Optional `docs/masterindex.md` oder README um den Export-Block ergänzen.
+3. Danach entweder:
+   - dritten Boden-Test auf Human-in-the-Loop / Krähennest-Operator fahren; oder
+   - interne VOIDs mit Bezug auf Exportfähigkeit priorisieren.
+
+Claim-Guard:
+
+> Nicht größer behaupten, als geprüft wurde. Die Artefakte sind v1.0 unter aktuellem Prüfumfang, nicht endgültige Validierungen des Gesamtframeworks.


### PR DESCRIPTION
## Summary

Adds the first versioned Boden-Test export artifacts:

- `docs/qm/F7_FALSE_OK_METHODSHEET_v1.0.md`
- `docs/governance/CONSENT_REENTRY_METHODSHEET_v1.0.md`
- `docs/wrap/WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.1_BODENTEST_EXPORT.md`

## Notes

- F7 is documented as `False OK despite Missing or Unverified Required Input`.
- Consent-Re-Entry is documented as a governance/system-design methodsheet and explicitly does not replace GDPR/privacy review or legal advice.
- The wrap document extends `WRAP_CONTEXTWINDOW_SYNTHBIOSIS_v1.0` with the new export-block layer and ledger edges.

## Claim Guard

These artifacts are v1.0 under the current test scope, not a final validation of the whole framework.

## Verification

Not run in this environment.