### PR TITLE
ci(deepjump): handle missing HMAC secret on dependency PRs

### DIFF
--- a/.github/workflows/deepjump-audit.reusable.yml
+++ b/.github/workflows/deepjump-audit.reusable.yml
@@ -9,7 +9,7 @@ on:
         default: "3.11"
     secrets:
       ENTA_HMAC_SECRET:
-        required: true
+        required: false
 
 jobs:
   deepjump-audit:
@@ -37,6 +37,17 @@ jobs:
             echo "::add-mask::$ENTA_HMAC_SECRET"
           fi
 
+      - name: Check HMAC secret availability
+        id: hmac
+        shell: bash
+        run: |
+          if [ -n "${ENTA_HMAC_SECRET:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=DeepJump HMAC skipped::ENTA_HMAC_SECRET unavailable for this run; skipping signed status emit/verify."
+          fi
+
       - name: "Phase 1: Verify Pointers"
         run: python3 tools/verify_pointers.py --strict
 
@@ -50,7 +61,23 @@ jobs:
         run: pytest tests/ -v --tb=short
 
       - name: "Phase 2: Emit & Verify Status"
+        if: ${{ steps.hmac.outputs.available == 'true' }}
         run: make status-verify STATUS=PASS H=0.85 DMI=4.8 PHI=0.75
+
+      - name: "Phase 2: Record unsigned status skip"
+        if: ${{ steps.hmac.outputs.available != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p out/status out/badges
+          cat > out/status/deepjump_status_skipped.json <<'JSON'
+          {
+            "status": "SKIPPED",
+            "reason": "ENTA_HMAC_SECRET unavailable; signed status emit/verify skipped for this run.",
+            "signature_type": "hmac-sha256",
+            "signed": false
+          }
+          JSON
+          printf '%s\n' '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="20"><rect width="120" height="20" fill="#555"/><rect x="70" width="50" height="20" fill="#dfb317"/><g fill="#fff" text-anchor="middle" font-family="Verdana" font-size="11"><text x="35" y="14">DeepJump</text><text x="95" y="14">SKIP</text></g></svg>' > out/badges/deepjump.svg
 
       - name: "Phase 3: Generate Snapshot Manifest"
         run: make snapshot SNAPSHOT_INPUTS='"seeds/*.yaml" "audit/*.yaml" "index/*.yaml"'
@@ -65,6 +92,7 @@ jobs:
           name: deepjump-audit-trail
           path: |
             out/status/deepjump_status.json
+            out/status/deepjump_status_skipped.json
             out/badges/deepjump.svg
             out/verify.json
             out/snapshot_manifest.json

--- a/.github/workflows/deepjump-audit.reusable.yml
+++ b/.github/workflows/deepjump-audit.reusable.yml
@@ -7,6 +7,10 @@ on:
         required: false
         type: string
         default: "3.11"
+      allow-unsigned-status-skip:
+        required: false
+        type: boolean
+        default: false
     secrets:
       ENTA_HMAC_SECRET:
         required: false
@@ -37,15 +41,22 @@ jobs:
             echo "::add-mask::$ENTA_HMAC_SECRET"
           fi
 
-      - name: Check HMAC secret availability
+      - name: Check HMAC availability
         id: hmac
         shell: bash
         run: |
           if [ -n "${ENTA_HMAC_SECRET:-}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "skip_allowed=false" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.allow-unsigned-status-skip }}" = "true" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "skip_allowed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=DeepJump HMAC skipped::HMAC signing key unavailable in dependency/fork PR context."
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice title=DeepJump HMAC skipped::ENTA_HMAC_SECRET unavailable for this run; skipping signed status emit/verify."
+            echo "skip_allowed=false" >> "$GITHUB_OUTPUT"
+            echo "::error title=DeepJump HMAC missing::HMAC signing key is required for trusted audit runs."
+            false
           fi
 
       - name: "Phase 1: Verify Pointers"
@@ -65,14 +76,14 @@ jobs:
         run: make status-verify STATUS=PASS H=0.85 DMI=4.8 PHI=0.75
 
       - name: "Phase 2: Record unsigned status skip"
-        if: ${{ steps.hmac.outputs.available != 'true' }}
+        if: ${{ steps.hmac.outputs.skip_allowed == 'true' }}
         shell: bash
         run: |
           mkdir -p out/status out/badges
           cat > out/status/deepjump_status_skipped.json <<'JSON'
           {
             "status": "SKIPPED",
-            "reason": "ENTA_HMAC_SECRET unavailable; signed status emit/verify skipped for this run.",
+            "reason": "HMAC signing key unavailable in dependency/fork PR context; signed status emit/verify skipped.",
             "signature_type": "hmac-sha256",
             "signed": false
           }

--- a/.github/workflows/deepjump-ci.yml
+++ b/.github/workflows/deepjump-ci.yml
@@ -47,3 +47,4 @@ jobs:
     secrets: inherit
     with:
       python-version: "3.11"
+      allow-unsigned-status-skip: ${{ github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository) }}


### PR DESCRIPTION
## Summary

Adds a semipermeable guard for DeepJump audit runs where `ENTA_HMAC_SECRET` is unavailable, especially dependency bot PR contexts.

## Why

The reusable DeepJump workflow required `ENTA_HMAC_SECRET`. On dependency PRs, the normal blocking lint/test stages can pass, but the nested `deepjump-audit` job fails before useful logs are available because signed status emit/verify requires the secret.

## Change

- Make `ENTA_HMAC_SECRET` optional at the reusable workflow boundary.
- Detect secret availability explicitly.
- Keep signed `make status-verify` required when the secret exists.
- When the secret is unavailable, write a clear skipped-status artifact instead of producing a false red audit failure.
- Preserve pointer lint, receipt lint, claim lint, tests, snapshot, and legacy receipt verification.

## Guardrail

This does **not** permit unsigned signed-status verification. It only marks the signed-status phase as skipped when the secret is unavailable, while all non-secret DeepJump checks still run.