### PR TITLE
ci: replace deprecated safety stdin scan with pip-audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install bandit safety
+          pip install bandit pip-audit
 
       - name: Run bandit security linter
         run: |
@@ -128,7 +128,7 @@ jobs:
 
       - name: Check dependencies for vulnerabilities
         run: |
-          pip freeze | safety check --stdin --json
+          pip-audit -r requirements.txt
 
   # Stage 4: Gate Policy Validation
   gate-policy:


### PR DESCRIPTION
## Summary

Fixes #171.

Replaces the deprecated CI dependency scan:

```bash
pip freeze | safety check --stdin --json
```

with:

```bash
pip-audit -r requirements.txt
```

## Scope

Changed only:
- `.github/workflows/ci.yml`

Intentional guardrails:
- no `requirements-dev.txt` upgrade
- no `black>=26.3.1` from #157
- no UI changes
- no VOIDMAP/CHANGELOG/Release changes

## Rationale

#157 identified the deprecated `safety check --stdin` path but mixed the fix with unrelated changes. This PR extracts only the CI security-scan change.

## Validation expectation

CI should verify that the security stage installs `bandit pip-audit` and runs `pip-audit -r requirements.txt`.