### PR TITLE
docs: document SUSPENDED VOIDMAP status

### DIFF
--- a/VOIDMAP.yml
+++ b/VOIDMAP.yml
@@ -4,7 +4,7 @@
 # This file tracks open gaps (VOIDs) in the entaENGELment framework.
 # Each VOID represents a known gap that needs to be addressed.
 #
-# Status: OPEN | IN_PROGRESS | CLOSED
+# Status: OPEN | IN_PROGRESS | CLOSED | SUSPENDED
 # Priority: critical | high | medium | low
 # Domain tags: [BIO], [MATH], [PHYS], [CHEM], [COMP], [META], [DEV]
 


### PR DESCRIPTION
## Summary

Partially fixes #173.

Documents `SUSPENDED` as an allowed VOIDMAP status because `VOID-014` already uses it.

## Scope

Changed only:
- `VOIDMAP.yml`

Intentional guardrails:
- no `last_updated` change without broader VOIDMAP content update
- no CHANGELOG or RC preflight claims
- no CI/workflow changes
- no dependency/UI changes

## Rationale

#157 identified that `VOID-014` uses `SUSPENDED` while the VOIDMAP header only listed `OPEN | IN_PROGRESS | CLOSED`. This PR extracts only that minimal documentation correction.