### PR TITLE
ci: make UI build install reproducible with npm ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install UI dependencies
         working-directory: ui-app
-        run: npm install
+        run: npm ci
 
       - name: Build UI
         working-directory: ui-app


### PR DESCRIPTION
## Summary

Fixes #172.

Makes the existing `ui-build` workflow reproducible by replacing `npm install` with `npm ci` in `ui-app`.

## Scope

Changed only:
- `.github/workflows/test.yml`

Intentional guardrails:
- no dependency upgrades
- no `ui-app/package.json` changes
- no `ui-app/package-lock.json` changes
- no #155 changes
- no audit/VOIDMAP/release-doc changes

## Rationale

`test.yml` already contains a UI Build job and no longer contains stale `master`/`develop` triggers. The remaining safe improvement from #172 is to use the lockfile-backed install path.

## Validation expectation

The `UI Build` job should run:

```bash
cd ui-app
npm ci
npm run build
```

If `npm ci` fails, that indicates package-lock drift and should be fixed separately, not hidden by `npm install`.