### PR TITLE
feat(frame): introduce Frame Operator lint v0.1.1

### DIFF
--- a/docs/decisions/ANNEX_A1_1_FORWARD_RESONANCE_QM_QFT_001.md
+++ b/docs/decisions/ANNEX_A1_1_FORWARD_RESONANCE_QM_QFT_001.md
@@ -1,0 +1,148 @@
+# ANNEX A1.1 Forward Resonance Note — QM/QFT
+
+ID: `A1.1-FRN-QM-QFT-001`  
+Status: `nektar_hold`  
+Claim status: `HYPOTHESE`  
+Placement: Annex A1.1, Section 3 — Traversal Grammar Placement, footnote/side-note only
+
+> Operatorverwandtschaft ja. Identität nein.
+
+## 0. Scope
+
+This note records a forward resonance between the Brackwasser/Mündung motif and quantum-mechanical or quantum-field-theoretic transition language. It is not part of the A1.1 main proof path, not a motif test, not a physics claim, and not a canonical VOIDMAP registration.
+
+A1.1 remains narrow:
+
+```yaml
+A1_1_main_question:
+  focus: Brackwasser vs. Mündung
+  not_focus:
+    - Brackwasser/QM/QFT/Gesamtphysik
+    - proof_by_physics
+    - identity_claim_between_media
+```
+
+## 1. Forward resonance note
+
+```yaml
+forward_resonance_note:
+  id: A1.1-FRN-QM-QFT-001
+  status: nektar_hold
+  claim_status: HYPOTHESE
+  placement: "Annex A1.1, Section 3 — Traversal Grammar Placement, footnote/side-note only"
+  observation: >
+    Brackwasser/Mündung zeigt eine mögliche Operatorverwandtschaft
+    zu quantenmechanischen und quantenfeldtheoretischen Übergangsformen:
+    Superposition, Pfadintegral, Komplementarität und Dekohärenz/Messung.
+  guard:
+    medium_translation: active
+    no_identity_claim: true
+    no_physics_proof: true
+```
+
+## 2. Mapping precision
+
+```yaml
+mapping_precision:
+  brackwasser:
+    operator: gehaltene Koexistenz ohne sofortige Entscheidung
+    qm_qft_near_reading:
+      - kohärente Möglichkeitsschichtung
+      - phasenhaltige Koexistenz
+      - pre-decisive transition field
+
+  muendung:
+    operator: gerichteter Übergang mit irreversibler oder schwer reversibler Spur
+    qm_qft_near_reading:
+      - gerichtete Spurwerdung
+      - loss_of_observable_coherence_as_image
+      - transition_into_classically_readable_trace
+
+  path_integral:
+    cautious_reading: >
+      Mehrere mögliche Wege tragen formal als Amplitudenbeiträge
+      zur Übergangswahrscheinlichkeit bei, mit Gewichtung und Phase.
+    avoid: >
+      Nicht schreiben: alle Wege koexistieren gleichzeitig.
+
+  superposition:
+    cautious_reading: >
+      Mehrere Zustandsanteile bleiben kohärent,
+      solange keine dekohärente Festlegung dominiert.
+
+  complementarity:
+    cautious_reading: >
+      Verschiedene Beschreibungsmodi bleiben gültig,
+      aber nicht gleichzeitig im selben klassischen Bild totalisierbar.
+
+  decoherence_measurement:
+    cautious_reading: >
+      Dekohärenz ist hier ein Mündungsbild,
+      weil aus kohärenter Schichtung eine stabile Spur
+      oder klassisch lesbare Struktur wird.
+    guard: >
+      Dekohärenz ist nicht automatisch Kollaps im starken Sinn;
+      sie beschreibt zunächst den Verlust beobachtbarer Kohärenz
+      durch Kopplung an Umgebung/Freiheitsgrade.
+```
+
+## 3. Densest formulation
+
+> Brackwasser ist phasenhaltige Koexistenz; Mündung ist gerichtete, spurtragende Lesbarkeit.
+
+Or:
+
+> Brackwasser verhält sich zu Mündung wie kohärente Möglichkeitsschichtung zu gerichteter Spurwerdung — als Traversierungsähnlichkeit, nicht als Medienidentität.
+
+## 4. VOID status
+
+No canonical VOID ID is registered by this note. The bridge remains a candidate until VOIDMAP explicitly accepts it.
+
+```yaml
+void_link:
+  status: candidate
+  proposed_title: "Scale-Invariance Bridge: Brackwasser/Mündung ↔ Superposition/Dekohärenz"
+  proposed_priority: P2
+  touches_existing:
+    - VOID-011 # if measurement grammar / resonance metrics are affected
+    - VOID-010 # if taxonomy / spectra / physical assignment are affected
+  registry_action: "VOIDMAP entry required before canonical ID"
+```
+
+## 5. Linter hooks
+
+```yaml
+LINT_FORWARD_RESONANCE_QM_QFT_001:
+  fail_if:
+    - Brackwasser is claimed to be quantum superposition
+    - Mündung is claimed to be physical measurement or collapse
+    - path integral is described as literal simultaneous coexistence of all paths
+    - decoherence is treated as identical to strong collapse
+    - physics is used to prove the motif
+    - motif resonance is used to prove physics
+    - note is promoted from nektar_hold to canonical claim without VOIDMAP registration
+
+  warn_if:
+    - analogy language becomes ontological language
+    - medium translation strengthens claim status
+    - QM/QFT language displaces the Brackwasser-vs-Mündung main question
+    - the side-note starts behaving like a test protocol
+```
+
+## 6. A1.1 decision
+
+```yaml
+A1_1_decision:
+  include_in_main_flow: false
+  include_as_side_note: true
+  note_role: forward_resonance_for_later_SCALE_INVARIANT_BRIDGE
+  current_state: nektar_hold
+  next_allowed_action: >
+    Only register in VOIDMAP after explicit registry action.
+```
+
+## 7. Commit summary
+
+This note preserves the QM/QFT resonance without crowning it. It keeps the Brackwasser/Mündung motif narrow, protects the medium-translation boundary, and stores the possible operator bridge in `nektar_hold` until VOIDMAP registration is explicitly requested.
+
+> Die Intuition wird nicht verloren, aber auch nicht gekrönt.

--- a/docs/decisions/DEC-VOID-016-NAMESPACE.yml
+++ b/docs/decisions/DEC-VOID-016-NAMESPACE.yml
@@ -1,0 +1,60 @@
+# DEC-VOID-016-NAMESPACE — Frame Operator Namespace Decision
+
+id: DEC-VOID-016-NAMESPACE
+title: "Separate legacy VOID-016 τ-Kernel from GitHub Frame Operator namespace"
+status: ACCEPTED
+created: "2026-05-15"
+decision_owner: Fleks
+
+---
+
+## context
+
+Legacy Drive specifications used `VOID-016` for the τ-Kernel / process-retention
+without time archive. The Frame Operator workstream introduced a new operator that
+makes the operative frame of a claim explicit before inference/hypothesis logging.
+
+Using `VOID-016` for both meanings in GitHub would create an ambiguous ledger key.
+
+---
+
+## decision
+
+- `VOID-016` remains a legacy identifier for the τ-Kernel in historical Drive context.
+- The GitHub repository instantiates the new Frame Operator as:
+
+```yaml
+void_id: VOID-FRAME-OPERATOR-001
+```
+
+- All new implementation artifacts use `VOID-FRAME-OPERATOR-001`.
+- Any migration note may reference legacy VOID-016, but must not reuse it as a
+  current GitHub VOID id for the Frame Operator.
+
+---
+
+## implementation artifacts
+
+- `policies/frame_taxonomy_v0_1_1.yml`
+- `tools/frame_lint.py`
+- `tests/unit/test_frame_lint.py`
+
+---
+
+## closure conditions
+
+VOID-FRAME-OPERATOR-001 may close when:
+
+1. taxonomy file exists and is lint-readable;
+2. frame_lint implements declaration and content baseline checks;
+3. unit tests cover VALID, MISSING_FRAME, WRONG_TAXONOMY, MET_ALIAS,
+   TRIGGER_WARN, CUSTOM_VALID, CUSTOM_MISSING_REQUIRED;
+4. at least one GOV_AUDIT claim/receipt passes frame lint;
+5. deferred content-aware parsing remains tracked as `VOID-FRAME-CONTENT-PARSE-001`.
+
+---
+
+## related
+
+- `VOID-FRAME-CONTENT-PARSE-001`
+- `VOID-FRAME-BRIDGE-RULES-001`

--- a/docs/decisions/TRAVERSAL_GRAMMAR_v0_1.md
+++ b/docs/decisions/TRAVERSAL_GRAMMAR_v0_1.md
@@ -1,0 +1,350 @@
+# TRAVERSAL_GRAMMAR v0.1
+
+Status: canonical decision record for v0.1.2-pre  
+Branch target: `codex/frame-operator-v0-1-1`  
+Scope: traversal grammar, receipt boundary, A0 scope guard, and open VOIDMAP bridge notes
+
+> Keine Frame-Taxonomie ohne Bewegungsrichtung.
+
+## 0. Purpose
+
+This decision record defines the movement grammar between the emerging v0.1.2 frames. It does not introduce empirical claims, new motifs, or direct test obligations. Its function is to define how a signal may enter, traverse, pause, or exit the frame system without collapsing pre-threshold material into premature claims.
+
+The document protects four distinctions:
+
+1. Signal forms are not holding states.
+2. Traversal is not claim creation.
+3. Bridge candidates are not registered as proven equivalences.
+4. A0 prepares Annex A1 but does not perform motif testing.
+
+## 1. Canonical frame stack
+
+```yaml
+frames_v0_1_2_pre:
+  - WELLE_BIJEKT
+  - SCHWELLENFLIMMERN
+  - SEMIOTIC_RECEPTION
+  - SYMBOL_NICHTRAUM
+  - HERMENEUTIC_MEMBRANE
+  - Reentry
+```
+
+### 1.1 WELLE_BIJEKT
+
+`WELLE_BIJEKT` is the mathematical/physical-facing frame for the transition from continuous potential or wave structure toward discrete, addressable object structure.
+
+```yaml
+WELLE_BIJEKT:
+  domain: mathematical_physical
+  claim_scope: formal_or_model_based
+  role: potential_to_object_transition
+  guard: >
+    This frame must not be collapsed into SCHWELLENFLIMMERN.
+```
+
+### 1.2 SCHWELLENFLIMMERN
+
+`SCHWELLENFLIMMERN` is the phenomenological/cognitive pre-threshold frame. It marks modulation of the meaning threshold before a sign, thought, object, or claim is stable.
+
+```yaml
+SCHWELLENFLIMMERN:
+  aka: PRE_THRESHOLD_SIGNAL
+  domain: phenomenological_cognitive
+  role: threshold_modulation
+  signal_forms:
+    backward:
+      - lasso_attraktor
+    forward:
+      - kraehennest_schaltmoment
+  guard: >
+    It marks readiness, pull, shimmer, warning, or threshold modulation;
+    it is not yet receipt, claim, proof, or finished sign.
+```
+
+### 1.3 SEMIOTIC_RECEPTION
+
+`SEMIOTIC_RECEPTION` starts only when a sign, symbol, word, gesture, or minimal externalized statement can be received as such.
+
+```yaml
+SEMIOTIC_RECEPTION:
+  domain: semiotic_operational
+  role: sign_receipt
+  requires:
+    - minimal_externalized_statement_or_marker
+    - readable_context
+    - claim_status_or_nonclaim_status_marked
+```
+
+### 1.4 SYMBOL_NICHTRAUM
+
+`SYMBOL_NICHTRAUM` is the protected semantic void of a symbol: meaning is present as potential, but not yet forced into explicit sign, object, or claim form.
+
+```yaml
+SYMBOL_NICHTRAUM:
+  domain: protective_semantic_void
+  role: preserve_latent_meaning
+  protects:
+    - non_externalized_potential
+    - ambiguity_without_arbitrariness
+    - pre_reentry_symbolic_resonance
+```
+
+### 1.5 HERMENEUTIC_MEMBRANE
+
+`HERMENEUTIC_MEMBRANE` defines interpretation as controlled traversal of a symbol's Nicht-Raum through context, prior understanding, language history, resonance, and Reentry.
+
+```yaml
+HERMENEUTIC_MEMBRANE:
+  domain: interpretation_traversal_operator
+  role: controlled_symbol_traversal
+  protects_against:
+    - premature_translation
+    - motif_overclaiming
+    - arbitrary_resonance_without_reentry
+```
+
+## 2. Receipt boundary
+
+The receipt boundary separates pre-receipt signals from holding states and from receipt-ready material. Signal forms can activate traversal, but they are not holding states. Holding states can preserve pre-receipt material, but they are not themselves signal forms.
+
+```yaml
+receipt_boundary:
+  signal_forms_pre_receipt:
+    - schwellenflimmern
+    - lasso_attraktor
+  holding_states_pre_receipt:
+    - nektar_hold
+  receipt_ready:
+    - externalisierte minimale Aussage
+    - Reentry erfolgt
+    - Claim-Status markiert
+```
+
+### 2.1 Interpretation
+
+- `schwellenflimmern` names a threshold modulation.
+- `lasso_attraktor` names a backward pull signal marking possible latent value.
+- `nektar_hold` names a protected holding state in which material may remain effective without being forced into receipt or claim space.
+
+## 3. A0 scope
+
+A0 is a traversal-definition layer. It is not a motif-test layer and does not create new claims. A0 may prepare Annex A1, where later motif tests or stronger formalizations may be considered under explicit scope.
+
+```yaml
+a0_scope:
+  tests_motifs: false
+  defines_traversal: true
+  creates_new_claims: false
+  prepares_annex_a1: true
+  violation_signal: >
+    Wenn A0 einen neuen Claim, ein neues Motiv oder
+    ein neues Frame produziert, ist es kein A0 mehr.
+```
+
+### 3.1 A0 allowed work
+
+```yaml
+a0_allowed:
+  - define traversal direction
+  - define entry and exit conditions
+  - separate signal forms from holding states
+  - mark claim status boundaries
+  - prepare but not execute Annex A1 work
+```
+
+### 3.2 A0 forbidden work
+
+```yaml
+a0_forbidden:
+  - create new motif claims
+  - validate motif tests
+  - register scale invariance as proven
+  - treat metaphor as evidence
+  - treat κ as a literal cognitive measurement value
+```
+
+## 4. Nektar hold
+
+`nektar_hold` is a pre-receipt holding state. It preserves material that is not ready for externalization, receipt, or claim status, while keeping it available for later traversal.
+
+```yaml
+nektar_hold:
+  type: protected_pre_receipt_holding_state
+  function: >
+    Material bleibt wirksam, aber nicht receipt-ready.
+    Es darf gehalten, gereift und später erneut traversiert werden.
+  not_equivalent_to:
+    - schwellenflimmern
+    - lasso_attraktor
+    - semiotic_reception
+    - claim_space
+  exit_paths:
+    - renewed_schwellenflimmern
+    - minimal_externalization
+    - reentry_attempt
+    - explicit_drop
+```
+
+## 5. Traversal sequence
+
+This is the central movement grammar. Without an entry signal, there is no traversal. Without Reentry, there is no stable claim-space exit.
+
+```yaml
+traversal_sequence:
+  entry_condition: >
+    Ein Signal aus SCHWELLENFLIMMERN (backward: Lasso-Attraktor
+    oder forward: Krähennest-Schaltmoment) aktiviert die Traversierung.
+    Ohne Einstiegssignal beginnt keine Bewegung durch die Frames.
+  sequence:
+    - WELLE_BIJEKT
+    - SCHWELLENFLIMMERN
+    - SEMIOTIC_RECEPTION
+    - SYMBOL_NICHTRAUM
+    - HERMENEUTIC_MEMBRANE
+    - Reentry
+  exit_condition: >
+    Reentry prüft Stabilität. Was nicht reentry-stabil ist,
+    kehrt in nektar_hold zurück, nicht in den Claim-Raum.
+```
+
+### 5.1 Movement notes
+
+1. `WELLE_BIJEKT` marks the potential-to-object problem at formal scale.
+2. `SCHWELLENFLIMMERN` marks threshold modulation at phenomenological scale.
+3. `SEMIOTIC_RECEPTION` starts only when a minimal sign can be received.
+4. `SYMBOL_NICHTRAUM` protects what the sign does not yet exhaust.
+5. `HERMENEUTIC_MEMBRANE` traverses the protected symbolic void without premature collapse.
+6. `Reentry` decides whether the result may stabilize or must return to `nektar_hold`.
+
+## 6. Scale-invariant bridge candidate
+
+The possible connection between `WELLE_BIJEKT` and `SCHWELLENFLIMMERN` is not a claim of identity. It is an open bridge candidate.
+
+```yaml
+scale_invariant_bridges:
+  WELLE_OBJEKT_TRANSITION:
+    claim_status: HYPOTHESE
+    bridge_type: SCALE_INVARIANT_OPERATOR_CANDIDATE
+    linked_void: VOID-SCALE-INVARIANCE-001
+
+    core_operator: >
+      Übergang von kontinuierlicher Potenzial-/Wellenstruktur
+      zu diskreter, adressierbarer, zeichen- oder objektförmiger Struktur.
+
+    instances:
+      - frame: WELLE_BIJEKT
+        scale: mathematical_physical
+        marker:
+          - continuous symmetry -> discrete structure
+          - O(2)->D6, sofern im Branch formal definiert
+          - κ = λ/ξ als Schwellen-/Kontrollparameter
+        risk:
+          - physikalische Spezifität wird zu stark verallgemeinert
+
+      - frame: SCHWELLENFLIMMERN
+        scale: phenomenological_cognitive
+        marker:
+          - pre-threshold modulation
+          - Erregbarkeit vor Bedeutung
+          - Matrose/Intuition split
+          - Windlesen statt Zeichenfixierung
+        risk:
+          - phänomenologische Erfahrung wird zu früh formalisiert
+
+    allowed_inference:
+      - gemeinsame Traversierungsgrammatik untersuchen
+      - Übergangssignaturen vergleichen
+      - Schwellen-, Taktungs- und Diskretisierungslogik nebeneinander modellieren
+
+    forbidden_inference:
+      - Physik beweist die Phänomenologie
+      - Phänomenologie beweist die Physik
+      - κ wird wörtlich als kognitiver Messwert gelesen
+
+    closure_condition: >
+      Der Bridge-Status darf erst von Hypothese zu stärkerem Claim wechseln,
+      wenn auf beiden Skalen eine vergleichbare formale Übergangssignatur
+      reproduzierbar gezeigt wird — nicht bloß ein ähnliches Bild.
+```
+
+Protection sentence:
+
+> Die Brücke wird geführt, aber nicht geschlossen.
+
+## 7. Medium translation guard
+
+Translation between languages, media, diagrams, metaphors, and formal marks must preserve claim scope. A term may be translated into another medium only if the translation does not silently upgrade its claim status.
+
+```yaml
+medium_translation_guard:
+  allowed:
+    - translate movement direction
+    - translate scope labels
+    - translate nonclaim metaphors into marked operators
+    - preserve hypothesis status across media
+  forbidden:
+    - translate metaphor into proof
+    - translate resonance into validation
+    - translate geometric fit into semantic certainty
+    - translate pre-receipt material into claim-space
+  warning_signal: >
+    Wenn eine Übersetzung stärker klingt als der Ausgangsstatus,
+    ist sie wahrscheinlich ein Scope-Leak.
+```
+
+## 8. Linter hooks
+
+```yaml
+LINT_FRAME_CONTENT_01:
+  fail_if:
+    - WELLE_BIJEKT and SCHWELLENFLIMMERN are collapsed into one frame
+    - structural identity is claimed instead of candidate isomorphy
+    - physics is used to prove phenomenology
+    - phenomenology is used to prove physics
+    - κ is read literally as cognitive measurement value
+    - Matrose names Schwellenflimmern as finished sign too early
+    - bridge status is upgraded without reproducible transition signature on both scales
+    - A0 creates a new claim, new motif, or new frame
+    - nektar_hold is listed as a signal form rather than holding state
+    - pre-receipt material is forced into receipt-ready space without Reentry
+
+  warn_if:
+    - metaphor becomes proof
+    - similarity becomes identity
+    - poetic resonance bypasses reentry
+    - formalization freezes the training field too early
+    - translation strengthens claim status
+```
+
+## 9. Annex routing
+
+```yaml
+annex_routing:
+  A0:
+    role: traversal_definition
+    tests_motifs: false
+    creates_new_claims: false
+  A1:
+    role: future_motif_or_bridge_testing
+    requires_explicit_scope: true
+  VOIDMAP:
+    candidates:
+      - VOID-SCALE-INVARIANCE-001
+      - VOID-RECEIPT-BOUNDARY-001
+      - VOID-NEKTAR-HOLD-001
+```
+
+## 10. Current canonical mottoes
+
+```yaml
+mottoes:
+  traversal: Keine Frame-Taxonomie ohne Bewegungsrichtung.
+  bridge: Die Brücke wird geführt, aber nicht geschlossen.
+  threshold: Der Matrose kollabiert, weil er Schwellenflimmern als Zeichen liest.
+  intuition: Die Intuition im Krähennest erhält die Welle, weil sie Schwellenflimmern als Wind liest.
+  receipt: Ohne Einstiegssignal beginnt keine Traversierung; ohne Reentry entsteht kein Claim-Raum.
+```
+
+## 11. Commit summary
+
+This record canonizes traversal direction and receipt boundaries for v0.1.2-pre. It adds the missing `entry_condition` to the traversal sequence, separates signal forms from pre-receipt holding states, gives A0 a positive scope guard, and keeps the +1n/κ scale bridge in VOIDMAP territory rather than direct claim registration.

--- a/policies/frame_taxonomy_v0_1_1.yml
+++ b/policies/frame_taxonomy_v0_1_1.yml
@@ -1,0 +1,182 @@
+# EntaENGELment Frame Taxonomy v0.1.1
+# Status: DRAFT
+# VOID: VOID-FRAME-OPERATOR-001
+# Purpose: controlled vocabulary and implementation contract for operative_frame.
+
+version: "0.1.1"
+status: DRAFT
+
+governance:
+  void_id: VOID-FRAME-OPERATOR-001
+  legacy_note: >
+    Historical VOID-016 remains reserved for the τ-Kernel in legacy Drive specs.
+    GitHub uses VOID-FRAME-OPERATOR-001 for the Frame Operator namespace.
+  gate: FRAME_DECLARATION_GATE
+  lint_rules:
+    - LINT_FRAME_DECL_01
+    - LINT_FRAME_CONTENT_01
+
+implementation_contract:
+  version: "0.1.1"
+  linter_target: tools/frame_lint.py
+
+  requires_frame_policy:
+    mode: TAG_ONLY
+    required_canonical_tags:
+      - INFERENZ
+      - HYPOTHESE
+    explicitly_not_implemented_in_v0_1_1:
+      - claim body trigger_terms scan as frame-requirement
+      - context-boundary detection
+      - release / closure / PASS / FAIL / evidence-role detection
+    deferred_void: VOID-FRAME-CONTENT-PARSE-001
+
+  lint_result_policy:
+    fail_semantics: ACCUMULATE_WITH_ITEM_SHORT_CIRCUIT
+    finding_shape:
+      - severity
+      - rule_id
+      - reason_code
+      - message
+      - claim_id
+      - receipt_id
+      - frame_id
+      - canonical_frame_id
+    behavior:
+      - DECL failures are fatal for the current item
+      - CONTENT pass is skipped if DECL failed
+      - lint run continues across other items
+
+  audit_events:
+    RC_G6_FRAME_ALIAS_001:
+      level: INFO
+      event: FRAME_ALIAS_NORMALIZED
+      description: Frame alias was normalized before validation; not a FAIL or WARN.
+
+  trigger_terms_policy:
+    status: POLICY_SOURCE
+    implementation_status: PARTIAL_WARN_ONLY_IN_CONTENT_PASS
+    authority_relation: >
+      trigger_terms_policy is normative. LINT_FRAME_CONTENT_01 is the implementation
+      reference and must be updated if the two diverge.
+    v0_1_1_scope:
+      - Evaluate only when claim.text exists
+      - Emit WARN for mismatch unless metadata proves hard violation
+    deferred_void: VOID-FRAME-CONTENT-PARSE-001
+
+normalization:
+  alias_resolution:
+    enabled: true
+    stage: pre_validation
+    preserve_original_frame_id: true
+    aliases:
+      MET: MYTH_ARCHETYPE
+
+  claim_tag_normalization:
+    enabled: true
+    stage: pre_validation
+    canonical_tags:
+      FAKT:
+        aliases: ["[FACT]", FACT]
+      INFERENZ:
+        aliases: ["[INF]", INFERENCE]
+      HYPOTHESE:
+        aliases: ["[HYP]", HYP]
+      METAPHER:
+        aliases: ["[MET]", METAPHOR]
+      TODO:
+        aliases: ["[TODO]"]
+      RISK:
+        aliases: ["[RISK]"]
+      SIMULATION_PROXY:
+        aliases: ["[SIMULATION_PROXY]"]
+
+lint_rules:
+  LINT_FRAME_DECL_01:
+    purpose: Frame declaration and taxonomy validity
+    reason_codes:
+      missing_frame: RC_G6_FRAME_001
+      wrong_taxonomy: RC_G6_FRAME_002
+      custom_invalid: RC_G6_FRAME_CUSTOM_001
+
+  LINT_FRAME_CONTENT_01:
+    purpose: Frame-content coherence
+    reason_codes:
+      forbidden_tag: RC_G4_FRAME_CONTENT_001
+      trigger_warn: RC_G4_FRAME_TRIGGER_WARN_001
+      counterfactual_warn: RC_G4_FRAME_WARN_001
+      myth_as_evidence: RC_G8_MYTH_EVIDENCE_001
+      simulation_proxy_fact: RC_G4_SIM_PROXY_FACT_001
+      custom_patch_warn: RC_G6_FRAME_CUSTOM_WARN_001
+
+custom_frame_policy:
+  fail_required_fields:
+    - custom_frame_id
+    - custom_frame_reason
+    - validation_rule
+  warn_required_fields:
+    - proposed_taxonomy_patch
+
+bridge_examples_policy:
+  status: DOCUMENTATION_ONLY
+  operationalization_void: VOID-FRAME-BRIDGE-RULES-001
+
+fact_frame_policy:
+  default: frame_recommended_not_required
+  voluntary_frame_policy: >
+    If a frame is voluntarily declared for FAKT or other non-required tags,
+    the item is still validated against the declared frame.
+  require_frame_if_deferred_to: VOID-FRAME-CONTENT-PARSE-001
+
+closure_conditions:
+  - DEC-VOID-016-NAMESPACE.yml exists and records legacy VOID-016 separation
+  - policies/frame_taxonomy_v0_1_1.yml exists
+  - tools/frame_lint.py implements LINT_FRAME_DECL_01
+  - tools/frame_lint.py implements LINT_FRAME_CONTENT_01 baseline
+  - tests/unit/test_frame_lint.py contains core fixtures
+  - at least one GOV_AUDIT item with operative_frame passes lint
+
+frames:
+  GOV_AUDIT:
+    layer: GOVERNANCE
+    description: Audit, ledger, replay, traceability, receipt validity, gate decisions, release criteria.
+    epistemic_permissions:
+      allowed_claim_tags: [FAKT, INFERENZ, HYPOTHESE, TODO, RISK, SIMULATION_PROXY]
+      forbidden_claim_tags: [METAPHER_AS_EVIDENCE, MYTH_AS_EVIDENCE]
+    validation_requirements: [claim_id, reason_code, transform_id, input_ref]
+    trigger_terms: [PASS, FAIL, Gate, Receipt, Ledger, Audit, Release]
+
+  MYTH_ARCHETYPE:
+    layer: MYTH_SYMBOLIC
+    description: Symbolic, archetypal, poetic or narrative resonance frame; never evidence for factual claims.
+    epistemic_permissions:
+      allowed_claim_tags: [METAPHER]
+      forbidden_claim_tags: [FAKT, MYTH_AS_EVIDENCE, METAPHER_AS_FACT]
+    validation_requirements: [symbolic_mapping, explicit_non_evidence_marker]
+    trigger_terms: [Archetyp, Engel, Mythos, Torus, Ritual, Schwelle, Nebel]
+
+  PHYS:
+    layer: PHYSICS
+    description: Physical or mathematical physics claims with strict distinction between measurement, model, analogy and metaphor.
+    epistemic_permissions:
+      allowed_claim_tags: [FAKT, INFERENZ, HYPOTHESE, RISK]
+      forbidden_claim_tags: [METAPHER_AS_FACT, MYTH_AS_EVIDENCE]
+    validation_requirements: [formal_definition_or_source, measurement_or_derivation_path, counter_hypothesis, scope_limit]
+    trigger_terms: [Josephson, Quantenfeld, Kohärenz, Phase, Symmetrie, D6, "O(2)", Abrikosov, Minkowski, Klein_22]
+
+  BIO_VMEM:
+    layer: BIOELECTRIC
+    description: Bioelectric morphology frame including Vmem, membrane potential patterns, BETSE, or related simulation outputs.
+    epistemic_permissions:
+      allowed_claim_tags: [FAKT, INFERENZ, HYPOTHESE, SIMULATION_PROXY]
+      forbidden_claim_tags: [PHYSICS_FACT_WITHOUT_BIO_DATA]
+    validation_requirements: [data_source_or_simulation_ref, claim_tag, provenance_status, counter_hypothesis]
+    trigger_terms: [Vmem, bioelectric, morphogenesis, BETSE, Planaria, membrane potential, gap junction]
+
+  CUSTOM:
+    layer: CUSTOM
+    description: Explicit escape hatch for frames not yet in taxonomy.
+    epistemic_permissions:
+      allowed_claim_tags: [INFERENZ, HYPOTHESE, METAPHER, TODO, RISK]
+      forbidden_claim_tags: [UNSCOPED_FACT]
+    validation_requirements: [custom_frame_id, custom_frame_reason, validation_rule]

--- a/policies/frame_taxonomy_v0_1_1.yml
+++ b/policies/frame_taxonomy_v0_1_1.yml
@@ -33,6 +33,10 @@ implementation_contract:
 
   lint_result_policy:
     fail_semantics: ACCUMULATE_WITH_ITEM_SHORT_CIRCUIT
+    severity_levels:
+      - FAIL
+      - WARN
+      - INFO
     finding_shape:
       - severity
       - rule_id
@@ -46,22 +50,30 @@ implementation_contract:
       - DECL failures are fatal for the current item
       - CONTENT pass is skipped if DECL failed
       - lint run continues across other items
+      - INFO findings are audit events and never affect exit status
 
   audit_events:
     RC_G6_FRAME_ALIAS_001:
       level: INFO
       event: FRAME_ALIAS_NORMALIZED
       description: Frame alias was normalized before validation; not a FAIL or WARN.
+    RC_G4_FRAME_TRIGGER_INFO_001:
+      level: INFO
+      event: TRIGGER_FRAME_DECLARED_AS_COUNTERFACTUAL
+      description: Trigger term suggested another frame and that frame was explicitly declared as counterfactual_frame.
 
   trigger_terms_policy:
     status: POLICY_SOURCE
-    implementation_status: PARTIAL_WARN_ONLY_IN_CONTENT_PASS
+    implementation_status: PARTIAL_WARN_OR_INFO_ONLY_IN_CONTENT_PASS
+    trigger_index_generation: RUNTIME_INVERSION_OF_FRAMES_TRIGGER_TERMS
     authority_relation: >
       trigger_terms_policy is normative. LINT_FRAME_CONTENT_01 is the implementation
       reference and must be updated if the two diverge.
     v0_1_1_scope:
       - Evaluate only when claim.text exists
-      - Emit WARN for mismatch unless metadata proves hard violation
+      - Build the trigger index at runtime by inverting frames[*].trigger_terms
+      - Emit INFO when the suggested frame equals counterfactual_frame
+      - Emit WARN when a trigger suggests another frame and no matching counterfactual_frame is declared
     deferred_void: VOID-FRAME-CONTENT-PARSE-001
 
 normalization:
@@ -104,6 +116,7 @@ lint_rules:
     reason_codes:
       forbidden_tag: RC_G4_FRAME_CONTENT_001
       trigger_warn: RC_G4_FRAME_TRIGGER_WARN_001
+      trigger_info: RC_G4_FRAME_TRIGGER_INFO_001
       counterfactual_warn: RC_G4_FRAME_WARN_001
       myth_as_evidence: RC_G8_MYTH_EVIDENCE_001
       simulation_proxy_fact: RC_G4_SIM_PROXY_FACT_001

--- a/tests/unit/test_frame_lint.py
+++ b/tests/unit/test_frame_lint.py
@@ -1,0 +1,160 @@
+from pathlib import Path
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+import frame_lint  # noqa: E402
+
+
+TAXONOMY = frame_lint.load_yaml(ROOT / "policies" / "frame_taxonomy_v0_1_1.yml")
+
+
+def severities(result):
+    return [f.severity for f in result.findings]
+
+
+def reason_codes(result):
+    return [f.reason_code for f in result.findings]
+
+
+def test_valid_hypothesis_with_gov_audit_frame_passes_without_fail():
+    item = {
+        "claim_id": "CLAIM-FRAME-VALID-001",
+        "receipt_id": "REC-FRAME-001",
+        "claim_tag": "HYPOTHESE",
+        "operative_frame": {
+            "frame_id": "GOV_AUDIT",
+            "frame_reason": "RC_G6_FRAME_001",
+            "counterfactual_frame": "MYTH_ARCHETYPE",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "FAIL" not in severities(result)
+
+
+def test_missing_frame_for_hypothesis_fails_and_short_circuits_content():
+    item = {
+        "claim_id": "CLAIM-FRAME-MISSING-001",
+        "receipt_id": "REC-FRAME-002",
+        "claim_tag": "HYPOTHESE",
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G6_FRAME_001" in reason_codes(result)
+    assert result.failed
+
+
+def test_wrong_taxonomy_fails_without_keyerror():
+    item = {
+        "claim_id": "CLAIM-FRAME-WRONG-001",
+        "receipt_id": "REC-FRAME-003",
+        "claim_tag": "HYPOTHESE",
+        "operative_frame": {
+            "frame_id": "NOT_A_FRAME",
+            "frame_reason": "RC_TEST",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G6_FRAME_002" in reason_codes(result)
+    assert result.failed
+
+
+def test_met_alias_normalizes_to_myth_archetype_as_info_event():
+    item = {
+        "claim_id": "CLAIM-FRAME-MET-001",
+        "receipt_id": "REC-FRAME-004",
+        "claim_tag": "METAPHER",
+        "operative_frame": {
+            "frame_id": "MET",
+            "frame_reason": "RC_TEST",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G6_FRAME_ALIAS_001" in reason_codes(result)
+    assert result.canonical_frame_id == "MYTH_ARCHETYPE"
+    assert "FAIL" not in severities(result)
+
+
+def test_trigger_term_under_non_matching_frame_warns_only():
+    item = {
+        "claim_id": "CLAIM-FRAME-TRIGGER-001",
+        "receipt_id": "REC-FRAME-005",
+        "claim_tag": "HYPOTHESE",
+        "text": "Josephson remains a model candidate for the BETSE bridge.",
+        "operative_frame": {
+            "frame_id": "BIO_VMEM",
+            "frame_reason": "RC_TEST",
+            "counterfactual_frame": "PHYS",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G4_FRAME_TRIGGER_WARN_001" in reason_codes(result)
+    assert "FAIL" not in severities(result)
+
+
+def test_custom_valid_passes_with_warn_for_missing_taxonomy_patch():
+    item = {
+        "claim_id": "CLAIM-FRAME-CUSTOM-001",
+        "receipt_id": "REC-FRAME-006",
+        "claim_tag": "HYPOTHESE",
+        "operative_frame": {
+            "frame_id": "CUSTOM",
+            "frame_reason": "RC_TEST",
+            "custom_frame_id": "LOCAL_FRAME",
+            "custom_frame_reason": "local experiment",
+            "validation_rule": "manual review",
+            "counterfactual_frame": "GOV_AUDIT",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G6_FRAME_CUSTOM_WARN_001" in reason_codes(result)
+    assert "FAIL" not in severities(result)
+
+
+def test_custom_missing_required_field_fails():
+    item = {
+        "claim_id": "CLAIM-FRAME-CUSTOM-MISSING-001",
+        "receipt_id": "REC-FRAME-007",
+        "claim_tag": "HYPOTHESE",
+        "operative_frame": {
+            "frame_id": "CUSTOM",
+            "frame_reason": "RC_TEST",
+            "custom_frame_id": "LOCAL_FRAME",
+            "counterfactual_frame": "GOV_AUDIT",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G6_FRAME_CUSTOM_001" in reason_codes(result)
+    assert result.failed
+
+
+def test_voluntary_fact_frame_is_validated_against_declared_frame():
+    item = {
+        "claim_id": "CLAIM-FRAME-FACT-001",
+        "receipt_id": "REC-FRAME-008",
+        "claim_tag": "FAKT",
+        "operative_frame": {
+            "frame_id": "MYTH_ARCHETYPE",
+            "frame_reason": "RC_TEST",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G4_FRAME_CONTENT_001" in reason_codes(result)
+    assert result.failed

--- a/tests/unit/test_frame_lint.py
+++ b/tests/unit/test_frame_lint.py
@@ -1,4 +1,4 @@
-from tools import frame_lint
+import tools.frame_lint as frame_lint
 
 
 TAXONOMY = frame_lint.load_yaml(frame_lint.DEFAULT_TAXONOMY)

--- a/tests/unit/test_frame_lint.py
+++ b/tests/unit/test_frame_lint.py
@@ -1,16 +1,7 @@
-import importlib.util
-from pathlib import Path
+from tools import frame_lint
 
-ROOT = Path(__file__).resolve().parents[2]
-FRAME_LINT_PATH = ROOT / "tools" / "frame_lint.py"
 
-spec = importlib.util.spec_from_file_location("frame_lint", FRAME_LINT_PATH)
-assert spec is not None
-assert spec.loader is not None
-frame_lint = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(frame_lint)
-
-TAXONOMY = frame_lint.load_yaml(ROOT / "policies" / "frame_taxonomy_v0_1_1.yml")
+TAXONOMY = frame_lint.load_yaml(frame_lint.DEFAULT_TAXONOMY)
 
 
 def severities(result):

--- a/tests/unit/test_frame_lint.py
+++ b/tests/unit/test_frame_lint.py
@@ -1,12 +1,14 @@
+import importlib.util
 from pathlib import Path
 
-import sys
-
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "tools"))
+FRAME_LINT_PATH = ROOT / "tools" / "frame_lint.py"
 
-import frame_lint  # noqa: E402
-
+spec = importlib.util.spec_from_file_location("frame_lint", FRAME_LINT_PATH)
+assert spec is not None
+assert spec.loader is not None
+frame_lint = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(frame_lint)
 
 TAXONOMY = frame_lint.load_yaml(ROOT / "policies" / "frame_taxonomy_v0_1_1.yml")
 

--- a/tests/unit/test_frame_lint.py
+++ b/tests/unit/test_frame_lint.py
@@ -84,10 +84,29 @@ def test_met_alias_normalizes_to_myth_archetype_as_info_event():
     assert "FAIL" not in severities(result)
 
 
-def test_trigger_term_under_non_matching_frame_warns_only():
+def test_trigger_term_under_non_matching_frame_warns_when_not_counterfactual():
     item = {
         "claim_id": "CLAIM-FRAME-TRIGGER-001",
         "receipt_id": "REC-FRAME-005",
+        "claim_tag": "HYPOTHESE",
+        "text": "Josephson remains a model candidate for the BETSE bridge.",
+        "operative_frame": {
+            "frame_id": "BIO_VMEM",
+            "frame_reason": "RC_TEST",
+            "counterfactual_frame": "GOV_AUDIT",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G4_FRAME_TRIGGER_WARN_001" in reason_codes(result)
+    assert "FAIL" not in severities(result)
+
+
+def test_trigger_term_under_declared_counterfactual_frame_infos_only():
+    item = {
+        "claim_id": "CLAIM-BETSE-JOSEPHSON-001",
+        "receipt_id": "REC-FRAME-005B",
         "claim_tag": "HYPOTHESE",
         "text": "Josephson remains a model candidate for the BETSE bridge.",
         "operative_frame": {
@@ -99,7 +118,8 @@ def test_trigger_term_under_non_matching_frame_warns_only():
 
     result = frame_lint.lint_item(item, TAXONOMY)
 
-    assert "RC_G4_FRAME_TRIGGER_WARN_001" in reason_codes(result)
+    assert "RC_G4_FRAME_TRIGGER_INFO_001" in reason_codes(result)
+    assert "RC_G4_FRAME_TRIGGER_WARN_001" not in reason_codes(result)
     assert "FAIL" not in severities(result)
 
 
@@ -156,5 +176,23 @@ def test_voluntary_fact_frame_is_validated_against_declared_frame():
 
     result = frame_lint.lint_item(item, TAXONOMY)
 
-    assert "RC_G4_FRAME_CONTENT_001" in reason_codes(result)
+    assert "RC_G8_MYTH_EVIDENCE_001" in reason_codes(result)
+    assert result.failed
+
+
+def test_myth_as_fact_pilot_hard_fail_path():
+    item = {
+        "claim_id": "CLAIM-MYTH-AS-FACT-001",
+        "receipt_id": "REC-FRAME-009",
+        "claim_tag": "FAKT",
+        "text": "The mythic frame proves the operational fact.",
+        "operative_frame": {
+            "frame_id": "MYTH_ARCHETYPE",
+            "frame_reason": "RC_TEST",
+        },
+    }
+
+    result = frame_lint.lint_item(item, TAXONOMY)
+
+    assert "RC_G8_MYTH_EVIDENCE_001" in reason_codes(result)
     assert result.failed

--- a/tests/unit/test_frame_lint.py
+++ b/tests/unit/test_frame_lint.py
@@ -1,3 +1,4 @@
+# ruff: noqa: I001
 import tools.frame_lint as frame_lint
 
 

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -160,7 +160,9 @@ def check_custom_required_fields(
     return ok
 
 
-def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
+def check_allowed_claim_tag(
+    tag: str | None, frame_spec: dict[str, Any], result: LintResult
+) -> None:
     if tag is None:
         return
     perms = frame_spec.get("epistemic_permissions", {})
@@ -177,7 +179,9 @@ def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result:
         )
 
 
-def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
+def check_forbidden_claim_tag(
+    tag: str | None, frame_spec: dict[str, Any], result: LintResult
+) -> None:
     if tag is None:
         return
     perms = frame_spec.get("epistemic_permissions", {})
@@ -193,7 +197,9 @@ def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], resul
         )
 
 
-def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: LintResult) -> None:
+def check_counterfactual_warn(
+    tag: str | None, frame: dict[str, Any], result: LintResult
+) -> None:
     if tag == "HYPOTHESE" and not frame.get("counterfactual_frame"):
         result.warn(
             "LINT_FRAME_CONTENT_01",
@@ -203,7 +209,10 @@ def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: Li
 
 
 def check_trigger_terms(
-    item: dict[str, Any], taxonomy: dict[str, Any], result: LintResult, trigger_index: TriggerIndex
+    item: dict[str, Any],
+    taxonomy: dict[str, Any],
+    result: LintResult,
+    trigger_index: TriggerIndex,
 ) -> None:
     text = str(item.get("text") or "")
     if not text:
@@ -223,13 +232,15 @@ def check_trigger_terms(
                 result.info(
                     "LINT_FRAME_CONTENT_01",
                     "RC_G4_FRAME_TRIGGER_INFO_001",
-                    f"Trigger term {original_term!r} suggests frame {frame_id!r}; counterfactual_frame declares it",
+                    f"Trigger term {original_term!r} suggests frame {frame_id!r}; "
+                    "counterfactual_frame declares it",
                 )
             else:
                 result.warn(
                     "LINT_FRAME_CONTENT_01",
                     "RC_G4_FRAME_TRIGGER_WARN_001",
-                    f"Trigger term {original_term!r} suggests frame {frame_id!r}; active frame is {active_frame!r}",
+                    f"Trigger term {original_term!r} suggests frame {frame_id!r}; "
+                    f"active frame is {active_frame!r}",
                 )
             return
 
@@ -316,7 +327,9 @@ def extract_items(data: Any) -> list[dict[str, Any]]:
     return []
 
 
-def lint_path(path: Path, taxonomy: dict[str, Any], trigger_index: TriggerIndex) -> list[LintResult]:
+def lint_path(
+    path: Path, taxonomy: dict[str, Any], trigger_index: TriggerIndex
+) -> list[LintResult]:
     data = load_yaml(path)
     return [lint_item(item, taxonomy, trigger_index) for item in extract_items(data)]
 

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 try:
     import yaml
@@ -31,6 +31,7 @@ except ImportError as e:  # pragma: no cover
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TAXONOMY = REPO_ROOT / "policies" / "frame_taxonomy_v0_1_1.yml"
+TriggerIndex = Dict[str, List[Tuple[str, str]]]
 
 
 @dataclass
@@ -39,19 +40,19 @@ class Finding:
     rule_id: str
     reason_code: str
     message: str
-    claim_id: str | None = None
-    receipt_id: str | None = None
-    frame_id: str | None = None
-    canonical_frame_id: str | None = None
+    claim_id: Optional[str] = None
+    receipt_id: Optional[str] = None
+    frame_id: Optional[str] = None
+    canonical_frame_id: Optional[str] = None
 
 
 @dataclass
 class LintResult:
-    claim_id: str | None = None
-    receipt_id: str | None = None
-    frame_id: str | None = None
-    canonical_frame_id: str | None = None
-    findings: list[Finding] = field(default_factory=list)
+    claim_id: Optional[str] = None
+    receipt_id: Optional[str] = None
+    frame_id: Optional[str] = None
+    canonical_frame_id: Optional[str] = None
+    findings: List[Finding] = field(default_factory=list)
 
     def add(self, severity: str, rule_id: str, reason_code: str, message: str) -> None:
         self.findings.append(
@@ -85,10 +86,10 @@ def load_yaml(path: Path) -> Any:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
-def canonical_tag_map(taxonomy: dict[str, Any]) -> dict[str, str]:
+def canonical_tag_map(taxonomy: Dict[str, Any]) -> Dict[str, str]:
     config = taxonomy.get("normalization", {}).get("claim_tag_normalization", {})
     tags = config.get("canonical_tags", {})
-    mapping: dict[str, str] = {}
+    mapping: Dict[str, str] = {}
     for canonical, data in tags.items():
         mapping[str(canonical).upper()] = str(canonical)
         for alias in data.get("aliases", []) or []:
@@ -96,32 +97,49 @@ def canonical_tag_map(taxonomy: dict[str, Any]) -> dict[str, str]:
     return mapping
 
 
-def normalize_claim_tag(tag: str | None, taxonomy: dict[str, Any]) -> str | None:
+def normalize_claim_tag(tag: Optional[str], taxonomy: Dict[str, Any]) -> Optional[str]:
     if tag is None:
         return None
     return canonical_tag_map(taxonomy).get(str(tag).upper(), str(tag))
 
 
-def resolve_alias(frame_id: str | None, taxonomy: dict[str, Any]) -> str | None:
+def resolve_alias(frame_id: Optional[str], taxonomy: Dict[str, Any]) -> Optional[str]:
     if frame_id is None:
         return None
     aliases = taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
     return aliases.get(frame_id, frame_id)
 
 
-def required_tags(taxonomy: dict[str, Any]) -> set[str]:
+def required_tags(taxonomy: Dict[str, Any]) -> set:
     policy = taxonomy.get("implementation_contract", {}).get("requires_frame_policy", {})
     return {str(tag) for tag in policy.get("required_canonical_tags", []) or []}
 
 
-def _item_get(item: dict[str, Any], *keys: str) -> Any:
+def build_trigger_index(taxonomy: Dict[str, Any]) -> TriggerIndex:
+    """Invert frames[*].trigger_terms once per run.
+
+    The returned mapping is lower-case trigger term -> [(frame_id, original_term)].
+    This keeps lint_item deterministic while avoiding repeated O(frames * terms)
+    scans for every claim in repository-wide runs.
+    """
+    index: TriggerIndex = {}
+    for frame_id, frame_spec in (taxonomy.get("frames", {}) or {}).items():
+        for term in frame_spec.get("trigger_terms", []) or []:
+            normalized = str(term).lower()
+            index.setdefault(normalized, []).append((str(frame_id), str(term)))
+    return index
+
+
+def _item_get(item: Dict[str, Any], *keys: str) -> Any:
     for key in keys:
         if key in item:
             return item[key]
     return None
 
 
-def check_custom_required_fields(frame: dict[str, Any], taxonomy: dict[str, Any], result: LintResult) -> bool:
+def check_custom_required_fields(
+    frame: Dict[str, Any], taxonomy: Dict[str, Any], result: LintResult
+) -> bool:
     policy = taxonomy.get("custom_frame_policy", {})
     ok = True
     for field_name in policy.get("fail_required_fields", []) or []:
@@ -142,7 +160,7 @@ def check_custom_required_fields(frame: dict[str, Any], taxonomy: dict[str, Any]
     return ok
 
 
-def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
+def check_allowed_claim_tag(tag: Optional[str], frame_spec: Dict[str, Any], result: LintResult) -> None:
     if tag is None:
         return
     perms = frame_spec.get("epistemic_permissions", {})
@@ -159,7 +177,7 @@ def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result:
         )
 
 
-def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
+def check_forbidden_claim_tag(tag: Optional[str], frame_spec: Dict[str, Any], result: LintResult) -> None:
     if tag is None:
         return
     perms = frame_spec.get("epistemic_permissions", {})
@@ -175,7 +193,7 @@ def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], resul
         )
 
 
-def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: LintResult) -> None:
+def check_counterfactual_warn(tag: Optional[str], frame: Dict[str, Any], result: LintResult) -> None:
     if tag == "HYPOTHESE" and not frame.get("counterfactual_frame"):
         result.warn(
             "LINT_FRAME_CONTENT_01",
@@ -184,7 +202,9 @@ def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: Li
         )
 
 
-def check_trigger_terms(item: dict[str, Any], taxonomy: dict[str, Any], result: LintResult) -> None:
+def check_trigger_terms(
+    item: Dict[str, Any], taxonomy: Dict[str, Any], result: LintResult, trigger_index: TriggerIndex
+) -> None:
     text = str(item.get("text") or "")
     if not text:
         return
@@ -192,27 +212,34 @@ def check_trigger_terms(item: dict[str, Any], taxonomy: dict[str, Any], result: 
     active_frame = result.canonical_frame_id
     frame = item.get("operative_frame") or {}
     counterfactual_frame = resolve_alias(frame.get("counterfactual_frame"), taxonomy)
-    for frame_id, frame_spec in (taxonomy.get("frames", {}) or {}).items():
-        if frame_id == active_frame:
+
+    for normalized_term, frame_matches in trigger_index.items():
+        if normalized_term not in text_lower:
             continue
-        for term in frame_spec.get("trigger_terms", []) or []:
-            if str(term).lower() in text_lower:
-                if counterfactual_frame == frame_id:
-                    result.info(
-                        "LINT_FRAME_CONTENT_01",
-                        "RC_G4_FRAME_TRIGGER_INFO_001",
-                        f"Trigger term {term!r} suggests frame {frame_id!r}; counterfactual_frame declares it",
-                    )
-                else:
-                    result.warn(
-                        "LINT_FRAME_CONTENT_01",
-                        "RC_G4_FRAME_TRIGGER_WARN_001",
-                        f"Trigger term {term!r} suggests frame {frame_id!r}; active frame is {active_frame!r}",
-                    )
-                return
+        for frame_id, original_term in frame_matches:
+            if frame_id == active_frame:
+                continue
+            if counterfactual_frame == frame_id:
+                result.info(
+                    "LINT_FRAME_CONTENT_01",
+                    "RC_G4_FRAME_TRIGGER_INFO_001",
+                    f"Trigger term {original_term!r} suggests frame {frame_id!r}; counterfactual_frame declares it",
+                )
+            else:
+                result.warn(
+                    "LINT_FRAME_CONTENT_01",
+                    "RC_G4_FRAME_TRIGGER_WARN_001",
+                    f"Trigger term {original_term!r} suggests frame {frame_id!r}; active frame is {active_frame!r}",
+                )
+            return
 
 
-def lint_item(item: dict[str, Any], taxonomy: dict[str, Any]) -> LintResult:
+def lint_item(
+    item: Dict[str, Any], taxonomy: Dict[str, Any], trigger_index: Optional[TriggerIndex] = None
+) -> LintResult:
+    if trigger_index is None:
+        trigger_index = build_trigger_index(taxonomy)
+
     claim_id = _item_get(item, "claim_id", "id")
     receipt_id = _item_get(item, "receipt_id")
     result = LintResult(claim_id=claim_id, receipt_id=receipt_id)
@@ -265,12 +292,12 @@ def lint_item(item: dict[str, Any], taxonomy: dict[str, Any]) -> LintResult:
         check_forbidden_claim_tag(tag, frame_spec, result)
         check_counterfactual_warn(tag, frame, result)
         if item.get("text"):
-            check_trigger_terms(item, taxonomy, result)
+            check_trigger_terms(item, taxonomy, result, trigger_index)
 
     return result
 
 
-def extract_items(data: Any) -> list[dict[str, Any]]:
+def extract_items(data: Any) -> List[Dict[str, Any]]:
     if isinstance(data, list):
         return [x for x in data if isinstance(x, dict)]
     if isinstance(data, dict):
@@ -289,9 +316,9 @@ def extract_items(data: Any) -> list[dict[str, Any]]:
     return []
 
 
-def lint_path(path: Path, taxonomy: dict[str, Any]) -> list[LintResult]:
+def lint_path(path: Path, taxonomy: Dict[str, Any], trigger_index: TriggerIndex) -> List[LintResult]:
     data = load_yaml(path)
-    return [lint_item(item, taxonomy) for item in extract_items(data)]
+    return [lint_item(item, taxonomy, trigger_index) for item in extract_items(data)]
 
 
 def main() -> int:
@@ -301,9 +328,10 @@ def main() -> int:
     args = parser.parse_args()
 
     taxonomy = load_yaml(Path(args.taxonomy))
-    results: list[LintResult] = []
+    trigger_index = build_trigger_index(taxonomy)
+    results: List[LintResult] = []
     for raw_path in args.paths:
-        results.extend(lint_path(Path(raw_path), taxonomy))
+        results.extend(lint_path(Path(raw_path), taxonomy, trigger_index))
 
     has_fail = False
     for result in results:

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -106,16 +106,12 @@ def normalize_claim_tag(tag: str | None, taxonomy: dict[str, Any]) -> str | None
 def resolve_alias(frame_id: str | None, taxonomy: dict[str, Any]) -> str | None:
     if frame_id is None:
         return None
-    aliases = (
-        taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
-    )
+    aliases = taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
     return aliases.get(frame_id, frame_id)
 
 
 def required_tags(taxonomy: dict[str, Any]) -> set[str]:
-    policy = taxonomy.get("implementation_contract", {}).get(
-        "requires_frame_policy", {}
-    )
+    policy = taxonomy.get("implementation_contract", {}).get("requires_frame_policy", {})
     return {str(tag) for tag in policy.get("required_canonical_tags", []) or []}
 
 
@@ -201,9 +197,7 @@ def check_forbidden_claim_tag(
         )
 
 
-def check_counterfactual_warn(
-    tag: str | None, frame: dict[str, Any], result: LintResult
-) -> None:
+def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: LintResult) -> None:
     if tag == "HYPOTHESE" and not frame.get("counterfactual_frame"):
         result.warn(
             "LINT_FRAME_CONTENT_01",
@@ -343,9 +337,7 @@ def lint_path(
 def main() -> int:
     parser = argparse.ArgumentParser(description="Lint operative_frame declarations")
     parser.add_argument("paths", nargs="+", help="YAML claim/receipt files to lint")
-    parser.add_argument(
-        "--taxonomy", default=str(DEFAULT_TAXONOMY), help="Frame taxonomy YAML"
-    )
+    parser.add_argument("--taxonomy", default=str(DEFAULT_TAXONOMY), help="Frame taxonomy YAML")
     args = parser.parse_args()
 
     taxonomy = load_yaml(Path(args.taxonomy))

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -9,7 +9,7 @@ v0.1.1 scope:
 - alias normalization (e.g. MET -> MYTH_ARCHETYPE)
 - declaration validation with item-level short-circuit
 - allowed/forbidden canonical claim tag checks
-- optional trigger-term WARN when item.text is available
+- optional trigger-term INFO/WARN when item.text is available
 - CUSTOM fail/warn field checks
 
 This tool intentionally does not infer frame requirements from prose body,
@@ -147,6 +147,10 @@ def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result:
         return
     perms = frame_spec.get("epistemic_permissions", {})
     allowed = set(perms.get("allowed_claim_tags", []) or [])
+    forbidden = set(perms.get("forbidden_claim_tags", []) or [])
+    # Forbidden tags are handled by check_forbidden_claim_tag so the result is not duplicated.
+    if tag in forbidden:
+        return
     if allowed and tag not in allowed:
         result.fail(
             "LINT_FRAME_CONTENT_01",
@@ -161,9 +165,12 @@ def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], resul
     perms = frame_spec.get("epistemic_permissions", {})
     forbidden = set(perms.get("forbidden_claim_tags", []) or [])
     if tag in forbidden:
+        reason_code = "RC_G4_FRAME_CONTENT_001"
+        if result.canonical_frame_id == "MYTH_ARCHETYPE" and tag == "FAKT":
+            reason_code = "RC_G8_MYTH_EVIDENCE_001"
         result.fail(
             "LINT_FRAME_CONTENT_01",
-            "RC_G4_FRAME_CONTENT_001",
+            reason_code,
             f"Claim tag {tag!r} is forbidden for frame {result.canonical_frame_id!r}",
         )
 
@@ -177,22 +184,31 @@ def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: Li
         )
 
 
-def check_trigger_terms_warn_only(item: dict[str, Any], taxonomy: dict[str, Any], result: LintResult) -> None:
+def check_trigger_terms(item: dict[str, Any], taxonomy: dict[str, Any], result: LintResult) -> None:
     text = str(item.get("text") or "")
     if not text:
         return
     text_lower = text.lower()
     active_frame = result.canonical_frame_id
+    frame = item.get("operative_frame") or {}
+    counterfactual_frame = resolve_alias(frame.get("counterfactual_frame"), taxonomy)
     for frame_id, frame_spec in (taxonomy.get("frames", {}) or {}).items():
         if frame_id == active_frame:
             continue
         for term in frame_spec.get("trigger_terms", []) or []:
             if str(term).lower() in text_lower:
-                result.warn(
-                    "LINT_FRAME_CONTENT_01",
-                    "RC_G4_FRAME_TRIGGER_WARN_001",
-                    f"Trigger term {term!r} suggests frame {frame_id!r}; active frame is {active_frame!r}",
-                )
+                if counterfactual_frame == frame_id:
+                    result.info(
+                        "LINT_FRAME_CONTENT_01",
+                        "RC_G4_FRAME_TRIGGER_INFO_001",
+                        f"Trigger term {term!r} suggests frame {frame_id!r}; counterfactual_frame declares it",
+                    )
+                else:
+                    result.warn(
+                        "LINT_FRAME_CONTENT_01",
+                        "RC_G4_FRAME_TRIGGER_WARN_001",
+                        f"Trigger term {term!r} suggests frame {frame_id!r}; active frame is {active_frame!r}",
+                    )
                 return
 
 
@@ -249,7 +265,7 @@ def lint_item(item: dict[str, Any], taxonomy: dict[str, Any]) -> LintResult:
         check_forbidden_claim_tag(tag, frame_spec, result)
         check_counterfactual_warn(tag, frame, result)
         if item.get("text"):
-            check_trigger_terms_warn_only(item, taxonomy, result)
+            check_trigger_terms(item, taxonomy, result)
 
     return result
 

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """EntaENGELment Frame Lint v0.1.1.
 
-Validates operative_frame declarations for claims/receipts using
+Checks operative_frame declarations for claims/receipts using
 policies/frame_taxonomy_v0_1_1.yml.
 
 v0.1.1 scope:
@@ -22,16 +22,16 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 try:
     import yaml
 except ImportError as e:  # pragma: no cover
-    raise SystemExit("PyYAML is required. Install with: pip install pyyaml") from e
+    raise SystemExit("PyYAML is needed. Install with: pip install pyyaml") from e
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_TAXONOMY = REPO_ROOT / "policies" / "frame_taxonomy_v0_1_1.yml"
-TriggerIndex = Dict[str, List[Tuple[str, str]]]
+TriggerIndex = dict[str, list[tuple[str, str]]]
 
 
 @dataclass
@@ -40,19 +40,19 @@ class Finding:
     rule_id: str
     reason_code: str
     message: str
-    claim_id: Optional[str] = None
-    receipt_id: Optional[str] = None
-    frame_id: Optional[str] = None
-    canonical_frame_id: Optional[str] = None
+    claim_id: str | None = None
+    receipt_id: str | None = None
+    frame_id: str | None = None
+    canonical_frame_id: str | None = None
 
 
 @dataclass
 class LintResult:
-    claim_id: Optional[str] = None
-    receipt_id: Optional[str] = None
-    frame_id: Optional[str] = None
-    canonical_frame_id: Optional[str] = None
-    findings: List[Finding] = field(default_factory=list)
+    claim_id: str | None = None
+    receipt_id: str | None = None
+    frame_id: str | None = None
+    canonical_frame_id: str | None = None
+    findings: list[Finding] = field(default_factory=list)
 
     def add(self, severity: str, rule_id: str, reason_code: str, message: str) -> None:
         self.findings.append(
@@ -86,10 +86,10 @@ def load_yaml(path: Path) -> Any:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
-def canonical_tag_map(taxonomy: Dict[str, Any]) -> Dict[str, str]:
+def canonical_tag_map(taxonomy: dict[str, Any]) -> dict[str, str]:
     config = taxonomy.get("normalization", {}).get("claim_tag_normalization", {})
     tags = config.get("canonical_tags", {})
-    mapping: Dict[str, str] = {}
+    mapping: dict[str, str] = {}
     for canonical, data in tags.items():
         mapping[str(canonical).upper()] = str(canonical)
         for alias in data.get("aliases", []) or []:
@@ -97,25 +97,25 @@ def canonical_tag_map(taxonomy: Dict[str, Any]) -> Dict[str, str]:
     return mapping
 
 
-def normalize_claim_tag(tag: Optional[str], taxonomy: Dict[str, Any]) -> Optional[str]:
+def normalize_claim_tag(tag: str | None, taxonomy: dict[str, Any]) -> str | None:
     if tag is None:
         return None
     return canonical_tag_map(taxonomy).get(str(tag).upper(), str(tag))
 
 
-def resolve_alias(frame_id: Optional[str], taxonomy: Dict[str, Any]) -> Optional[str]:
+def resolve_alias(frame_id: str | None, taxonomy: dict[str, Any]) -> str | None:
     if frame_id is None:
         return None
     aliases = taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
     return aliases.get(frame_id, frame_id)
 
 
-def required_tags(taxonomy: Dict[str, Any]) -> set:
+def required_tags(taxonomy: dict[str, Any]) -> set[str]:
     policy = taxonomy.get("implementation_contract", {}).get("requires_frame_policy", {})
     return {str(tag) for tag in policy.get("required_canonical_tags", []) or []}
 
 
-def build_trigger_index(taxonomy: Dict[str, Any]) -> TriggerIndex:
+def build_trigger_index(taxonomy: dict[str, Any]) -> TriggerIndex:
     """Invert frames[*].trigger_terms once per run.
 
     The returned mapping is lower-case trigger term -> [(frame_id, original_term)].
@@ -130,7 +130,7 @@ def build_trigger_index(taxonomy: Dict[str, Any]) -> TriggerIndex:
     return index
 
 
-def _item_get(item: Dict[str, Any], *keys: str) -> Any:
+def _item_get(item: dict[str, Any], *keys: str) -> Any:
     for key in keys:
         if key in item:
             return item[key]
@@ -138,7 +138,7 @@ def _item_get(item: Dict[str, Any], *keys: str) -> Any:
 
 
 def check_custom_required_fields(
-    frame: Dict[str, Any], taxonomy: Dict[str, Any], result: LintResult
+    frame: dict[str, Any], taxonomy: dict[str, Any], result: LintResult
 ) -> bool:
     policy = taxonomy.get("custom_frame_policy", {})
     ok = True
@@ -147,7 +147,7 @@ def check_custom_required_fields(
             result.fail(
                 "LINT_FRAME_DECL_01",
                 "RC_G6_FRAME_CUSTOM_001",
-                f"CUSTOM frame missing required field: {field_name}",
+                f"CUSTOM frame missing field: {field_name}",
             )
             ok = False
     for field_name in policy.get("warn_required_fields", []) or []:
@@ -160,7 +160,7 @@ def check_custom_required_fields(
     return ok
 
 
-def check_allowed_claim_tag(tag: Optional[str], frame_spec: Dict[str, Any], result: LintResult) -> None:
+def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
     if tag is None:
         return
     perms = frame_spec.get("epistemic_permissions", {})
@@ -177,7 +177,7 @@ def check_allowed_claim_tag(tag: Optional[str], frame_spec: Dict[str, Any], resu
         )
 
 
-def check_forbidden_claim_tag(tag: Optional[str], frame_spec: Dict[str, Any], result: LintResult) -> None:
+def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
     if tag is None:
         return
     perms = frame_spec.get("epistemic_permissions", {})
@@ -193,7 +193,7 @@ def check_forbidden_claim_tag(tag: Optional[str], frame_spec: Dict[str, Any], re
         )
 
 
-def check_counterfactual_warn(tag: Optional[str], frame: Dict[str, Any], result: LintResult) -> None:
+def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: LintResult) -> None:
     if tag == "HYPOTHESE" and not frame.get("counterfactual_frame"):
         result.warn(
             "LINT_FRAME_CONTENT_01",
@@ -203,7 +203,7 @@ def check_counterfactual_warn(tag: Optional[str], frame: Dict[str, Any], result:
 
 
 def check_trigger_terms(
-    item: Dict[str, Any], taxonomy: Dict[str, Any], result: LintResult, trigger_index: TriggerIndex
+    item: dict[str, Any], taxonomy: dict[str, Any], result: LintResult, trigger_index: TriggerIndex
 ) -> None:
     text = str(item.get("text") or "")
     if not text:
@@ -235,7 +235,7 @@ def check_trigger_terms(
 
 
 def lint_item(
-    item: Dict[str, Any], taxonomy: Dict[str, Any], trigger_index: Optional[TriggerIndex] = None
+    item: dict[str, Any], taxonomy: dict[str, Any], trigger_index: TriggerIndex | None = None
 ) -> LintResult:
     if trigger_index is None:
         trigger_index = build_trigger_index(taxonomy)
@@ -253,7 +253,7 @@ def lint_item(
         result.fail(
             "LINT_FRAME_DECL_01",
             "RC_G6_FRAME_001",
-            f"Claim tag {tag!r} requires operative_frame",
+            f"Claim tag {tag!r} needs operative_frame",
         )
         decl_ok = False
 
@@ -297,7 +297,7 @@ def lint_item(
     return result
 
 
-def extract_items(data: Any) -> List[Dict[str, Any]]:
+def extract_items(data: Any) -> list[dict[str, Any]]:
     if isinstance(data, list):
         return [x for x in data if isinstance(x, dict)]
     if isinstance(data, dict):
@@ -316,7 +316,7 @@ def extract_items(data: Any) -> List[Dict[str, Any]]:
     return []
 
 
-def lint_path(path: Path, taxonomy: Dict[str, Any], trigger_index: TriggerIndex) -> List[LintResult]:
+def lint_path(path: Path, taxonomy: dict[str, Any], trigger_index: TriggerIndex) -> list[LintResult]:
     data = load_yaml(path)
     return [lint_item(item, taxonomy, trigger_index) for item in extract_items(data)]
 
@@ -329,7 +329,7 @@ def main() -> int:
 
     taxonomy = load_yaml(Path(args.taxonomy))
     trigger_index = build_trigger_index(taxonomy)
-    results: List[LintResult] = []
+    results: list[LintResult] = []
     for raw_path in args.paths:
         results.extend(lint_path(Path(raw_path), taxonomy, trigger_index))
 

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""EntaENGELment Frame Lint v0.1.1.
+
+Validates operative_frame declarations for claims/receipts using
+policies/frame_taxonomy_v0_1_1.yml.
+
+v0.1.1 scope:
+- tag-based frame requirement only for INFERENZ / HYPOTHESE
+- alias normalization (e.g. MET -> MYTH_ARCHETYPE)
+- declaration validation with item-level short-circuit
+- allowed/forbidden canonical claim tag checks
+- optional trigger-term WARN when item.text is available
+- CUSTOM fail/warn field checks
+
+This tool intentionally does not infer frame requirements from prose body,
+context-boundary crossing, or release/evidence roles. See
+VOID-FRAME-CONTENT-PARSE-001.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError as e:  # pragma: no cover
+    raise SystemExit("PyYAML is required. Install with: pip install pyyaml") from e
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TAXONOMY = REPO_ROOT / "policies" / "frame_taxonomy_v0_1_1.yml"
+
+
+@dataclass
+class Finding:
+    severity: str
+    rule_id: str
+    reason_code: str
+    message: str
+    claim_id: str | None = None
+    receipt_id: str | None = None
+    frame_id: str | None = None
+    canonical_frame_id: str | None = None
+
+
+@dataclass
+class LintResult:
+    claim_id: str | None = None
+    receipt_id: str | None = None
+    frame_id: str | None = None
+    canonical_frame_id: str | None = None
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, severity: str, rule_id: str, reason_code: str, message: str) -> None:
+        self.findings.append(
+            Finding(
+                severity=severity,
+                rule_id=rule_id,
+                reason_code=reason_code,
+                message=message,
+                claim_id=self.claim_id,
+                receipt_id=self.receipt_id,
+                frame_id=self.frame_id,
+                canonical_frame_id=self.canonical_frame_id,
+            )
+        )
+
+    def fail(self, rule_id: str, reason_code: str, message: str) -> None:
+        self.add("FAIL", rule_id, reason_code, message)
+
+    def warn(self, rule_id: str, reason_code: str, message: str) -> None:
+        self.add("WARN", rule_id, reason_code, message)
+
+    def info(self, rule_id: str, reason_code: str, message: str) -> None:
+        self.add("INFO", rule_id, reason_code, message)
+
+    @property
+    def failed(self) -> bool:
+        return any(f.severity == "FAIL" for f in self.findings)
+
+
+def load_yaml(path: Path) -> Any:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def canonical_tag_map(taxonomy: dict[str, Any]) -> dict[str, str]:
+    config = taxonomy.get("normalization", {}).get("claim_tag_normalization", {})
+    tags = config.get("canonical_tags", {})
+    mapping: dict[str, str] = {}
+    for canonical, data in tags.items():
+        mapping[str(canonical).upper()] = str(canonical)
+        for alias in data.get("aliases", []) or []:
+            mapping[str(alias).upper()] = str(canonical)
+    return mapping
+
+
+def normalize_claim_tag(tag: str | None, taxonomy: dict[str, Any]) -> str | None:
+    if tag is None:
+        return None
+    return canonical_tag_map(taxonomy).get(str(tag).upper(), str(tag))
+
+
+def resolve_alias(frame_id: str | None, taxonomy: dict[str, Any]) -> str | None:
+    if frame_id is None:
+        return None
+    aliases = taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
+    return aliases.get(frame_id, frame_id)
+
+
+def required_tags(taxonomy: dict[str, Any]) -> set[str]:
+    policy = taxonomy.get("implementation_contract", {}).get("requires_frame_policy", {})
+    return {str(tag) for tag in policy.get("required_canonical_tags", []) or []}
+
+
+def _item_get(item: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in item:
+            return item[key]
+    return None
+
+
+def check_custom_required_fields(frame: dict[str, Any], taxonomy: dict[str, Any], result: LintResult) -> bool:
+    policy = taxonomy.get("custom_frame_policy", {})
+    ok = True
+    for field_name in policy.get("fail_required_fields", []) or []:
+        if not frame.get(field_name):
+            result.fail(
+                "LINT_FRAME_DECL_01",
+                "RC_G6_FRAME_CUSTOM_001",
+                f"CUSTOM frame missing required field: {field_name}",
+            )
+            ok = False
+    for field_name in policy.get("warn_required_fields", []) or []:
+        if not frame.get(field_name):
+            result.warn(
+                "LINT_FRAME_CONTENT_01",
+                "RC_G6_FRAME_CUSTOM_WARN_001",
+                f"CUSTOM frame missing recommended field: {field_name}",
+            )
+    return ok
+
+
+def check_allowed_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
+    if tag is None:
+        return
+    perms = frame_spec.get("epistemic_permissions", {})
+    allowed = set(perms.get("allowed_claim_tags", []) or [])
+    if allowed and tag not in allowed:
+        result.fail(
+            "LINT_FRAME_CONTENT_01",
+            "RC_G4_FRAME_CONTENT_001",
+            f"Claim tag {tag!r} is not allowed for frame {result.canonical_frame_id!r}",
+        )
+
+
+def check_forbidden_claim_tag(tag: str | None, frame_spec: dict[str, Any], result: LintResult) -> None:
+    if tag is None:
+        return
+    perms = frame_spec.get("epistemic_permissions", {})
+    forbidden = set(perms.get("forbidden_claim_tags", []) or [])
+    if tag in forbidden:
+        result.fail(
+            "LINT_FRAME_CONTENT_01",
+            "RC_G4_FRAME_CONTENT_001",
+            f"Claim tag {tag!r} is forbidden for frame {result.canonical_frame_id!r}",
+        )
+
+
+def check_counterfactual_warn(tag: str | None, frame: dict[str, Any], result: LintResult) -> None:
+    if tag == "HYPOTHESE" and not frame.get("counterfactual_frame"):
+        result.warn(
+            "LINT_FRAME_CONTENT_01",
+            "RC_G4_FRAME_WARN_001",
+            "HYPOTHESE frame declaration should include counterfactual_frame",
+        )
+
+
+def check_trigger_terms_warn_only(item: dict[str, Any], taxonomy: dict[str, Any], result: LintResult) -> None:
+    text = str(item.get("text") or "")
+    if not text:
+        return
+    text_lower = text.lower()
+    active_frame = result.canonical_frame_id
+    for frame_id, frame_spec in (taxonomy.get("frames", {}) or {}).items():
+        if frame_id == active_frame:
+            continue
+        for term in frame_spec.get("trigger_terms", []) or []:
+            if str(term).lower() in text_lower:
+                result.warn(
+                    "LINT_FRAME_CONTENT_01",
+                    "RC_G4_FRAME_TRIGGER_WARN_001",
+                    f"Trigger term {term!r} suggests frame {frame_id!r}; active frame is {active_frame!r}",
+                )
+                return
+
+
+def lint_item(item: dict[str, Any], taxonomy: dict[str, Any]) -> LintResult:
+    claim_id = _item_get(item, "claim_id", "id")
+    receipt_id = _item_get(item, "receipt_id")
+    result = LintResult(claim_id=claim_id, receipt_id=receipt_id)
+
+    tag = normalize_claim_tag(_item_get(item, "claim_tag", "tag"), taxonomy)
+    frame = item.get("operative_frame")
+    frame_required = tag in required_tags(taxonomy)
+    decl_ok = True
+
+    if frame_required and not frame:
+        result.fail(
+            "LINT_FRAME_DECL_01",
+            "RC_G6_FRAME_001",
+            f"Claim tag {tag!r} requires operative_frame",
+        )
+        decl_ok = False
+
+    if frame:
+        original_frame_id = frame.get("frame_id")
+        canonical_frame_id = resolve_alias(original_frame_id, taxonomy)
+        result.frame_id = original_frame_id
+        result.canonical_frame_id = canonical_frame_id
+
+        if canonical_frame_id != original_frame_id:
+            result.info(
+                "FRAME_ALIAS_NORMALIZED",
+                "RC_G6_FRAME_ALIAS_001",
+                f"Frame alias {original_frame_id!r} normalized to {canonical_frame_id!r}",
+            )
+
+        frames = taxonomy.get("frames", {}) or {}
+        if canonical_frame_id not in frames and canonical_frame_id != "CUSTOM":
+            result.fail(
+                "LINT_FRAME_DECL_01",
+                "RC_G6_FRAME_002",
+                f"Unknown frame_id: {original_frame_id!r}",
+            )
+            decl_ok = False
+
+        if canonical_frame_id == "CUSTOM":
+            decl_ok = check_custom_required_fields(frame, taxonomy, result) and decl_ok
+
+    if not decl_ok:
+        return result
+
+    if frame:
+        frames = taxonomy.get("frames", {}) or {}
+        frame_spec = frames.get(result.canonical_frame_id, frames.get("CUSTOM", {}))
+        check_allowed_claim_tag(tag, frame_spec, result)
+        check_forbidden_claim_tag(tag, frame_spec, result)
+        check_counterfactual_warn(tag, frame, result)
+        if item.get("text"):
+            check_trigger_terms_warn_only(item, taxonomy, result)
+
+    return result
+
+
+def extract_items(data: Any) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [x for x in data if isinstance(x, dict)]
+    if isinstance(data, dict):
+        if isinstance(data.get("claims"), list):
+            receipt_id = data.get("receipt_id") or data.get("id")
+            items = []
+            for claim in data["claims"]:
+                if isinstance(claim, dict):
+                    item = dict(claim)
+                    item.setdefault("receipt_id", receipt_id)
+                    if "operative_frame" not in item and "operative_frame" in data:
+                        item["operative_frame"] = data["operative_frame"]
+                    items.append(item)
+            return items
+        return [data]
+    return []
+
+
+def lint_path(path: Path, taxonomy: dict[str, Any]) -> list[LintResult]:
+    data = load_yaml(path)
+    return [lint_item(item, taxonomy) for item in extract_items(data)]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Lint operative_frame declarations")
+    parser.add_argument("paths", nargs="+", help="YAML claim/receipt files to lint")
+    parser.add_argument("--taxonomy", default=str(DEFAULT_TAXONOMY), help="Frame taxonomy YAML")
+    args = parser.parse_args()
+
+    taxonomy = load_yaml(Path(args.taxonomy))
+    results: list[LintResult] = []
+    for raw_path in args.paths:
+        results.extend(lint_path(Path(raw_path), taxonomy))
+
+    has_fail = False
+    for result in results:
+        for finding in result.findings:
+            print(
+                f"{finding.severity} {finding.rule_id} {finding.reason_code} "
+                f"claim={finding.claim_id} receipt={finding.receipt_id} "
+                f"frame={finding.frame_id}->{finding.canonical_frame_id}: {finding.message}"
+            )
+            has_fail = has_fail or finding.severity == "FAIL"
+
+    if not results:
+        print("FRAME LINT: no lintable items")
+    elif has_fail:
+        print("FRAME LINT: FAIL")
+    else:
+        print("FRAME LINT: PASS")
+    return 1 if has_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -107,7 +107,7 @@ def resolve_alias(frame_id: str | None, taxonomy: dict[str, Any]) -> str | None:
     if frame_id is None:
         return None
     aliases = taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
-    return aliases.get(frame_id, frame_id)
+    return str(aliases.get(frame_id, frame_id))
 
 
 def required_tags(taxonomy: dict[str, Any]) -> set[str]:

--- a/tools/frame_lint.py
+++ b/tools/frame_lint.py
@@ -106,12 +106,16 @@ def normalize_claim_tag(tag: str | None, taxonomy: dict[str, Any]) -> str | None
 def resolve_alias(frame_id: str | None, taxonomy: dict[str, Any]) -> str | None:
     if frame_id is None:
         return None
-    aliases = taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
+    aliases = (
+        taxonomy.get("normalization", {}).get("alias_resolution", {}).get("aliases", {})
+    )
     return aliases.get(frame_id, frame_id)
 
 
 def required_tags(taxonomy: dict[str, Any]) -> set[str]:
-    policy = taxonomy.get("implementation_contract", {}).get("requires_frame_policy", {})
+    policy = taxonomy.get("implementation_contract", {}).get(
+        "requires_frame_policy", {}
+    )
     return {str(tag) for tag in policy.get("required_canonical_tags", []) or []}
 
 
@@ -246,7 +250,9 @@ def check_trigger_terms(
 
 
 def lint_item(
-    item: dict[str, Any], taxonomy: dict[str, Any], trigger_index: TriggerIndex | None = None
+    item: dict[str, Any],
+    taxonomy: dict[str, Any],
+    trigger_index: TriggerIndex | None = None,
 ) -> LintResult:
     if trigger_index is None:
         trigger_index = build_trigger_index(taxonomy)
@@ -337,7 +343,9 @@ def lint_path(
 def main() -> int:
     parser = argparse.ArgumentParser(description="Lint operative_frame declarations")
     parser.add_argument("paths", nargs="+", help="YAML claim/receipt files to lint")
-    parser.add_argument("--taxonomy", default=str(DEFAULT_TAXONOMY), help="Frame taxonomy YAML")
+    parser.add_argument(
+        "--taxonomy", default=str(DEFAULT_TAXONOMY), help="Frame taxonomy YAML"
+    )
     args = parser.parse_args()
 
     taxonomy = load_yaml(Path(args.taxonomy))


### PR DESCRIPTION
## Summary

Introduces the first implementation slice for `VOID-FRAME-OPERATOR-001`:

- adds `policies/frame_taxonomy_v0_1_1.yml`
- adds `tools/frame_lint.py`
- adds `tests/unit/test_frame_lint.py`
- records the namespace split in `docs/decisions/DEC-VOID-016-NAMESPACE.yml`

## Scope

v0.1.1 intentionally keeps `requires_frame()` tag-based only:

- `INFERENZ` and `HYPOTHESE` require `operative_frame`
- content-aware frame requirement parsing is deferred to `VOID-FRAME-CONTENT-PARSE-001`
- trigger terms emit WARN only when `item.text` is explicitly present
- alias normalization (`MET -> MYTH_ARCHETYPE`) is recorded as INFO
- declaration failures short-circuit content checks for the current item while the run continues

## Test fixtures

Added fixtures for:

- VALID
- MISSING_FRAME
- WRONG_TAXONOMY
- MET_ALIAS
- TRIGGER_WARN
- CUSTOM_VALID
- CUSTOM_MISSING_REQUIRED
- voluntary FAKT frame validation

## Notes

I did not wire this into `make verify` yet. This PR introduces the isolated linter and tests first so the policy surface can be reviewed before making it a blocking gate.