### PR TITLE
docs: add LOG-ZN orbit RZT operator

### DIFF
--- a/VOIDMAP.yml
+++ b/VOIDMAP.yml
@@ -15,7 +15,7 @@ description: >
 
 metadata:
   maintainer: entaENGELment
-  last_updated: "2026-04-04"
+  last_updated: "2026-05-17"
   generated_doc: docs/voids_backlog.md
 
 voids:
@@ -242,3 +242,22 @@ voids:
       (Projekt/Ökosystem) mit Bedeutung, Beispielen und Verwendungsregeln.
       [CLOSED 2026-03-06] Formale Definition etabliert als Grundlage
       für konsistentes Tagging.
+
+  - id: VOID-LOGZN-001
+    title: "LOG-ZN Orbit als Windungs-Gedächtnisoperator"
+    status: OPEN
+    priority: high
+    owner: "fleks"
+    target_date: null
+    domain: "[MATH][META]"
+    symptom: "Der entwickelte Winkel / log(z)-Orbit ist als neuer RZT-Operator erkannt, aber noch nicht in Tests, Metrics oder Receipts verankert."
+    closing_path: "docs/rzt/LOG_ZN_ORBIT_001.md + docs/tesser3takt/S4_LOGZN_bridge.md + Claim-Tags + optionaler Visual-/Replay-Test"
+    evidence:
+      - "docs/rzt/LOG_ZN_ORBIT_001.md"
+      - "docs/tesser3takt/S4_LOGZN_bridge.md"
+    created: "2026-05-17"
+    closed: null
+    notes: |
+      [FACT] Der komplexe Logarithmus entwickelt einen scheinbar geschlossenen Orbit über die Windungszahl k.
+      [MODEL] Sichtbare Wiederkehr modulo 2π ist nicht identisch mit entwickelter Windungsgeschichte.
+      [INFERENCE] Anschluss an RZT-0, Nektar-Maturation, A4-Reentry und tesser3TAKT/S4 ist prüfbar, aber nicht als Identitätsbehauptung zu lesen.

--- a/docs/rzt/LOG_ZN_ORBIT_001.md
+++ b/docs/rzt/LOG_ZN_ORBIT_001.md
@@ -1,0 +1,147 @@
+# LOG-ZN-ORBIT-001 — Wiederkehr ist nicht Identität
+
+Claim-Tags: [FACT] [MODEL] [INFERENCE] [METAPHOR]
+Status: [ANNEX] — RZT-kompatibler Operator, noch kein empirischer Beweisgang
+
+## 0. Receipt / Scope
+
+Dieses Dokument sedimentiert den Gesprächsknoten `LOG-ZN-ORBIT-001` als präzisen Operator im EntaENGELment-Framework.
+
+Der mathematische Kern ist stabil: der komplexe Logarithmus hebt einen scheinbar geschlossenen Orbit auf eine mehrblättrige Struktur. Die Framework-Lesart bleibt ein Modell: Sie beschreibt Wiederkehr, Windungsgedächtnis und RZT-kompatible Distinktionsdisziplin.
+
+## 1. Mathematischer Kern
+
+[FACT] Für
+
+```math
+z = r e^{i\theta}
+```
+
+gilt der mehrwertige komplexe Logarithmus
+
+```math
+\log z = \ln r + i(\theta + 2\pi k),\quad k \in \mathbb{Z}.
+```
+
+Die sichtbare Kreisposition kann modulo `2π` identisch erscheinen:
+
+```math
+\theta \bmod 2\pi = 0
+```
+
+während der entwickelte Winkel unterschiedliche Windungsstände trägt:
+
+```math
+\theta = 0, 2\pi, 4\pi, 6\pi, \dots
+```
+
+## 2. Framework-Lesart
+
+[MODEL] Der 0-Punkt wird nicht betreten oder besessen, sondern umkreist. Der Orbit um die Mitte ist der operative Vorgang; die Windungszahl ist das Sediment der Umkreisung.
+
+```text
+sichtbarer Kreis        → Wiederkehr
+entwickelter Winkel     → Geschichte
+Windungszahl k          → Integrationsgedächtnis
+0-Punkt                 → unverfügbare Mitte / RZT-0
+```
+
+Kernsatz:
+
+> Der Kreis zeigt die Rückkehr. Der Logarithmus zeigt die Geschichte.
+
+## 3. RZT-Anschluss
+
+[INFERENCE] RZT-0 bezeichnet die unverfügbare Mitte, die Orientierung gibt, ohne besessen zu werden. LOG-ZN-ORBIT operationalisiert diesen Zusammenhang als Umlauf- und Windungsmodell:
+
+```text
+RZT-0 / unverfügbare Mitte
+  → Orbit statt Besitz
+  → Windung statt Reset
+  → entwickelte Rückkehr statt bloßer Wiederholung
+  → mögliche Distinktion nach Claim-Prüfung
+```
+
+Damit entsteht eine scharfe Regel:
+
+> Wiederkehr ist nicht Identität.
+
+Eine Rückkehr an denselben sichtbaren Ort ist nur dann derselbe Zustand, wenn der Windungsstand ignoriert wird. Wird der Winkel entwickelt, trägt jede Umkreisung ein anderes Gedächtnis.
+
+## 4. Nektar- und VOIDMAP-Anschluss
+
+[MODEL] LOG-ZN-ORBIT passt in die bestehende Reifelogik:
+
+```text
+raw_resonance
+  → held_in_nectar
+  → membrane_checked
+  → claim_candidate
+  → VOIDMAP entry or receipt
+```
+
+Eine Windung erzeugt nicht automatisch einen Claim. Sie erzeugt zunächst eine prüfbare Differenz:
+
+- Ist die neue Windung nur dekorative Wiederholung?
+- Verändert sie die Distinktionslage?
+- Braucht sie einen VOID?
+- Braucht sie ein Receipt?
+- Muss sie im Nichtraum gehalten werden?
+
+## 5. Guardrails
+
+[FACT/MODEL] Dieser Operator darf nicht ohne weitere Prüfung mit physikalischen Spinoren, neuronalen Oszillationen, kosmologischen Orbits oder biologischen Zyklen gleichgesetzt werden.
+
+Erlaubt:
+
+- [FACT] mathematische Aussage über den mehrwertigen Logarithmus.
+- [MODEL] RZT-Lesart als Windungsoperator.
+- [INFERENCE] Anschluss an Reentry, Wiederkehr, Nektar-Reifung und VOIDMAP.
+- [METAPHER] poetische Lesart des Kreises als Gedächtnisträger.
+
+Nicht erlaubt:
+
+- stilles Upgrade zur physikalischen Evidenz;
+- Gleichsetzung mit SU(2)-Spinor ohne gesonderten Claim;
+- Gleichsetzung mit tesser3TAKT/S4 ohne Brückendokument;
+- Ontologisierung des 0-Punkts als besitzbares Zentrum.
+
+## 6. Minimaler Anwendungs-Test
+
+Eine Struktur darf als LOG-ZN-Kandidat markiert werden, wenn alle drei Bedingungen erfüllt sind:
+
+1. Es gibt eine sichtbare Wiederkehr oder Repetition.
+2. Es gibt ein entwickelbares Gedächtnis der Wiederkehr.
+3. Die neue Windung verändert die Lesbarkeit des Zustands.
+
+Wenn nur Bedingung 1 erfüllt ist, bleibt es Wiederholung. Wenn 1–3 erfüllt sind, kann ein VOID-, Claim- oder Receipt-Pfad eröffnet werden.
+
+## 7. Repo-Anschluss
+
+Empfohlene Artefakte:
+
+```text
+docs/rzt/LOG_ZN_ORBIT_001.md
+docs/tesser3takt/S4_LOGZN_bridge.md
+VOIDMAP.yml → VOID-LOGZN-001
+```
+
+Empfohlene Prüfungen:
+
+```text
+make verify
+make status
+make snapshot
+```
+
+## 8. Kompakte Formel
+
+```text
+Orbit + Windungszahl = Wiederkehr mit Gedächtnis
+```
+
+```text
+RZT entscheidet, ob daraus eine legitime Distinktion wird.
+VOIDMAP hält die offene Stelle.
+Receipt macht die Setzung verantwortbar.
+```

--- a/docs/tesser3takt/S4_LOGZN_bridge.md
+++ b/docs/tesser3takt/S4_LOGZN_bridge.md
@@ -1,0 +1,140 @@
+# S4 ↔ LOG-ZN Bridge
+
+Claim-Tags: [FACT] [MODEL] [INFERENCE] [HYPOTHESIS]
+Status: [ANNEX] — Brückendokument, keine Identitätsbehauptung
+
+## 0. Problemstellung
+
+Annex F beschreibt `S4` als diskreten Zustandsraum des tesser3TAKT: Permutationsstruktur, Inversionszahl, Cayley-Graph und Phasenübergangslogik.
+
+`LOG-ZN-ORBIT-001` beschreibt dagegen eine kontinuierliche Hebung: Ein scheinbar geschlossener Orbit wird durch den entwickelten Winkel und die Windungszahl `k` zu einer geschichteten Struktur.
+
+Dieses Dokument trennt beide Operatoren sauber und markiert ihren gemeinsamen Nenner.
+
+## 1. Nicht-Gleichsetzung
+
+[FACT] `S4` ist die symmetrische Gruppe auf vier Elementen.
+
+[FACT] `log(z)` ist der mehrwertige komplexe Logarithmus.
+
+[MODEL] Beide können als Gedächtnisoperatoren für Transformation gelesen werden.
+
+Nicht zulässig:
+
+```text
+S4 = log(z)
+log(z) = tesser3TAKT
+tesser3TAKT = physikalischer Spinor
+```
+
+Zulässig:
+
+```text
+S4 und LOG-ZN markieren verschiedene Arten, Transformationsgeschichte nicht als Reset zu behandeln.
+```
+
+## 2. Vergleichsmatrix
+
+| Aspekt | S4 | LOG-ZN |
+|---|---|---|
+| Strukturtyp | diskret | kontinuierlich / mehrblättrig |
+| Grundraum | 24 Permutationen | Orbit um 0 / Branch Point |
+| Gedächtnis | Inversionszahl `inv(π)` / Pfadlänge | Windungszahl `k` |
+| lokale Operation | Transposition / Permutation | Winkelentwicklung |
+| globale Operation | Reordering | Umkreisung |
+| Framework-Funktion | tesser3TAKT-Pulsation zählbar machen | RZT-Orbit/Wiederkehr lesbar machen |
+| Risiko | Überalgebraisierung | Symbolüberdehnung |
+| Testidee | Random Walk / Inversionsverlauf | Orbit-Replay / k-Tracking |
+
+## 3. Gemeinsamer Nenner
+
+[MODEL] Der gemeinsame Nenner ist nicht Geometrie, sondern Gedächtnis:
+
+```text
+Transformation + nichtgelöschte Spur = Zustand mit Geschichte
+```
+
+Bei S4:
+
+```text
+Permutation π + inv(π) = diskretes Reordering-Gedächtnis
+```
+
+Bei LOG-ZN:
+
+```text
+Orbit + k = kontinuierliches Windungs-Gedächtnis
+```
+
+## 4. RZT-Lesart
+
+[INFERENCE] RZT verlangt, dass eine Distinktion ihren Geltungsbereich, ihre Mitte und ihren Setzungsstatus markiert.
+
+S4 erfüllt das für diskrete Zustandswechsel:
+
+```text
+Zustand π → Pfad auf Cayley-Graph → Distanz / Inversion
+```
+
+LOG-ZN erfüllt das für Wiederkehrbewegungen:
+
+```text
+θ mod 2π → sichtbare Wiederkehr
+θ + 2πk → entwickelte Rückkehr
+```
+
+Beide verhindern denselben Fehler:
+
+> Ein scheinbar gleicher Zustand wird nicht automatisch als identisch behandelt.
+
+## 5. Hypothese für tesser3TAKT
+
+[HYPOTHESIS] S4 und LOG-ZN können als zwei komplementäre Leseschichten des tesser3TAKT behandelt werden:
+
+```text
+S4        → lokale Permutations-/Reordering-Schicht
+LOG-ZN    → globale Windungs-/Reentry-Schicht
+```
+
+Möglicher Mapping-Vorschlag:
+
+| tesser3TAKT-Moment | S4-Lesung | LOG-ZN-Lesung |
+|---|---|---|
+| Systole | konkrete Permutation | sichtbarer Orbitpunkt |
+| Diastole | Pfad-/Reordering-Raum | entwickelte Winkelspur |
+| Reentry | neue Permutation / geringere Inversion | neue Windung `k+1` |
+| A4-Bruch | diskontinuierlicher Sprung im Graphen | Branch-/Cut-Konflikt |
+| Receipt | dokumentierte Transformation | gespeicherter Windungsstand |
+
+## 6. Falsifikationspfad
+
+LOG-ZN bleibt ein poetisch-operativer Annex, wenn:
+
+- `k` keine zusätzliche Klassifikationsleistung gegenüber `inv(π)` bringt;
+- Wiederkehrqualitäten besser allein durch S4-Pfade beschrieben werden;
+- keine operationalisierbaren Reentry-Fälle gefunden werden.
+
+LOG-ZN wird als eigener RZT-Operator stärker, wenn:
+
+- Reentry-Fälle existieren, bei denen sichtbare Wiederholung gleich bleibt, aber Windungsstand die Deutung ändert;
+- `k` hilft, A4d/Nektar/Nichtraum-Übergänge zu unterscheiden;
+- ein VOID- oder Receipt-Pfad ohne `k` schlechter auditierbar wäre.
+
+## 7. Minimaler Testfall
+
+```text
+Input: Wiederkehrender Prozess P mit identischer sichtbarer Position X.
+Frage 1: Gibt es einen entwickelbaren Verlauf θ_unwrapped?
+Frage 2: Gibt es einen diskreten Windungszähler k?
+Frage 3: Ändert k die Claim-/VOID-/Receipt-Entscheidung?
+```
+
+Wenn Frage 1–3 positiv sind, ist LOG-ZN operational relevant.
+
+## 8. Schlussformel
+
+```text
+S4 zählt Umordnungen.
+LOG-ZN zählt Umkreisungen.
+RZT entscheidet, ob die gezählte Spur als legitime Distinktion auftreten darf.
+```


### PR DESCRIPTION
## Summary

Adds the LOG-ZN orbit operator as an RZT-compatible ANNEX layer and bridges it to the existing S4/tesser3TAKT permutation layer.

## Changes

- add `docs/rzt/LOG_ZN_ORBIT_001.md`
- add `docs/tesser3takt/S4_LOGZN_bridge.md`
- register `VOID-LOGZN-001` in `VOIDMAP.yml`

## Claim discipline

- mathematical core: `[FACT]` for `log z = ln r + i(θ + 2πk)`
- framework reading: `[MODEL]` / `[INFERENCE]`
- no identity claim between LOG-ZN, S4, tesser3TAKT, spinors, physics, or biology

## Validation

Not run locally in this connector session. Intended follow-up:

```bash
make verify
make status
make snapshot
```
