### PR TITLE
docs(voidmap): deterministic backlog generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DMI ?= 4.7
 PHI ?= 0.72
 REFRACTORY ?= 120
 
-.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -52,6 +52,10 @@ help:
 	@echo ""
 	@echo "Cleanup:"
 	@echo "  make clean           Remove build artifacts and cache"
+	@echo ""
+	@echo "Docs:"
+	@echo "  make voids-backlog       Regenerate docs/voids_backlog.md from VOIDMAP.yml"
+	@echo "  make voids-backlog-check Verify docs/voids_backlog.md is in sync (exit 1 on drift)"
 
 # === Setup ===
 install:
@@ -147,6 +151,14 @@ verify-pointers:
 claim-lint:
 	@echo "=== CLAIM LINT ==="
 	@$(PY) tools/claim_lint.py --scope index,spec,receipts,tools
+
+# Docs generator: regenerate docs/voids_backlog.md from VOIDMAP.yml.
+# Not wired into `verify` — opt-in. Use `voids-backlog-check` for drift detection.
+voids-backlog:
+	@$(PY) tools/voids_backlog_gen.py
+
+voids-backlog-check:
+	@$(PY) tools/voids_backlog_gen.py --check
 
 # Phase 2: STATUS (HMAC Receipt)
 status:

--- a/docs/voids_backlog.md
+++ b/docs/voids_backlog.md
@@ -1,0 +1,48 @@
+# VOIDMAP Backlog
+
+> Auto-generated from `VOIDMAP.yml`. Do not edit by hand.
+> Regenerate via: `python3 tools/voids_backlog_gen.py`
+> Source `last_updated`: 2026-05-17
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| OPEN | 1 |
+| IN_PROGRESS | 2 |
+| SUSPENDED | 1 |
+| CLOSED | 9 |
+| **Total** | **13** |
+
+## OPEN
+
+| ID | Title | Priority | Owner | Domain | Target | Symptom |
+|---|---|---|---|---|---|---|
+| VOID-LOGZN-001 | LOG-ZN Orbit als Windungs-Gedächtnisoperator | high | fleks | [MATH][META] | — | Der entwickelte Winkel / log(z)-Orbit ist als neuer RZT-Operator erkannt, aber noch nicht in Tests, Metrics oder Receipts verankert. |
+
+## IN_PROGRESS
+
+| ID | Title | Priority | Owner | Domain | Target | Symptom |
+|---|---|---|---|---|---|---|
+| VOID-010 | Taxonomie & Spektren (Empirie) | high | fleks | [PHYS] | 2026-06-01 | Spektrale Zuordnung ohne belastbare Literatur-/Datenbasis |
+| VOID-011 | Metriken der Resonanz (MI, PLV, FD) | high | fleks | [MATH] | 2026-06-01 | MI/FD waren Minimal-Stubs; Toy-Simulation als Proof noch ausstehend |
+
+## SUSPENDED
+
+| ID | Title | Priority | Owner | Domain | Target | Symptom |
+|---|---|---|---|---|---|---|
+| VOID-014 | Protein-Design (in-silico, safety-bounded) | medium | fleks | [BIO] | — | Exploration gewünscht, aber hohes Risiko bei operativen Laboranleitungen |
+
+## CLOSED (chronological, newest first)
+
+| ID | Title | Closed | Evidence |
+|---|---|---|---|
+| VOID-003 | Status Emit Receipt Format | 2026-03-06 | tools/status_emit.py |
+| VOID-012 | GateProof Checkliste (Governance) | 2026-03-06 | policies/gateproof_v1.yaml, tests/ethics/test_fail_safe_expired_consent.py |
+| VOID-013 | Sensor-Architektur (BOM & Protokoll) | 2026-03-06 | docs/sensors/bom.md, spec/sensors.spec.json |
+| VOID-023 | MICRO/MESO/MACRO Tagging konsistent ausrollen | 2026-03-06 | policies/port_codebooks.yaml |
+| VOID-002 | CI Pipeline Integration | 2026-02-15 | .github/workflows/deepjump-ci.yml |
+| VOID-020 | Port-Matrix Suite (K0..K4) fehlt | 2026-01-13 | tools/port_lint.py, tests/test_port_lint.py |
+| VOID-021 | Port-Codebooks fehlen | 2026-01-13 | policies/port_codebooks.yaml |
+| VOID-022 | Flood-Guard Threshold fehlt (MAX_CLAIMS_PER_RECEIPT) | 2026-01-13 | tools/port_lint.py |
+| VOID-001 | DeepJump Protocol Implementation | 2026-01-04 | — |

--- a/tools/voids_backlog_gen.py
+++ b/tools/voids_backlog_gen.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""VOIDMAP Backlog Generator.
+
+Reads VOIDMAP.yml and emits a deterministic Markdown backlog document.
+
+Usage:
+    python3 tools/voids_backlog_gen.py [--source VOIDMAP.yml]
+                                       [--out docs/voids_backlog.md]
+                                       [--check]
+
+In --check mode, the script compares the freshly generated output against
+the existing file and exits with code 1 if they differ. Otherwise the file
+is written (creating parent directories as needed).
+
+The output ordering is deterministic:
+- Groups: OPEN, IN_PROGRESS, SUSPENDED, CLOSED, OTHER (if any).
+- OPEN/IN_PROGRESS/SUSPENDED/OTHER: sorted by ID ascending (string sort).
+- CLOSED: sorted by close date descending; within same date by ID ascending
+  (stable sort).
+
+Missing fields render as an em-dash (—). External network access is not used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("[ERROR] PyYAML required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SOURCE = REPO_ROOT / "VOIDMAP.yml"
+DEFAULT_OUT = REPO_ROOT / "docs" / "voids_backlog.md"
+
+STATUS_ORDER = ["OPEN", "IN_PROGRESS", "SUSPENDED", "CLOSED"]
+EMPTY = "—"
+
+
+def cell(value: Any) -> str:
+    """Render a value as a Markdown-safe table cell."""
+    if value is None or value == "":
+        return EMPTY
+    if isinstance(value, list):
+        if not value:
+            return EMPTY
+        rendered = ", ".join(str(v) for v in value)
+    else:
+        rendered = str(value)
+    rendered = rendered.replace("\r", "")
+    first_line = next((ln for ln in rendered.split("\n") if ln.strip()), "")
+    first_line = first_line.strip()
+    if not first_line:
+        return EMPTY
+    return first_line.replace("|", r"\|")
+
+
+def load_voidmap(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"VOIDMAP source is not a YAML mapping: {path}")
+    return data
+
+
+def group_voids(voids: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = {s: [] for s in STATUS_ORDER}
+    other: list[dict[str, Any]] = []
+    for v in voids:
+        if not isinstance(v, dict):
+            continue
+        status = str(v.get("status") or "").upper()
+        if status in groups:
+            groups[status].append(v)
+        else:
+            other.append(v)
+    if other:
+        groups["OTHER"] = other
+    return groups
+
+
+def sort_by_id(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(items, key=lambda v: str(v.get("id") or ""))
+
+
+def sort_closed(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_id = sorted(items, key=lambda v: str(v.get("id") or ""))
+    return sorted(by_id, key=lambda v: str(v.get("closed") or ""), reverse=True)
+
+
+def render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "_No entries._\n"
+    lines = ["| " + " | ".join(headers) + " |", "|" + "|".join(["---"] * len(headers)) + "|"]
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines) + "\n"
+
+
+def render_active_table(items: list[dict[str, Any]]) -> str:
+    headers = ["ID", "Title", "Priority", "Owner", "Domain", "Target", "Symptom"]
+    rows = [
+        [
+            cell(v.get("id")),
+            cell(v.get("title")),
+            cell(v.get("priority")),
+            cell(v.get("owner")),
+            cell(v.get("domain")),
+            cell(v.get("target_date")),
+            cell(v.get("symptom")),
+        ]
+        for v in items
+    ]
+    return render_table(headers, rows)
+
+
+def render_closed_table(items: list[dict[str, Any]]) -> str:
+    headers = ["ID", "Title", "Closed", "Evidence"]
+    rows = [
+        [
+            cell(v.get("id")),
+            cell(v.get("title")),
+            cell(v.get("closed")),
+            cell(v.get("evidence")),
+        ]
+        for v in items
+    ]
+    return render_table(headers, rows)
+
+
+def render_document(data: dict[str, Any], source_rel: str) -> str:
+    metadata = data.get("metadata") or {}
+    last_updated = metadata.get("last_updated") or ""
+    voids_raw = data.get("voids") or []
+    voids = voids_raw if isinstance(voids_raw, list) else []
+
+    groups = group_voids(voids)
+
+    out: list[str] = []
+    out.append("# VOIDMAP Backlog")
+    out.append("")
+    out.append(f"> Auto-generated from `{source_rel}`. Do not edit by hand.")
+    out.append("> Regenerate via: `python3 tools/voids_backlog_gen.py`")
+    if last_updated:
+        out.append(f"> Source `last_updated`: {last_updated}")
+    out.append("")
+
+    out.append("## Summary")
+    out.append("")
+    out.append("| Status | Count |")
+    out.append("|--------|-------|")
+    for s in STATUS_ORDER:
+        out.append(f"| {s} | {len(groups.get(s, []))} |")
+    if "OTHER" in groups:
+        out.append(f"| OTHER | {len(groups['OTHER'])} |")
+    out.append(f"| **Total** | **{len(voids)}** |")
+    out.append("")
+
+    out.append("## OPEN")
+    out.append("")
+    out.append(render_active_table(sort_by_id(groups.get("OPEN", []))).rstrip("\n"))
+    out.append("")
+
+    out.append("## IN_PROGRESS")
+    out.append("")
+    out.append(render_active_table(sort_by_id(groups.get("IN_PROGRESS", []))).rstrip("\n"))
+    out.append("")
+
+    out.append("## SUSPENDED")
+    out.append("")
+    out.append(render_active_table(sort_by_id(groups.get("SUSPENDED", []))).rstrip("\n"))
+    out.append("")
+
+    out.append("## CLOSED (chronological, newest first)")
+    out.append("")
+    out.append(render_closed_table(sort_closed(groups.get("CLOSED", []))).rstrip("\n"))
+    out.append("")
+
+    if "OTHER" in groups:
+        out.append("## OTHER (unrecognized status)")
+        out.append("")
+        out.append(render_active_table(sort_by_id(groups["OTHER"])).rstrip("\n"))
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate docs/voids_backlog.md from VOIDMAP.yml (deterministic).",
+    )
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE,
+                        help=f"Source VOIDMAP file (default: {DEFAULT_SOURCE.relative_to(REPO_ROOT)})")
+    parser.add_argument("--out", type=Path, default=DEFAULT_OUT,
+                        help=f"Output Markdown file (default: {DEFAULT_OUT.relative_to(REPO_ROOT)})")
+    parser.add_argument("--check", action="store_true",
+                        help="Compare current output against existing file; exit 1 on drift.")
+    args = parser.parse_args(argv)
+
+    source: Path = args.source
+    out_path: Path = args.out
+
+    if not source.exists():
+        print(f"[ERROR] Source not found: {source}", file=sys.stderr)
+        return 2
+
+    data = load_voidmap(source)
+    try:
+        source_rel = str(source.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        source_rel = str(source)
+    rendered = render_document(data, source_rel)
+
+    if args.check:
+        if not out_path.exists():
+            print(f"[CHECK] Output missing: {out_path}", file=sys.stderr)
+            return 1
+        existing = out_path.read_text(encoding="utf-8")
+        if existing != rendered:
+            print(f"[CHECK] Drift detected: {out_path}", file=sys.stderr)
+            return 1
+        print(f"[CHECK] Up to date: {out_path}")
+        return 0
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+    print(f"[OK] Wrote {out_path} ({len(rendered)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/voids_backlog_gen.py
+++ b/tools/voids_backlog_gen.py
@@ -96,7 +96,10 @@ def sort_closed(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def render_table(headers: list[str], rows: list[list[str]]) -> str:
     if not rows:
         return "_No entries._\n"
-    lines = ["| " + " | ".join(headers) + " |", "|" + "|".join(["---"] * len(headers)) + "|"]
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "|" + "|".join(["---"] * len(headers)) + "|",
+    ]
     for row in rows:
         lines.append("| " + " | ".join(row) + " |")
     return "\n".join(lines) + "\n"
@@ -194,12 +197,23 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Generate docs/voids_backlog.md from VOIDMAP.yml (deterministic).",
     )
-    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE,
-                        help=f"Source VOIDMAP file (default: {DEFAULT_SOURCE.relative_to(REPO_ROOT)})")
-    parser.add_argument("--out", type=Path, default=DEFAULT_OUT,
-                        help=f"Output Markdown file (default: {DEFAULT_OUT.relative_to(REPO_ROOT)})")
-    parser.add_argument("--check", action="store_true",
-                        help="Compare current output against existing file; exit 1 on drift.")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=DEFAULT_SOURCE,
+        help=f"Source VOIDMAP file (default: {DEFAULT_SOURCE.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"Output Markdown file (default: {DEFAULT_OUT.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compare current output against existing file; exit 1 on drift.",
+    )
     args = parser.parse_args(argv)
 
     source: Path = args.source


### PR DESCRIPTION
SAFE_TEST_PATCH (Slice 2a) — VOIDMAP-Backlog-Generator.

Changes:
- `tools/voids_backlog_gen.py`: deterministic Markdown generator (yaml.safe_load only, no network)
- `docs/voids_backlog.md`: first generated artifact (13 VOIDs: 1 OPEN / 2 IN_PROGRESS / 1 SUSPENDED / 9 CLOSED)
- `Makefile`: opt-in targets `voids-backlog` and `voids-backlog-check`

Resolves the dead pointer at `VOIDMAP.yml:13` (`metadata.generated_doc: docs/voids_backlog.md`) without modifying the GOLD source.

Not changed:
- `VOIDMAP.yml` (read-only)
- `policies/`, `index/`, `data/receipts/`
- no `.github/workflows/` changes
- not wired into `make verify` or CI
- no release/tag actions

Determinism:
- Groups: OPEN, IN_PROGRESS, SUSPENDED, CLOSED, (OTHER)
- Active groups: sort by id (asc)
- CLOSED: sort by close date (desc), id (asc) via stable sort
- Idempotent: rerun produces byte-identical output

Local checks (READ_PROXY):
- [x] `python3 tools/voids_backlog_gen.py` → wrote 2295 bytes
- [x] re-run → `git diff` empty (idempotent)
- [x] `python3 tools/voids_backlog_gen.py --check` → exit 0
- [x] `python3 tools/verify_pointers.py --strict` → exit 0 (core green)
- [x] `make help` shows both targets

---

FOKUS: VOIDMAP-Backlog-Generator

Merge-Kriterium: alle laufenden CI-Checks grün, keine neuen Review-Kommentare.

https://claude.ai/code/session_016nkuKiFyHBhHfdju1DpEmj

---
_Generated by [Claude Code](https://claude.ai/code/session_016nkuKiFyHBhHfdju1DpEmj)_