### PR TITLE
test(logzn): executable evidence for VOID-LOGZN-001 substrate

### DIFF
--- a/tests/unit/test_logzn_orbit.py
+++ b/tests/unit/test_logzn_orbit.py
@@ -1,0 +1,65 @@
+# ruff: noqa: I001
+"""Minimal executable evidence for VOID-LOGZN-001.
+
+Slice S-3a. These tests do not claim the RZT/LOG-ZN operator as such; they
+only show that the mathematical substrate described in
+docs/rzt/LOG_ZN_ORBIT_001.md is reachable and behaves as written in the
+underlying stdlib/numpy primitives.
+
+Semantic status:
+- VOID-LOGZN-001 remains formally OPEN.
+- Evidence position shifts: docs-only -> executable evidence present.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+
+import numpy as np
+
+
+def test_cmath_log_branch_cut_orientation() -> None:
+    # Two points infinitesimally above and below the negative real axis.
+    eps = 1e-12
+    above = cmath.log(complex(-1.0, eps))
+    below = cmath.log(complex(-1.0, -eps))
+
+    # Real parts: |z| = 1 on both sides -> ln(1) = 0.
+    assert math.isclose(above.real, 0.0, abs_tol=1e-9)
+    assert math.isclose(below.real, 0.0, abs_tol=1e-9)
+
+    # Imaginary parts land on opposite sides of the principal branch cut:
+    # above -> +pi, below -> -pi.
+    assert math.isclose(above.imag, math.pi, abs_tol=1e-6)
+    assert math.isclose(below.imag, -math.pi, abs_tol=1e-6)
+
+    # Therefore the two log values straddle the cut; their difference
+    # is approximately 2*pi in the imaginary direction.
+    assert math.isclose(above.imag - below.imag, 2.0 * math.pi, abs_tol=1e-6)
+
+
+def test_phase_unwrap_tracks_winding_number() -> None:
+    # Two full continuous revolutions: theta sweeps 0 -> 4*pi.
+    n = 401
+    theta = np.linspace(0.0, 4.0 * math.pi, n)
+
+    # numpy.angle on exp(i*theta) wraps into (-pi, pi]; numpy.unwrap should
+    # recover the underlying continuous phase without 2*pi jumps.
+    wrapped = np.angle(np.exp(1j * theta))
+    unwrapped = np.unwrap(wrapped)
+
+    # Wrapped signal carries at least one 2*pi discontinuity (the visible
+    # return to the same circle position).
+    max_wrapped_jump = float(np.max(np.abs(np.diff(wrapped))))
+    assert max_wrapped_jump > math.pi
+
+    # Unwrapped signal is monotone in the small step regime and has no
+    # 2*pi discontinuity.
+    max_unwrapped_jump = float(np.max(np.abs(np.diff(unwrapped))))
+    assert max_unwrapped_jump < math.pi
+
+    # Total developed phase recovers the input range up to numpy.unwrap's
+    # constant offset; the span equals 4*pi (= winding number 2 * 2*pi).
+    span = float(unwrapped[-1] - unwrapped[0])
+    assert math.isclose(span, 4.0 * math.pi, abs_tol=1e-6)


### PR DESCRIPTION
SAFE_TEST_PATCH (Slice S-3a) — executable evidence for VOID-LOGZN-001 substrate.

Base SHA: `c2b170df3f125cb248ee50739fa75a0442233816` (main, post-merge of #194/RC-preflight docs).

## Changes

- New: `tests/unit/test_logzn_orbit.py` with two minimal tests:
  1. `test_cmath_log_branch_cut_orientation` — `cmath.log(-1 + i*eps)` vs. `cmath.log(-1 - i*eps)` land on opposite sides of the principal branch cut (Im ≈ +π vs. ≈ -π), difference ≈ 2π.
  2. `test_phase_unwrap_tracks_winding_number` — continuous phase 0 → 4π via `numpy.angle ∘ exp(iθ)` is reconstructed by `numpy.unwrap` without 2π jumps; total developed span = 4π = two windings.

## What this proves

- The mathematical substrate described in `docs/rzt/LOG_ZN_ORBIT_001.md` §1 is reachable and behaves as written in stdlib/numpy primitives.
- VOID-LOGZN-001 moves from purely-documentary to having executable test evidence.

## What this does NOT prove

- No claim about RZT-0, nektar maturation, A4-reentry, spinor identity, or any framework-level operator equivalence.
- No empirical validation of the LOG-ZN operator as such — only its mathematical substrate.

## Semantic status

VOID-LOGZN-001 remains **formally OPEN**. Evidence position shifts:

> docs-only → executable evidence present

Closing is a separate decision and not the goal of this slice. Closing would require evidence that `k` (winding number) yields a distinction beyond what is recoverable from `inv(π)` or other simpler operators — out of scope here.

## Not changed

- `VOIDMAP.yml` — no status edit to CLOSED, no `last_updated` bump
- `docs/voids_backlog.md` — no regeneration
- `docs/rzt/LOG_ZN_ORBIT_001.md` — no new doc claim
- `data/receipts/` — no receipt
- `Makefile`, `.github/workflows/`, release files — untouched
- orphan branch `claude/repo-maintenance-audit-mnZVm` — no pickup, no rebase, no force-push

## Local checks

- `ruff check tests/unit/test_logzn_orbit.py` → All checks passed
- `black --check tests/unit/test_logzn_orbit.py` → would leave unchanged
- `pytest tests/unit/test_logzn_orbit.py -v` → 2 passed in 0.13s

---

FOKUS: S-3a VOID-LOGZN-001 minimal test

Merge-Kriterium: alle laufenden CI-Checks grün, keine neuen Review-Kommentare.

https://claude.ai/code/session_016nkuKiFyHBhHfdju1DpEmj

---
_Generated by [Claude Code](https://claude.ai/code/session_016nkuKiFyHBhHfdju1DpEmj)_