### PR TITLE
docs: add reentry save-state frame

### DIFF
--- a/docs/analysis/reentry_save_state_v1.md
+++ b/docs/analysis/reentry_save_state_v1.md
@@ -1,0 +1,88 @@
+# EntaENGELment · Recursive Reentry Save State v1
+
+Created: 2026-05-20  
+Source: uploaded `entaengelment_reentry_save_state_v1.zip`  
+Status: GO_conservative_hold_50
+
+## Kurzverdichtung
+
+Dieser Reentry-State bündelt den Übergang von der Upload-Landkarte zurück ins Live-Repository `fleksible/entaENGELment-`.
+
+Die konsolidierten Achsen sind:
+
+1. Governance-Gate: GateOpen nur bei Consent, Ethik, No-Override, Normierung, Lock und Twin-Pass.
+2. Perzeptive Kontrolle: ABX, CJ, Maxwell, Delta-Fenster, adaptiver Refraktär, EAMW.
+3. Post-symbolischer Innenraum: Nektar-Synapsen-Raum und Synthosia als imaginale UI-Schicht.
+4. Aperiodische Struktur: Penrose, Quasikristall, Tissot, Hopf, 72/720 als Formlogik.
+5. Auditierbarkeit: DeepJump, Receipts, Badges, Verify, Status, Snapshot, Ledger.
+
+## Current hold
+
+Primärer Engpass: ABX-Long-Tail in Delta-Randzonen.  
+Primärer nächster Hebel: ABX-tail posterior, TwinPass epsilon_I und Save-State Cards im Repo.
+
+## Gefestigter State
+
+- Quadratur v4 ist Master-Composite.
+- CP-pi-Cancer-beta+ ist Gate-/DF-Kern.
+- DeepJump ist Repo-/Audit-Kern.
+- CephaloCamouflage bleibt Referenz für Statistik-Resonanz, nicht für ungeprüfte Mimikry-Claims.
+- ACK-Triade ist Moduswechsel-Gate.
+- Quanterion K/C/E/M ist UI-/Reward-Dial.
+- Nektar-Synapsen-Raum ist innerer Tiefenkern.
+- Synthosia ist späterer UI-/XR-Raum, aktuell nur Tor-Rahmen.
+- ABX-Long-Tail bleibt Hauptengpass.
+- Repo-Entwicklung folgt Verify-Before-Merge.
+
+## Aktueller Schwebezustand
+
+Nicht XR bauen. Zuerst den inneren Tor-Rahmen ins Repo hängen:
+
+- `docs/runbooks/inner_gate_frame.md`
+- `docs/spec/synthosia_scope.md`
+- `cards/templates/*.json`
+- `tools/verify_cards.py`
+
+## Reentry vector
+
+```yaml
+version: reentry_save_state_v1
+created_at: "2026-05-20T16:21:42"
+repo_target: fleksible/entaENGELment-
+current_status: GO_conservative_hold_50
+floating_problem: "Attach inner gate frame and save-state cards to repo without prematurely building XR."
+next_actions:
+  - id: A1
+    title: Add recursive save state docs
+    paths:
+      - docs/analysis/reentry_save_state_v1.md
+      - docs/runbooks/inner_gate_frame.md
+      - docs/spec/synthosia_scope.md
+  - id: A2
+    title: Mirror voids into VOIDMAP after collision check
+    paths:
+      - VOIDMAP.yml
+  - id: A3
+    title: Add card verifier
+    paths:
+      - tools/verify_cards.py
+      - cards/templates/*.json
+```
+
+## Kenogrammatic open knots
+
+The uploaded save state names these open knots for later VOIDMAP handling. They are recorded here first instead of being blindly merged into `VOIDMAP.yml`:
+
+| Knot | Meaning | Proposed target |
+|---|---|---|
+| K-Hopf-01 | chi/theta transport proof sketch | `docs/spec/hopf_transport.md` |
+| K-Hel-02 | Helicity to gate mapping | `docs/spec/helicity_gate_mapping.md` |
+| ABX-Tail-Prior | Hierarchical posterior for ABX long-tail near delta edges | `metrics/abx_tail_posterior.py` |
+| TwinPass-epsilon-I | Calibrate MI threshold for Twin-Pass independence | `audit/twinpass_v1.yaml` |
+| Nectar-R-Star | Define post-symbolic resonance quality metric R* | `cards/templates/nectar_attune.json` |
+| Rubedo-Stop | Redline HOLD policy for hue/load/ABX stress | `policies/rubedo_stop.yaml` |
+| Synthosia-Scope | Keep Synthosia as inner gate frame before XR build | `docs/spec/synthosia_scope.md` |
+
+## Resumption prompt
+
+Open `docs/analysis/reentry_save_state_v1.md`, then `docs/runbooks/inner_gate_frame.md`. Check `VOIDMAP.yml` before adding new K-voids. Next safe task: `tools/verify_cards.py` or `cards/templates/ack_triade.json`, not XR.

--- a/docs/runbooks/inner_gate_frame.md
+++ b/docs/runbooks/inner_gate_frame.md
@@ -1,0 +1,44 @@
+# Inner Gate Frame · Nektar/Synthosia
+
+Status: inner frame only; not an XR build.
+
+## Scope
+
+Synthosia is carried as an inner gate frame before any implementation work. The frame is intended to stabilize attention, closure, and re-entry before UI, XR, bio-feedback, or live-control layers are considered.
+
+## Daily 12-minute loop
+
+1. Arrive — 3 minutes.
+2. Focus — 4 minutes.
+3. Re-entry — 3 minutes.
+4. Closure — 2 minutes.
+
+## Inner-GO
+
+Inner-GO is reached only after three consecutive days with all three signals at or above 2:
+
+- K >= 2
+- C >= 2
+- E >= 2
+
+Until then, the state remains HOLD / observation.
+
+## HOLD markers
+
+Pause the loop when any of the following appears:
+
+- shallow breath
+- tunnel vision
+- semantic friction
+- pressure to build prematurely
+
+HOLD action:
+
+1. Pause.
+2. Widen peripheral view.
+3. Write a one-word log.
+4. Do not convert the state into implementation work.
+
+## Boundary
+
+This runbook does not authorize XR, bio-feedback, live steering, or autonomous control. It is a small re-entry ritual and a repository anchor for later, better-scoped work.

--- a/docs/spec/synthosia_scope.md
+++ b/docs/spec/synthosia_scope.md
@@ -1,0 +1,28 @@
+# Synthosia Scope
+
+## Status
+
+Do not implement Synthosia as XR/UI yet. Keep it as an inner gate frame until the re-entry loop has stable evidence.
+
+## Included concepts
+
+- 7x9 Matrix
+- Hopf spirals
+- central resonance point
+- phase gate
+- vertigo mirror
+- moss-mycelium navigation
+- re-entry echo
+- third presence
+
+## Boundary
+
+No XR engine, no bio-feed, no live steering, and no production control layer before Inner-GO is stable.
+
+## Required before implementation
+
+- a stable three-day Inner-GO run
+- explicit scope update
+- VOIDMAP entry or issue for the chosen implementation slice
+- tests or acceptance criteria for the slice
+- clear separation between metaphor, model, and measured evidence


### PR DESCRIPTION
## Summary

Adds a conservative reentry documentation slice from the uploaded save-state context:

- `docs/analysis/reentry_save_state_v1.md`
- `docs/runbooks/inner_gate_frame.md`
- `docs/spec/synthosia_scope.md`

## Scope

Docs-only. No changes to `main` logic, workflows, UI, dependencies, receipts, or immutable audit data.

## Rationale

This anchors the current reentry context in the repository without prematurely importing the full upload patch or starting Synthosia/XR implementation.

## Validation

Connector compare shows only three added Markdown files. No code execution required for docs-only slice.
