### PR TITLE
cards: add save-state card templates and verifier

### DIFF
--- a/cards/README.md
+++ b/cards/README.md
@@ -1,0 +1,21 @@
+# Save-State Cards
+
+Status: lightweight templates and verifier only.
+
+This folder stores small JSON templates for re-entry and inner-gate work. They are intentionally separate from immutable receipts and from `data/receipts/`.
+
+## Verify
+
+```bash
+python3 tools/verify_cards.py cards/templates
+```
+
+Expected signal:
+
+```text
+VERIFY CARDS: PASS (5 cards)
+```
+
+## Boundary
+
+Cards are working artifacts. They are not evidence receipts, not clinical records, and not implementation approval for Synthosia/XR.

--- a/cards/templates/ack_triade.json
+++ b/cards/templates/ack_triade.json
@@ -1,0 +1,13 @@
+{
+  "card_type": "ack_triade",
+  "timestamp": "2026-05-20T16:21:42",
+  "fields": {
+    "ack_me": "",
+    "ack_mensch": "",
+    "ack_sys": "",
+    "body_signal": "",
+    "rationale": "",
+    "mode_from": "",
+    "mode_to": ""
+  }
+}

--- a/cards/templates/nectar_attune.json
+++ b/cards/templates/nectar_attune.json
@@ -1,0 +1,11 @@
+{
+  "card_type": "nectar_attune",
+  "timestamp": "2026-05-20T16:21:42",
+  "fields": {
+    "signal": "",
+    "texture": "",
+    "intensity": 0,
+    "boundary": "",
+    "next_hold": ""
+  }
+}

--- a/cards/templates/reentry_vector.json
+++ b/cards/templates/reentry_vector.json
@@ -1,0 +1,10 @@
+{
+  "card_type": "reentry_vector",
+  "timestamp": "2026-05-20T16:21:42",
+  "fields": {
+    "status": "GO_conservative_hold_50",
+    "current_hold": "Attach save-state cards without importing full upload patch or building XR.",
+    "next_action": "Run verify_cards and then decide VOIDMAP collision handling.",
+    "source_doc": "docs/analysis/reentry_save_state_v1.md"
+  }
+}

--- a/cards/templates/rubedo_stop.json
+++ b/cards/templates/rubedo_stop.json
@@ -1,0 +1,11 @@
+{
+  "card_type": "rubedo_stop",
+  "timestamp": "2026-05-20T16:21:42",
+  "fields": {
+    "marker": "",
+    "hue_load": 0,
+    "abx_stress": 0,
+    "hold_reason": "",
+    "next_safe_action": ""
+  }
+}

--- a/cards/templates/synthosia_scope.json
+++ b/cards/templates/synthosia_scope.json
@@ -1,0 +1,24 @@
+{
+  "card_type": "synthosia_scope",
+  "timestamp": "2026-05-20T16:21:42",
+  "fields": {
+    "gate": "inner_frame_only",
+    "included_concepts": [
+      "7x9 matrix",
+      "Hopf spirals",
+      "central resonance point",
+      "phase gate",
+      "vertigo mirror",
+      "moss-mycelium navigation",
+      "re-entry echo",
+      "third presence"
+    ],
+    "forbidden_actions": [
+      "XR build",
+      "bio-feed integration",
+      "live steering",
+      "production control"
+    ],
+    "go_condition": "stable Inner-GO evidence before implementation"
+  }
+}

--- a/tools/verify_cards.py
+++ b/tools/verify_cards.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Verify save-state card templates.
+
+This checker intentionally uses only the Python standard library. It validates
+small JSON templates under cards/templates/ without treating them as immutable
+receipts or runtime evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ISO_LIKE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+REQUIRED_FIELDS: dict[str, set[str]] = {
+    "ack_triade": {
+        "ack_me",
+        "ack_mensch",
+        "ack_sys",
+        "body_signal",
+        "rationale",
+        "mode_from",
+        "mode_to",
+    },
+    "nectar_attune": {
+        "signal",
+        "texture",
+        "intensity",
+        "boundary",
+        "next_hold",
+    },
+    "rubedo_stop": {
+        "marker",
+        "hue_load",
+        "abx_stress",
+        "hold_reason",
+        "next_safe_action",
+    },
+    "synthosia_scope": {
+        "gate",
+        "included_concepts",
+        "forbidden_actions",
+        "go_condition",
+    },
+    "reentry_vector": {
+        "status",
+        "current_hold",
+        "next_action",
+        "source_doc",
+    },
+}
+
+
+def load_json(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, [f"{path}: invalid JSON: {exc}"]
+    except OSError as exc:
+        return None, [f"{path}: read error: {exc}"]
+
+    if not isinstance(data, dict):
+        return None, [f"{path}: top-level JSON value must be an object"]
+    return data, []
+
+
+def validate_card(path: Path) -> list[str]:
+    data, errors = load_json(path)
+    if data is None:
+        return errors
+
+    for key in ("card_type", "timestamp", "fields"):
+        if key not in data:
+            errors.append(f"{path}: missing top-level key: {key}")
+
+    card_type = data.get("card_type")
+    timestamp = data.get("timestamp")
+    fields = data.get("fields")
+
+    if not isinstance(card_type, str) or not card_type:
+        errors.append(f"{path}: card_type must be a non-empty string")
+        return errors
+
+    if card_type not in REQUIRED_FIELDS:
+        allowed = ", ".join(sorted(REQUIRED_FIELDS))
+        errors.append(f"{path}: unknown card_type {card_type!r}; allowed: {allowed}")
+        return errors
+
+    if not isinstance(timestamp, str) or not ISO_LIKE.search(timestamp):
+        errors.append(f"{path}: timestamp must be an ISO-like string")
+
+    if not isinstance(fields, dict):
+        errors.append(f"{path}: fields must be an object")
+        return errors
+
+    required = REQUIRED_FIELDS[card_type]
+    missing = sorted(required - set(fields))
+    if missing:
+        errors.append(f"{path}: missing fields: {', '.join(missing)}")
+
+    for field_name, value in fields.items():
+        if isinstance(value, (dict, list, str, int, float, bool)) or value is None:
+            continue
+        errors.append(f"{path}: field {field_name!r} has unsupported type")
+
+    return errors
+
+
+def iter_cards(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root]
+    return sorted(root.rglob("*.json"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Verify save-state card JSON templates")
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="cards/templates",
+        help="Card file or directory to verify (default: cards/templates)",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.path)
+    if not root.exists():
+        print(f"VERIFY CARDS: FAIL\n- path does not exist: {root}")
+        return 1
+
+    cards = iter_cards(root)
+    if not cards:
+        print(f"VERIFY CARDS: FAIL\n- no JSON card templates found under: {root}")
+        return 1
+
+    errors: list[str] = []
+    for card in cards:
+        errors.extend(validate_card(card))
+
+    if errors:
+        print("VERIFY CARDS: FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(f"VERIFY CARDS: PASS ({len(cards)} cards)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a small save-state card layer:

- `cards/README.md`
- five JSON templates under `cards/templates/`
- `tools/verify_cards.py` using only the Python standard library

## Scope

Lightweight working artifacts only. These cards are separate from immutable receipts and `data/receipts/`.

No workflow, UI, dependency, receipt, or immutable audit data changes.

## Local validation

```bash
python3 tools/verify_cards.py cards/templates
# VERIFY CARDS: PASS (5 cards)
```

## Boundary

This does not authorize Synthosia/XR implementation. It only makes the reentry card layer machine-checkable.
