### PR TITLE
spec: add ruecknahme operator release semantics

### DIFF
--- a/cards/README.md
+++ b/cards/README.md
@@ -13,8 +13,21 @@ python3 tools/verify_cards.py cards/templates
 Expected signal:
 
 ```text
-VERIFY CARDS: PASS (5 cards)
+VERIFY CARDS: PASS (6 cards)
 ```
+
+## Card types
+
+- `ack_triade`
+- `nectar_attune`
+- `rubedo_stop`
+- `synthosia_scope`
+- `reentry_vector`
+- `ruecknahme_exit`
+
+## Rücknahme invariant
+
+For `ruecknahme_exit`, `fields.no_trace` must be `true`. This means the release state is successful without post-exit telemetry or persistent binding.
 
 ## Boundary
 

--- a/cards/templates/ruecknahme_exit.json
+++ b/cards/templates/ruecknahme_exit.json
@@ -1,0 +1,12 @@
+{
+  "card_type": "ruecknahme_exit",
+  "timestamp": "2026-05-20T17:55:00",
+  "fields": {
+    "exit_gesture": "",
+    "sediment_action": "discard_or_explicit_export",
+    "released_state": true,
+    "no_trace": true,
+    "post_exit_claim": "none",
+    "boundary": "The system may shape the threshold. It must not possess what happens beyond it."
+  }
+}

--- a/docs/spec/ruecknahme_operator.md
+++ b/docs/spec/ruecknahme_operator.md
@@ -1,0 +1,67 @@
+# Rücknahme-Operator R↓
+
+Status: specification anchor; not a tracking feature.
+
+## Core thesis
+
+The Rücknahme-Operator models leaving the application not as failure, abandonment, or data loss, but as the successful completion of a mediated transition.
+
+The system fulfills its purpose when it releases the person without persistent digital binding.
+
+```text
+R↓(session, sediment, consent_exit) -> released_state + no_trace
+```
+
+## Semantics
+
+`no_trace` is not an error state. `no_trace` is PASS.
+
+The operator closes the loop by turning the system's post-exit non-knowledge into the strongest ethical confirmation: after the threshold, the application does not monitor, measure, infer, or retain the person's resonance.
+
+## Inputs
+
+- `session`: the local mediated interaction state
+- `sediment`: local working residue created during the session
+- `consent_exit`: an explicit exit gesture or equivalent local release action
+
+## Operation
+
+1. acknowledge the transition
+2. release the mediated frame
+3. discard local sediment or hand it back to the person as an explicit export
+4. close the local session
+5. create no server-side continuation
+6. perform no post-exit telemetry
+
+## Output
+
+- `released_state`
+- `no_trace: true`
+
+## Non-goals
+
+- no server-side tracking after exit
+- no behavioral proof after tab close
+- no claim that unmediated resonance is measured by the system
+- no hidden identity continuation
+- no post-exit reminders or re-engagement hooks unless separately and explicitly requested
+
+## Technical boundary
+
+The system may shape the threshold. It must not possess what happens beyond it.
+
+In implementation terms, success is represented by local release plus absence of persistent binding. The application should be able to record that an exit gesture occurred only inside the local closing flow; it must not convert the after-exit silence into a surveillance problem.
+
+## Card mapping
+
+The machine-checkable working artifact is:
+
+- `cards/templates/ruecknahme_exit.json`
+
+Required invariant:
+
+- `fields.no_trace` must be `true`
+
+## Review note
+
+This document intentionally keeps R↓ as a small spec anchor. UI affordances, storage behavior, and deletion/export mechanics should be added only in later narrow slices with explicit tests.

--- a/tools/verify_cards.py
+++ b/tools/verify_cards.py
@@ -53,6 +53,14 @@ REQUIRED_FIELDS: dict[str, set[str]] = {
         "next_action",
         "source_doc",
     },
+    "ruecknahme_exit": {
+        "exit_gesture",
+        "sediment_action",
+        "released_state",
+        "no_trace",
+        "post_exit_claim",
+        "boundary",
+    },
 }
 
 
@@ -67,6 +75,28 @@ def load_json(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
     if not isinstance(data, dict):
         return None, [f"{path}: top-level JSON value must be an object"]
     return data, []
+
+
+def validate_ruecknahme_exit(path: Path, fields: dict[str, Any]) -> list[str]:
+    """Validate Rücknahme-specific release semantics.
+
+    For this card type, `no_trace: true` is the invariant. It represents a
+    successful release state, not a telemetry target.
+    """
+    errors: list[str] = []
+
+    if fields.get("no_trace") is not True:
+        errors.append(f"{path}: ruecknahme_exit requires fields.no_trace to be true")
+
+    if fields.get("released_state") is not True:
+        errors.append(f"{path}: ruecknahme_exit requires fields.released_state to be true")
+
+    if fields.get("post_exit_claim") not in ("none", ""):
+        errors.append(
+            f"{path}: ruecknahme_exit post_exit_claim must be 'none' or empty"
+        )
+
+    return errors
 
 
 def validate_card(path: Path) -> list[str]:
@@ -107,6 +137,9 @@ def validate_card(path: Path) -> list[str]:
         if isinstance(value, (dict, list, str, int, float, bool)) or value is None:
             continue
         errors.append(f"{path}: field {field_name!r} has unsupported type")
+
+    if card_type == "ruecknahme_exit":
+        errors.extend(validate_ruecknahme_exit(path, fields))
 
     return errors
 


### PR DESCRIPTION
## Summary

Adds the Rücknahme-Operator `R↓` as a small architecture/spec slice:

- `docs/spec/ruecknahme_operator.md`
- `cards/templates/ruecknahme_exit.json`
- extends `tools/verify_cards.py` with `ruecknahme_exit`
- documents the new card type in `cards/README.md`

## Technical invariant

For `ruecknahme_exit`, the verifier requires:

- `fields.no_trace == true`
- `fields.released_state == true`
- `fields.post_exit_claim` is `none` or empty

## Scope

No UI implementation, no tracking code, no workflow change, no dependency change, no receipts or `data/receipts/` changes.

## Meaning

`no_trace` is modeled as PASS, not as a failure to observe. The system may shape the threshold, but must not possess what happens beyond it.

## Validation

Expected local signal after this PR:

```bash
python3 tools/verify_cards.py cards/templates
# VERIFY CARDS: PASS (6 cards)
```
