### PR TITLE
spec: clarify ruecknahme contact continuity

### DIFF
--- a/cards/templates/ruecknahme_exit.json
+++ b/cards/templates/ruecknahme_exit.json
@@ -6,7 +6,8 @@
     "sediment_action": "discard_or_explicit_export",
     "released_state": true,
     "no_trace": true,
+    "future_contact_policy": "user_initiated_fresh_consent",
     "post_exit_claim": "none",
-    "boundary": "The system may shape the threshold. It must not possess what happens beyond it."
+    "boundary": "No trace does not mean no contact. Future contact is possible only as user-initiated fresh consent."
   }
 }

--- a/docs/spec/ruecknahme_operator.md
+++ b/docs/spec/ruecknahme_operator.md
@@ -16,7 +16,30 @@ R↓(session, sediment, consent_exit) -> released_state + no_trace
 
 `no_trace` is not an error state. `no_trace` is PASS.
 
+`no_trace` also does not mean `no_contact`. It means no involuntary trace, no hidden tether, and no server-side identity continuation after the exit threshold.
+
 The operator closes the loop by turning the system's post-exit non-knowledge into the strongest ethical confirmation: after the threshold, the application does not monitor, measure, infer, or retain the person's resonance.
+
+## Contact continuity
+
+Future contact remains possible by design. It must happen as a voluntary new entry, not as a hidden continuation of the previous session.
+
+Allowed continuity:
+
+- user-initiated return
+- fresh consent at the new threshold
+- optional explicit re-import of a user-held export
+- no automatic follow-up
+- no background reminder, re-engagement hook, or inferred identity bridge
+
+In short:
+
+```text
+no_trace != no_contact
+future_contact == user_initiated + fresh_consent
+```
+
+The tool may remain available as a door. It must not behave like a leash.
 
 ## Inputs
 
@@ -32,11 +55,13 @@ The operator closes the loop by turning the system's post-exit non-knowledge int
 4. close the local session
 5. create no server-side continuation
 6. perform no post-exit telemetry
+7. allow later return only as user-initiated fresh consent
 
 ## Output
 
 - `released_state`
 - `no_trace: true`
+- `future_contact_policy: user_initiated_fresh_consent`
 
 ## Non-goals
 
@@ -45,6 +70,7 @@ The operator closes the loop by turning the system's post-exit non-knowledge int
 - no claim that unmediated resonance is measured by the system
 - no hidden identity continuation
 - no post-exit reminders or re-engagement hooks unless separately and explicitly requested
+- no forced rupture of future contact
 
 ## Technical boundary
 
@@ -52,15 +78,18 @@ The system may shape the threshold. It must not possess what happens beyond it.
 
 In implementation terms, success is represented by local release plus absence of persistent binding. The application should be able to record that an exit gesture occurred only inside the local closing flow; it must not convert the after-exit silence into a surveillance problem.
 
+If later contact happens, it is modeled as a new entrance with fresh consent. Any continuity must be carried by the person, for example through an explicit local export, not silently retained by the system.
+
 ## Card mapping
 
 The machine-checkable working artifact is:
 
 - `cards/templates/ruecknahme_exit.json`
 
-Required invariant:
+Required invariants:
 
 - `fields.no_trace` must be `true`
+- `fields.future_contact_policy` must be `user_initiated_fresh_consent`
 
 ## Review note
 

--- a/tools/verify_cards.py
+++ b/tools/verify_cards.py
@@ -58,6 +58,7 @@ REQUIRED_FIELDS: dict[str, set[str]] = {
         "sediment_action",
         "released_state",
         "no_trace",
+        "future_contact_policy",
         "post_exit_claim",
         "boundary",
     },
@@ -81,7 +82,7 @@ def validate_ruecknahme_exit(path: Path, fields: dict[str, Any]) -> list[str]:
     """Validate Rücknahme-specific release semantics.
 
     For this card type, `no_trace: true` is the invariant. It represents a
-    successful release state, not a telemetry target.
+    successful release state, not a telemetry target and not contact rupture.
     """
     errors: list[str] = []
 
@@ -90,6 +91,12 @@ def validate_ruecknahme_exit(path: Path, fields: dict[str, Any]) -> list[str]:
 
     if fields.get("released_state") is not True:
         errors.append(f"{path}: ruecknahme_exit requires fields.released_state to be true")
+
+    if fields.get("future_contact_policy") != "user_initiated_fresh_consent":
+        errors.append(
+            f"{path}: ruecknahme_exit requires future_contact_policy "
+            "to be 'user_initiated_fresh_consent'"
+        )
 
     if fields.get("post_exit_claim") not in ("none", ""):
         errors.append(


### PR DESCRIPTION
## Summary

Clarifies that `no_trace` does not mean contact rupture.

Updates:

- `docs/spec/ruecknahme_operator.md`
- `cards/templates/ruecknahme_exit.json`
- `tools/verify_cards.py`

## Semantics

`no_trace != no_contact`

Future contact remains possible, but only as:

```text
user_initiated + fresh_consent
```

## Technical invariant

For `ruecknahme_exit`, the verifier now requires:

- `fields.no_trace == true`
- `fields.released_state == true`
- `fields.future_contact_policy == "user_initiated_fresh_consent"`
- `fields.post_exit_claim` is `none` or empty

## Scope

No UI implementation, no tracking code, no workflow change, no dependency change, no receipts or `data/receipts/` changes.
