### PR TITLE
docs: add welcome guide and polish onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # entaENGELment Framework
 
-> Consent-First Framework für resonante Systeme mit auditier­barem Proof-Protokoll
+> Consent-First Framework für resonante Systeme mit auditierbarem Proof-Protokoll
+
+> New here? Start with [WELCOME.md](WELCOME.md) for a gentle orientation.
 
 ![DeepJump CI](https://github.com/fleksible/entaENGELment-/actions/workflows/deepjump-ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
@@ -21,7 +23,7 @@ EntaENGELment ist ein experimentelles Framework für Multi-Agent-Systeme mit Con
 **Use-Cases:**
 - Nachvollziehbare Entwicklung mit strengem Audit-Protokoll
 - Multi-Agent-Workflows mit Consent-Management
-- Experimentelle Resonanz-Metriken (ECI, Mass-Gap, Phi-basierte Gates)
+- Experimentelle Resonanz-Metriken (ECI, Mass-Gap, Phi-basierte Gates) als Modell-/Metrik-Proxies
 
 **Non-Goals:**
 - Production-Ready Software (experimenteller Status)
@@ -67,7 +69,7 @@ make verify         # Alles prüfen
 **Optional: UI starten**
 ```bash
 cd ui-app
-npm install
+npm ci
 npm run dev
 # → http://localhost:3000
 ```
@@ -93,7 +95,7 @@ npm run dev
 | `tools/` | DeepJump-Tools | `tools/verify_pointers.py`, `tools/status_emit.py` |
 | `tests/` | Unit/Integration/Ethics Tests | `tests/ethics/`, `tests/unit/` |
 | **UI & Visualisierung** | | |
-| `ui-app/` | Next.js 14 Web-App | `cd ui-app && npm run dev` |
+| `ui-app/` | Next.js Web-App | `cd ui-app && npm run dev` |
 | `bio_spiral_viewer/` | Console Spiral-Explorer | `python -m bio_spiral_viewer` |
 | `Fractalsense/` | Fractal Color Generator | siehe `ui-app/fractalsense` |
 | **Development** | | |
@@ -160,7 +162,7 @@ Das Framework folgt einem strikten Verify → Status → Snapshot Flow. `make ve
 - **G6: Verify-Before-Merge** – Tests laufen lassen, Report erstellen
 
 **Receipts, Audit, Determinismus:**
-Receipts sind HMAC-signiert und bilden einen nicht-repudiierbaren Audit-Trail. `data/receipts/` ist IMMUTABLE (append-only). Jede Modifikation würde Signaturen invalidieren. Audit-Reports in `docs/audit/` dokumentieren kritische Änderungen und werden versioniert. GateProof ([`policies/gateproof_v1.yaml`](policies/gateproof_v1.yaml)) definiert die Checkliste für latent→manifest Übergänge. Port-Matrix ([`policies/port_codebooks.yaml`](policies/port_codebooks.yaml)) codiert semantische Marker (K0..K4).
+Receipts sind HMAC-signiert und bilden einen manipulationserschwerten, nachvollziehbaren Audit-Trail. `data/receipts/` ist IMMUTABLE (append-only). Jede Modifikation würde Signaturen invalidieren. Audit-Reports in `docs/audit/` dokumentieren kritische Änderungen und werden versioniert. GateProof ([`policies/gateproof_v1.yaml`](policies/gateproof_v1.yaml)) definiert die Checkliste für latent→manifest Übergänge. Port-Matrix ([`policies/port_codebooks.yaml`](policies/port_codebooks.yaml)) codiert semantische Marker (K0..K4).
 
 ---
 
@@ -205,12 +207,12 @@ Receipts sind HMAC-signiert und bilden einen nicht-repudiierbaren Audit-Trail. `
 ## VII. UI (ui-app/)
 
 **Was es ist:**
-Next.js 14 Web-App mit mehreren Dashboards und Explorern.
+Next.js Web-App mit mehreren Dashboards und Explorern.
 
 **Wie starten:**
 ```bash
 cd ui-app
-npm install
+npm ci
 npm run dev
 # → http://localhost:3000
 ```
@@ -281,7 +283,7 @@ npm run dev
 🜁 Architektur · 🜄 Governance/Ethik · 🜃 Adaptive Schicht · 🜅 Tests · 🜂 Meta-Poetik
 
 **Mytho-technische Rahmung:**
-Index als "Pointer-Gold", Code als "Annex". Resonanz bleibt Magie, weil jeder Sprung verankert ist. Metatron als Schreiber-Guard. NICHTRAUM als Raum für Unentschiedenes. Receipts als nicht-repudiierbare Quittung. Governance als Judikative.
+Index als "Pointer-Gold", Code als "Annex". Resonanz bleibt Magie, weil jeder Sprung verankert ist. Metatron als Schreiber-Guard. NICHTRAUM als Raum für Unentschiedenes. Receipts als signierte Quittung. Governance als Judikative.
 
 **Tiefe Docs:**
 - [`docs/devops_tooling_kit_annex.md`](docs/devops_tooling_kit_annex.md)

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -1,0 +1,107 @@
+# Welcome to entaENGELment
+
+entaENGELment is an experimental consent-first framework for auditable, human-guided multi-agent workflows.
+
+It combines three layers:
+
+1. **Governance**
+   Clear boundaries, consent checks, evidence trails, and review gates.
+
+2. **Verification**
+   Repeatable commands such as `make verify`, pointer validation, claim linting, tests, and receipts.
+
+3. **Exploration**
+   A symbolic and conceptual research space for resonance, membranes, voids, and multi-agent coordination.
+
+This repository is not production-ready software. It is a research and governance framework in active formation.
+
+## Start here
+
+For a fast technical check:
+
+```bash
+git clone https://github.com/fleksible/entaENGELment-.git
+cd entaENGELment-
+make install-dev
+make verify
+```
+
+For the optional UI:
+
+```bash
+cd ui-app
+npm ci
+npm run dev
+```
+
+Then open:
+
+```text
+http://localhost:3000
+```
+
+## What matters most
+
+The project follows a simple rule:
+
+> No claim without status.
+> No merge without verification.
+> No resonance without boundary.
+
+Important terms:
+
+- **VOIDMAP** tracks open gaps, risks, and unresolved system questions.
+- **DeepJump** describes the verify -> status -> snapshot workflow.
+- **Receipts** document evidence and state transitions.
+- **Guards G0-G6** define consent, focus, boundary, and merge discipline.
+- **ANNEX vs GOLD** separates changeable work zones from protected canonical material.
+
+## What this project is not
+
+entaENGELment is not:
+
+- a finished product,
+- a general-purpose framework,
+- a production security system,
+- an empirical proof of its symbolic models,
+- or a claim that metaphor equals evidence.
+
+Symbolic language is allowed here, but it must not replace verification.
+
+## Recommended paths
+
+If you are a developer, start with:
+
+- `README.md`
+- `Makefile`
+- `tests/`
+- `tools/`
+
+If you are reviewing governance, start with:
+
+- `CLAUDE.md`
+- `policies/`
+- `VOIDMAP.yml`
+- `docs/guards/`
+
+If you are exploring the conceptual layer, start with:
+
+- `REPOSITORY_ESSENZ_ANALYSE.md`
+- `docs/`
+- `index/`
+- `spec/`
+
+## Contribution style
+
+Small, focused pull requests are preferred.
+
+Good PRs usually do one thing:
+
+- fix a typo,
+- add a test,
+- clarify a claim,
+- update one dependency,
+- close one VOID with evidence,
+- or improve one documented workflow.
+
+When unsure, choose the smaller change.

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -15,6 +15,8 @@ It combines three layers:
 
 This repository is not production-ready software. It is a research and governance framework in active formation.
 
+This guide is intentionally lightweight. Authoritative rules remain in `README.md`, `CLAUDE.md`, policies, tests, and CI gates.
+
 ## Start here
 
 For a fast technical check:


### PR DESCRIPTION
## Summary

Adds a gentle `WELCOME.md` orientation page and polishes README onboarding.

## Changes

- add `WELCOME.md` as first-entry orientation layer
- link README to the new welcome guide
- switch UI setup commands from `npm install` to `npm ci`
- remove stale `Next.js 14` wording in favor of version-neutral `Next.js Web-App`
- mark experimental resonance metrics as model/metric proxies
- soften audit wording from non-repudiation to a manipulation-resistant, traceable audit trail
- align the opt-in hermetic layer wording with claim discipline

## Test Plan

- docs-only change
- no runtime code changed
- review via rendered Markdown / diff

## Risk

Low. The PR changes only onboarding documentation and does not touch code, workflows, or governance source files.