### PR TITLE
docs: add security policy and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/claim_correction.yml
+++ b/.github/ISSUE_TEMPLATE/claim_correction.yml
@@ -1,0 +1,102 @@
+name: Claim correction
+about: Flag a claim that may be too strong, stale, unclear, or missing status
+labels: [claim-discipline, docs]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template when a statement needs sharper claim status, weaker wording, or better evidence.
+
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: File path, section, line, PR, or issue where the claim appears.
+      placeholder: README.md#governance--safety
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_claim
+    attributes:
+      label: Current claim
+      description: Paste the relevant sentence or summarize the claim precisely.
+      placeholder: "Receipts are ..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: current_status
+    attributes:
+      label: Current claim status, if stated
+      options:
+        - Not stated
+        - FAKT
+        - INFERENZ
+        - MODELL
+        - HYPOTHESE
+        - METAPHER
+        - CLAIM
+        - POESIE
+        - SPEC
+        - EXECUTED
+        - Unknown / mixed
+    validations:
+      required: true
+
+  - type: dropdown
+    id: suggested_status
+    attributes:
+      label: Suggested claim status
+      options:
+        - FAKT
+        - INFERENZ
+        - MODELL
+        - HYPOTHESE
+        - METAPHER
+        - CLAIM
+        - POESIE
+        - SPEC
+        - EXECUTED
+        - Needs maintainer decision
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is the problem?
+      description: Explain whether the issue is overclaiming, missing evidence, stale wording, ambiguity, pseudo-physics risk, or another boundary problem.
+      placeholder: The wording currently sounds stronger than the evidence supports because ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or references
+      description: Link repo evidence, receipts, tests, docs, issues, papers, or note that evidence is missing.
+      placeholder: Related PR, receipt, test output, or source link.
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposed_wording
+    attributes:
+      label: Proposed wording
+      description: Offer a weaker or clearer replacement sentence if possible.
+      placeholder: "Receipts are HMAC-signed and provide a tamper-evident audit trail within documented assumptions."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Boundary checks
+      options:
+        - label: I am not using metaphor as evidence.
+          required: true
+        - label: I chose the weaker status when unsure.
+          required: true
+        - label: I did not include secrets, credentials, private keys, or unrelated personal data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/claim_correction.yml
+++ b/.github/ISSUE_TEMPLATE/claim_correction.yml
@@ -1,5 +1,6 @@
 name: Claim correction
-about: Flag a claim that may be too strong, stale, unclear, or missing status
+description: Flag a claim that may be too strong, stale, unclear, or missing status
+title: "Claim correction: "
 labels: [claim-discipline, docs]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/void.yml
+++ b/.github/ISSUE_TEMPLATE/void.yml
@@ -1,5 +1,6 @@
 name: VOID entry
-about: Propose or refine an unresolved gap, risk, or open system question
+description: Propose or refine an unresolved gap, risk, or open system question
+title: "VOID: "
 labels: [void, governance]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/void.yml
+++ b/.github/ISSUE_TEMPLATE/void.yml
@@ -1,0 +1,94 @@
+name: VOID entry
+about: Propose or refine an unresolved gap, risk, or open system question
+labels: [void, governance]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for gaps that should be tracked deliberately instead of being hidden, rushed, or overclaimed.
+
+  - type: input
+    id: title
+    attributes:
+      label: VOID title
+      description: Short human-readable title.
+      placeholder: Claim status drift in onboarding docs
+    validations:
+      required: true
+
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain
+      options:
+        - governance
+        - security
+        - documentation
+        - ui
+        - ci
+        - evidence
+        - metrics
+        - conceptual model
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P1 critical
+        - P2 high
+        - P3 medium
+        - P4 low
+        - undecided
+    validations:
+      required: true
+
+  - type: textarea
+    id: gap
+    attributes:
+      label: Gap / unresolved question
+      description: What is missing, unstable, ambiguous, or unsafe to assume?
+      placeholder: The repo currently implies ..., but the evidence boundary is ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk if left unmarked
+      description: What could go wrong if this remains implicit?
+      placeholder: This could create false safety, stale documentation, drift, or merge confusion.
+    validations:
+      required: true
+
+  - type: textarea
+    id: closing_path
+    attributes:
+      label: Closing path
+      description: What evidence, PR, test, receipt, or decision would close this VOID?
+      placeholder: Add a docs patch, test, receipt, or ADR that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related files, issues, PRs, or receipts
+      placeholder: VOIDMAP.yml, PR #..., docs/..., data/receipts/...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Boundary checks
+      options:
+        - label: This issue marks uncertainty rather than pretending it is solved.
+          required: true
+        - label: This issue does not include secrets, credentials, private keys, or unrelated personal data.
+          required: true
+        - label: This issue does not use live biological, medical, or sensor data.
+          required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,85 @@
+# Security Policy
+
+entaENGELment is an experimental research and governance framework. It is not production-ready software and does not provide a security guarantee.
+
+This policy defines how security-relevant findings should be reported and how the project treats safety boundaries.
+
+## Supported scope
+
+Security-relevant reports may include:
+
+- CI/CD workflow weaknesses
+- dependency or supply-chain issues
+- unsafe GitHub Actions configuration
+- prompt-injection or untrusted-content handling gaps
+- receipt, signature, or audit-trail integrity issues
+- pointer-validation or claim-lint bypasses
+- accidental exposure of sensitive data
+- documentation claims that overstate security properties
+
+Out of scope:
+
+- requests to attack third-party systems
+- social-engineering attempts
+- reports requiring live biological, medical, or sensor data
+- speculative harm claims without a reproducible repo path
+- production-hardening demands beyond the current experimental status
+
+## Reporting
+
+Please open a GitHub issue when the finding can be public without increasing risk.
+
+Use a private channel or contact the maintainer first when the report includes:
+
+- exploitable details
+- secrets, tokens, or credentials
+- bypass steps for a live workflow
+- personal data
+- sensitive screenshots or logs
+
+Do not paste secrets, credentials, tokens, private keys, or unrelated personal data into issues or pull requests.
+
+## Report format
+
+A useful report includes:
+
+- affected file or workflow path
+- expected behavior
+- observed behavior
+- minimal reproduction steps
+- risk level: low / medium / high
+- suggested fix, if known
+- whether the issue is public-safe
+
+## Claim discipline
+
+Security claims must stay bounded.
+
+Preferred language:
+
+- "HMAC-signed receipt"
+- "tamper-evident within the documented assumptions"
+- "manipulation-resistant audit trail"
+- "verification step"
+
+Avoid unqualified claims such as:
+
+- "secure"
+- "unbreakable"
+- "non-bypassable"
+- "non-repudiable"
+- "guaranteed"
+
+When unsure, use the weaker claim and link evidence.
+
+## Safety boundaries
+
+This repository must not collect or process live biological, medical, or sensor data.
+
+Security or safety reports involving such data should be reframed as synthetic, documented, non-identifying examples before being added to the repo.
+
+## Response expectations
+
+The maintainer will triage reports according to risk, reproducibility, and project scope.
+
+Because this is an experimental project, some findings may be documented as open VOIDs instead of immediate fixes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,8 @@ entaENGELment is an experimental research and governance framework. It is not pr
 
 This policy defines how security-relevant findings should be reported and how the project treats safety boundaries.
 
+General claim-status corrections should use the Claim correction issue template. Security-sensitive findings should follow this policy first.
+
 ## Supported scope
 
 Security-relevant reports may include:


### PR DESCRIPTION
## Summary

Adds a bounded security policy and two repository-native issue templates.

## Changes

- add `SECURITY.md` with explicit experimental-status and reporting boundaries
- add `.github/ISSUE_TEMPLATE/claim_correction.yml` for claim-status and evidence corrections
- add `.github/ISSUE_TEMPLATE/void.yml` for unresolved gaps, risks, and open system questions

## Test Plan

- docs/config-only change
- no runtime code changed
- issue templates are YAML form definitions
- review via rendered GitHub issue-template forms / PR diff

## Risk

Low. This PR adds governance and reporting surfaces only. It does not modify source code, workflows, or existing policy files.