### PR TITLE
chore: add pipeline essentials scanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DMI ?= 4.7
 PHI ?= 0.72
 REFRACTORY ?= 120
 
-.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -56,6 +56,7 @@ help:
 	@echo "Docs:"
 	@echo "  make voids-backlog       Regenerate docs/voids_backlog.md from VOIDMAP.yml"
 	@echo "  make voids-backlog-check Verify docs/voids_backlog.md is in sync (exit 1 on drift)"
+	@echo "  make pipeline-essentials  Report pipeline essentials and next expansion options"
 
 # === Setup ===
 install:
@@ -159,6 +160,9 @@ voids-backlog:
 
 voids-backlog-check:
 	@$(PY) tools/voids_backlog_gen.py --check
+
+pipeline-essentials:
+	@$(PY) tools/pipeline_essentials.py
 
 # Phase 2: STATUS (HMAC Receipt)
 status:

--- a/docs/runbooks/pipeline_essentials.md
+++ b/docs/runbooks/pipeline_essentials.md
@@ -1,0 +1,40 @@
+# Pipeline Essentials — Ausbau-Runbook
+
+[FACT] Dieses Runbook bündelt weitere Möglichkeiten, die DeepJump-Pipeline für essenzielle Handhabung zu erweitern, ohne die bestehenden Gates zu überladen.
+
+## Zielbild
+
+Die Pipeline bleibt dreistufig: **Verify → Status → Snapshot**. Neue Checks werden zuerst als beobachtende Essentials sichtbar gemacht, danach mit klarer Scope-Definition in `make verify` oder CI gehärtet.
+
+Der Scanner ist bewusst beobachtend. Er dokumentiert Ausbauoptionen, verändert aber keine bestehenden Gates.
+
+## Schneller Lage-Scan
+
+```bash
+make pipeline-essentials
+```
+
+Der Befehl ruft `tools/pipeline_essentials.py` auf und erzeugt einen statischen Markdown-Report zu vorhandenen Essentials und nächsten Ausbauoptionen.
+
+## Konkrete Ausbau-Möglichkeiten
+
+| ID | Möglichkeit | Nutzen | Nächster Schritt |
+|----|-------------|--------|------------------|
+| ESS-001 | `make verify` als lokaler Single-Entry-Point | Weniger Bedienfehler vor PRs | Im Contributor-Flow weiter als Pflichtschritt kommunizieren |
+| ESS-002 | Receipt-Lint früher laufen lassen | Audit-Drift wird vor Release sichtbar | Scope für `receipts/` und `ark/p4/receipts/` festlegen |
+| ESS-003 | VOID-Backlog-Drift in PR-CI prüfen | Governance-Doku bleibt synchron zur `VOIDMAP.yml` | `make voids-backlog-check` in eine PR-Workflow-Stufe aufnehmen |
+| ESS-004 | Frame-Lint kanonisch scopen | Operative Frames werden maschinell konsistent | `FRAME_LINT_PATHS` verbindlich festlegen |
+| ESS-005 | HMAC-Status-Verifikation bewusst trennen | Fork-PRs ohne Secrets bleiben prüfbar | Signierte Runs nur in trusted CI/Schedule erzwingen |
+| ESS-006 | Snapshot-Artefakte konsequent hochladen | Reproduzierbarkeit wird leichter auditierbar | Manifest-Upload für geplante Runs prüfen |
+| ESS-007 | Lokale Dependency-Audit-Vorstufe | Release-Prep erkennt Risiko früher | Optionales Make-Target für leichte Audits ergänzen |
+| ESS-008 | Gepinnte Actions rotieren | Supply-Chain-Risiko bleibt reviewbar | SHA-Rotation über dedizierte Dependency-PRs planen |
+
+## Härtungsregel
+
+[FACT] Ein Essential wird erst dann blocking, wenn drei Bedingungen erfüllt sind:
+
+1. Scope ist eindeutig dokumentiert.
+2. Lokaler Befehl existiert und ist reproduzierbar.
+3. CI-Ausführung hat einen klaren Secret-/Fork-Fallback.
+
+So bleibt die Pipeline bedienbar und gewinnt trotzdem zusätzliche Kontrollpunkte.

--- a/tests/test_pipeline_essentials.py
+++ b/tests/test_pipeline_essentials.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import pipeline_essentials as pe
+
+
+def test_build_report_lists_all_essentials(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text(
+        "\n".join(
+            [
+                "verify: port-lint test verify-pointers claim-lint",
+                "voids-backlog-check:",
+                "frame-lint: FRAME_LINT_PATHS",
+                "status-verify: status tools/status_verify.py",
+                "snapshot: --strict",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True)
+    (workflows / "release.yml").write_text("tools/receipt_lint.py", encoding="utf-8")
+    (workflows / "ci.yml").write_text(
+        "pip-audit\nactions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+        encoding="utf-8",
+    )
+
+    report = pe.build_report(tmp_path)
+
+    assert "ESS-001" in report
+    assert "ESS-008" in report
+    assert "Ausbau-Möglichkeiten" in report
+    assert "OPEN" not in report
+
+
+def test_missing_essential_is_reported_open(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text("verify: test\n", encoding="utf-8")
+
+    report = pe.build_report(tmp_path)
+
+    assert "ESS-001 | OPEN" in report
+    assert "missing:" in report

--- a/tools/pipeline_essentials.py
+++ b/tools/pipeline_essentials.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Static checklist for DeepJump pipeline expansion candidates."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class EssentialCheck:
+    id: str
+    title: str
+    path: str
+    needles: tuple[str, ...]
+    recommendation: str
+    status_when_present: str = "covered"
+
+
+def get_repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+CHECKS: tuple[EssentialCheck, ...] = (
+    EssentialCheck(
+        id="ESS-001",
+        title="Canonical local verify entrypoint",
+        path="Makefile",
+        needles=("verify: port-lint test verify-pointers claim-lint",),
+        recommendation="Keep `make verify` as the single local pre-merge command.",
+    ),
+    EssentialCheck(
+        id="ESS-002",
+        title="Receipt lint in release gate",
+        path=".github/workflows/release.yml",
+        needles=("tools/receipt_lint.py",),
+        recommendation="Promote receipt lint into a reusable local/PR target once scope is stable.",
+    ),
+    EssentialCheck(
+        id="ESS-003",
+        title="VOID backlog drift check",
+        path="Makefile",
+        needles=("voids-backlog-check",),
+        recommendation="Run backlog drift checks in PR CI to catch stale governance docs early.",
+    ),
+    EssentialCheck(
+        id="ESS-004",
+        title="Frame operator lint exists",
+        path="Makefile",
+        needles=("frame-lint", "FRAME_LINT_PATHS"),
+        recommendation="Define canonical frame-lint scope, then add it to the verify chain.",
+    ),
+    EssentialCheck(
+        id="ESS-005",
+        title="HMAC status verification path",
+        path="Makefile",
+        needles=("status-verify: status", "tools/status_verify.py"),
+        recommendation="Keep signed status verification separate from fork PRs that lack secrets.",
+    ),
+    EssentialCheck(
+        id="ESS-006",
+        title="Strict snapshot guard path",
+        path="Makefile",
+        needles=("snapshot:", "--strict"),
+        recommendation="Upload snapshot manifests from scheduled and trusted CI runs.",
+    ),
+    EssentialCheck(
+        id="ESS-007",
+        title="Dependency vulnerability scan",
+        path=".github/workflows/ci.yml",
+        needles=("pip-audit",),
+        recommendation="Mirror a lightweight dependency audit target locally for release prep.",
+    ),
+    EssentialCheck(
+        id="ESS-008",
+        title="Pinned GitHub Actions",
+        path=".github/workflows/ci.yml",
+        needles=("actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",),
+        recommendation="Keep action SHAs pinned and rotate them through reviewable dependency PRs.",
+    ),
+)
+
+
+def check_file(repo_root: Path, check: EssentialCheck) -> tuple[bool, str]:
+    target = repo_root / check.path
+    if not target.exists():
+        return False, f"missing file: {check.path}"
+    text = target.read_text(encoding="utf-8")
+    missing = [needle for needle in check.needles if needle not in text]
+    if missing:
+        return False, "missing: " + ", ".join(f"`{needle}`" for needle in missing)
+    return True, check.status_when_present
+
+
+def build_report(repo_root: Path) -> str:
+    rows: list[str] = []
+    opportunities: list[str] = []
+    for check in CHECKS:
+        covered, detail = check_file(repo_root, check)
+        status = "COVERED" if covered else "OPEN"
+        rows.append(f"| {check.id} | {status} | {check.title} | `{check.path}` | {detail} |")
+        opportunities.append(f"- **{check.id}**: {check.recommendation}")
+
+    return "\n".join(
+        [
+            "# Pipeline Essentials Report",
+            "",
+            "[FACT] Static scan of local files for DeepJump pipeline essentials.",
+            "",
+            "| ID | Status | Essential | Evidence | Detail |",
+            "|----|--------|-----------|----------|--------|",
+            *rows,
+            "",
+            "## Ausbau-Möglichkeiten",
+            "",
+            *opportunities,
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=get_repo_root())
+    parser.add_argument("--out", type=Path, help="Optional Markdown output path.")
+    args = parser.parse_args()
+
+    report = build_report(args.repo_root.resolve())
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(report, encoding="utf-8")
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Rebuilds PR #215 on the current `main` after #216 and #217 were merged.

## Changes

- add `tools/pipeline_essentials.py` as a static scanner for DeepJump pipeline expansion candidates
- expose the scanner via `make pipeline-essentials`
- add `docs/runbooks/pipeline_essentials.md`
- add tests for covered and missing essentials

## Rationale

The original PR #215 had green checks after refresh but became non-mergeable after the docs/governance PRs landed. This branch reapplies the same focused change on top of current `main`.

## Test Plan

- GitHub Actions
- `tests/test_pipeline_essentials.py`
- docs/tooling-only change; no existing gates are changed

## Risk

Low to medium. Adds a new observational scanner and Makefile target; it does not make any new check blocking.