### PR TITLE
ci: add workflow permissions and concurrency guards

### DIFF
--- a/.github/workflows/ci-evidence-bundle.yml
+++ b/.github/workflows/ci-evidence-bundle.yml
@@ -5,6 +5,10 @@ on: [push]
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bundle:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-policy-lint.yml
+++ b/.github/workflows/ci-policy-lint.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-smoke.yml
+++ b/.github/workflows/ci-smoke.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-advisory:
     name: PR Advisory Gate

--- a/.github/workflows/deepjump-audit.reusable.yml
+++ b/.github/workflows/deepjump-audit.reusable.yml
@@ -15,6 +15,13 @@ on:
       ENTA_HMAC_SECRET:
         required: false
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deepjump-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/deepjump-ci.yml
+++ b/.github/workflows/deepjump-ci.yml
@@ -13,6 +13,13 @@ on:
   schedule:
     - cron: "0 3 * * *"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Blocking verification steps (VOID-002 closure)
   verify-lint:

--- a/.github/workflows/metatron-guard.yml
+++ b/.github/workflows/metatron-guard.yml
@@ -7,6 +7,13 @@ on:
     branches-ignore:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   metatron-pr-check:
     name: Check PR for FOKUS marker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gate-check:
     name: Release Gate Verification

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sbom:
     name: Generate SBOM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-javascript:
     name: JavaScript Tests

--- a/.github/workflows/void-sync.yml
+++ b/.github/workflows/void-sync.yml
@@ -9,6 +9,10 @@ permissions:
   issues: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-deadlines:
     name: Check VOID Deadlines

--- a/docs/ci/WORKFLOW_MAP.md
+++ b/docs/ci/WORKFLOW_MAP.md
@@ -1,0 +1,40 @@
+# CI Workflow Map
+
+[FACT] This map documents the repository's GitHub Actions workflows, their minimum token permissions, and their top-level concurrency guard.
+
+## Guard contract
+
+Each workflow should declare explicit `permissions` and a top-level `concurrency` block.
+
+Default read-only template:
+
+```yaml
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+Exception: `release.yml` keeps `contents: write` because it creates GitHub Releases from version tags.
+
+## Workflows
+
+| Workflow file | Purpose | Permissions | Concurrency |
+|---------------|---------|-------------|-------------|
+| `.github/workflows/ci.yml` | Legacy/advisory CI plus non-PR verify/build/security/gate-policy jobs | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/ci-evidence-bundle.yml` | Evidence bundle generation | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/ci-policy-lint.yml` | Policy JSON lint | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/ci-smoke.yml` | Python smoke tests | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/deepjump-audit.reusable.yml` | Reusable DeepJump audit core | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/deepjump-ci.yml` | DeepJump verify/lint plus reusable audit call | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/metatron-guard.yml` | FOKUS marker advisory guard for PRs/branch pushes | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/release.yml` | Release gate and GitHub Release creation | `contents: write` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/sbom.yml` | SBOM generation and artifact upload | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/test.yml` | JavaScript, Python, and UI build tests | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/void-sync.yml` | Scheduled VOID deadline monitoring and issue creation | `contents: read`, `issues: write` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+
+## Maintenance rule
+
+[FACT] New workflows must document any permission broader than `contents: read` in this file. The reason should be action-specific, not symbolic or implied.

--- a/docs/runbooks/pipeline_essentials.md
+++ b/docs/runbooks/pipeline_essentials.md
@@ -8,6 +8,8 @@ Die Pipeline bleibt dreistufig: **Verify → Status → Snapshot**. Neue Checks 
 
 Der Scanner ist bewusst beobachtend. Er dokumentiert Ausbauoptionen, verändert aber keine bestehenden Gates.
 
+Die aktuelle Workflow-/Rechtekarte steht in [`docs/ci/WORKFLOW_MAP.md`](../ci/WORKFLOW_MAP.md).
+
 ## Schneller Lage-Scan
 
 ```bash


### PR DESCRIPTION
## Summary

- add explicit workflow token permissions and top-level concurrency guards across CI workflows
- keep broader permissions only where needed: release creation keeps `contents: write`, VOID deadline monitor keeps `issues: write`
- add `docs/ci/WORKFLOW_MAP.md` as a workflow permissions/concurrency map
- link the workflow map from `docs/runbooks/pipeline_essentials.md`

## Notes

FOKUS: CI/CD membrane hardening

This PR intentionally avoids merging dependency/update PRs. It only documents and hardens workflow-level permissions/concurrency.

## Verification

- Static YAML/documentation changes only
- Existing workflow behavior preserved except for concurrency cancellation and explicit token scopes
