### PR TITLE
ci: add workflow posture drift check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DMI ?= 4.7
 PHI ?= 0.72
 REFRACTORY ?= 120
 
-.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials workflow-posture-check verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -57,6 +57,7 @@ help:
 	@echo "  make voids-backlog       Regenerate docs/voids_backlog.md from VOIDMAP.yml"
 	@echo "  make voids-backlog-check Verify docs/voids_backlog.md is in sync (exit 1 on drift)"
 	@echo "  make pipeline-essentials  Report pipeline essentials and next expansion options"
+	@echo "  make workflow-posture-check Verify workflows declare permissions + concurrency (exit 1 on drift)"
 
 # === Setup ===
 install:
@@ -163,6 +164,10 @@ voids-backlog-check:
 
 pipeline-essentials:
 	@$(PY) tools/pipeline_essentials.py
+
+# CI/CD posture drift check: verify workflows declare permissions + concurrency.
+workflow-posture-check:
+	@$(PY) tools/workflow_posture_check.py
 
 # Phase 2: STATUS (HMAC Receipt)
 status:

--- a/docs/ci/WORKFLOW_MAP.md
+++ b/docs/ci/WORKFLOW_MAP.md
@@ -38,3 +38,5 @@ Exception: `release.yml` keeps `contents: write` because it creates GitHub Relea
 ## Maintenance rule
 
 [FACT] New workflows must document any permission broader than `contents: read` in this file. The reason should be action-specific, not symbolic or implied.
+
+[FACT] `make workflow-posture-check` (`tools/workflow_posture_check.py`) verifies this contract locally: every workflow must declare explicit `permissions` and a `concurrency` block with `cancel-in-progress: true`, and any permission broader than `contents: read` must be named in this file. The check is read-only and deterministic.

--- a/docs/runbooks/pipeline_essentials.md
+++ b/docs/runbooks/pipeline_essentials.md
@@ -18,6 +18,14 @@ make pipeline-essentials
 
 Der Befehl ruft `tools/pipeline_essentials.py` auf und erzeugt einen statischen Markdown-Report zu vorhandenen Essentials und nächsten Ausbauoptionen.
 
+## Workflow-Posture-Drift prüfen
+
+```bash
+make workflow-posture-check
+```
+
+Der Befehl ruft `tools/workflow_posture_check.py` auf und prüft read-only, ob jede Datei unter `.github/workflows/` einen expliziten `permissions`-Block sowie einen `concurrency`-Block mit `cancel-in-progress: true` deklariert. Berechtigungen, die breiter als `contents: read` sind, müssen in [`docs/ci/WORKFLOW_MAP.md`](../ci/WORKFLOW_MAP.md) als Ausnahme dokumentiert sein (der Workflow-Dateiname muss dort genannt werden). Der Check verändert keine Dateien, braucht kein Netzwerk und endet bei Drift mit Exit-Code 1.
+
 ## Konkrete Ausbau-Möglichkeiten
 
 | ID | Möglichkeit | Nutzen | Nächster Schritt |

--- a/tests/test_workflow_posture_check.py
+++ b/tests/test_workflow_posture_check.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import workflow_posture_check as wpc
+
+
+def _make_workflow(root: Path, name: str, body: str) -> None:
+    wf_dir = root / ".github" / "workflows"
+    wf_dir.mkdir(parents=True, exist_ok=True)
+    (wf_dir / name).write_text(body, encoding="utf-8")
+
+
+def _make_map(root: Path, text: str) -> None:
+    map_path = root / "docs" / "ci" / "WORKFLOW_MAP.md"
+    map_path.parent.mkdir(parents=True, exist_ok=True)
+    map_path.write_text(text, encoding="utf-8")
+
+
+GOOD_READ_ONLY = """\
+name: Good
+on: [push]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+
+
+def test_minimal_permissions_helper() -> None:
+    assert wpc.is_minimal_permissions({"contents": "read"})
+    assert wpc.is_minimal_permissions({"contents": "none"})
+    assert not wpc.is_minimal_permissions({"contents": "write"})
+    assert not wpc.is_minimal_permissions({"issues": "write", "contents": "read"})
+    assert not wpc.is_minimal_permissions("write-all")
+    assert not wpc.is_minimal_permissions("read-all")
+
+
+def test_compliant_workflow_passes(tmp_path: Path) -> None:
+    _make_workflow(tmp_path, "ci.yml", GOOD_READ_ONLY)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is True
+    report = "\n".join(lines)
+    assert "PASS .github/workflows/ci.yml" in report
+
+
+def test_missing_permissions_fails(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace("permissions:\n  contents: read\n", "")
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("missing top-level 'permissions'" in line for line in lines)
+
+
+def test_missing_concurrency_fails(tmp_path: Path) -> None:
+    body = """\
+name: NoConcurrency
+on: [push]
+permissions:
+  contents: read
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"""
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("missing top-level 'concurrency'" in line for line in lines)
+
+
+def test_cancel_in_progress_must_be_true(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace("cancel-in-progress: true", "cancel-in-progress: false")
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("cancel-in-progress" in line for line in lines)
+
+
+def test_broad_permissions_require_documentation(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace("contents: read", "contents: write")
+    _make_workflow(tmp_path, "release.yml", body)
+    # Map does NOT mention release.yml.
+    _make_map(tmp_path, "# map without the workflow\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("not documented" in line for line in lines)
+
+
+def test_broad_permissions_pass_when_documented(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace("contents: read", "contents: write")
+    _make_workflow(tmp_path, "release.yml", body)
+    _make_map(tmp_path, "Exception: `release.yml` keeps `contents: write`.\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is True
+
+
+def test_no_workflows_is_ok(tmp_path: Path) -> None:
+    ok, lines = wpc.build_results(tmp_path)
+    assert ok is True
+    assert any("No workflow files found" in line for line in lines)
+
+
+def test_repo_workflows_meet_contract() -> None:
+    """The real repository workflows must satisfy the posture contract."""
+    ok, lines = wpc.build_results(wpc.REPO_ROOT)
+    assert ok is True, "\n".join(lines)

--- a/tools/verify_cards.py
+++ b/tools/verify_cards.py
@@ -99,9 +99,7 @@ def validate_ruecknahme_exit(path: Path, fields: dict[str, Any]) -> list[str]:
         )
 
     if fields.get("post_exit_claim") not in ("none", ""):
-        errors.append(
-            f"{path}: ruecknahme_exit post_exit_claim must be 'none' or empty"
-        )
+        errors.append(f"{path}: ruecknahme_exit post_exit_claim must be 'none' or empty")
 
     return errors
 

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -102,9 +102,7 @@ def build_results(root: Path) -> tuple[bool, list[str]]:
     """Run the check and return (ok, report_lines)."""
     workflows = find_workflows(root)
     map_path = root / WORKFLOW_MAP_REL
-    workflow_map_text = (
-        map_path.read_text(encoding="utf-8") if map_path.exists() else ""
-    )
+    workflow_map_text = map_path.read_text(encoding="utf-8") if map_path.exists() else ""
 
     lines: list[str] = ["# Workflow Posture Check", ""]
     if not workflows:

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Workflow posture drift check.
+
+Scans `.github/workflows/*.yml` and `.github/workflows/*.yaml` and verifies
+that each workflow keeps the CI/CD membrane contract:
+
+- a top-level ``permissions`` block is declared;
+- a top-level ``concurrency`` block is declared;
+- ``concurrency.cancel-in-progress`` is ``true``;
+- any permission broader than ``contents: read`` is documented as an
+  exception in ``docs/ci/WORKFLOW_MAP.md`` (the workflow filename must be
+  mentioned there).
+
+The check is read-only, deterministic, and needs no network access. It
+prints a PASS/FAIL summary and exits non-zero on drift.
+
+Usage:
+    python3 tools/workflow_posture_check.py [--root .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    print("[ERROR] PyYAML required. Install with: pip install pyyaml", file=sys.stderr)
+    sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_GLOBS = ("*.yml", "*.yaml")
+WORKFLOW_MAP_REL = "docs/ci/WORKFLOW_MAP.md"
+
+
+def find_workflows(root: Path) -> list[Path]:
+    """Return workflow files under ``.github/workflows`` sorted by name."""
+    wf_dir = root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return []
+    files: set[Path] = set()
+    for pattern in WORKFLOW_GLOBS:
+        files.update(wf_dir.glob(pattern))
+    return sorted(files, key=lambda p: p.name)
+
+
+def is_minimal_permissions(permissions: Any) -> bool:
+    """True if permissions are no broader than ``contents: read``.
+
+    A mapping is minimal when every entry is ``contents`` set to ``read`` (or
+    ``none``). Any extra scope, any ``write`` value, or a broad string form
+    such as ``write-all`` counts as broader and must be documented.
+    """
+    if isinstance(permissions, dict):
+        for scope, level in permissions.items():
+            if str(scope).strip().lower() != "contents":
+                return False
+            if str(level).strip().lower() not in ("read", "none"):
+                return False
+        return True
+    # String forms ("read-all", "write-all") or anything else are not minimal.
+    return False
+
+
+def check_workflow(path: Path, workflow_map_text: str) -> list[str]:
+    """Return a list of posture problems for a single workflow file."""
+    problems: list[str] = []
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        return [f"YAML parse error: {exc}"]
+
+    if not isinstance(doc, dict):
+        return ["top-level YAML is not a mapping"]
+
+    # permissions
+    if "permissions" not in doc:
+        problems.append("missing top-level 'permissions'")
+    elif not is_minimal_permissions(doc["permissions"]):
+        if path.name not in workflow_map_text:
+            problems.append(
+                "permissions broader than 'contents: read' but not documented "
+                f"in {WORKFLOW_MAP_REL}"
+            )
+
+    # concurrency
+    concurrency = doc.get("concurrency")
+    if "concurrency" not in doc:
+        problems.append("missing top-level 'concurrency'")
+    elif not isinstance(concurrency, dict):
+        problems.append("'concurrency' is not a mapping")
+    elif concurrency.get("cancel-in-progress") is not True:
+        problems.append("'concurrency.cancel-in-progress' is not true")
+
+    return problems
+
+
+def build_results(root: Path) -> tuple[bool, list[str]]:
+    """Run the check and return (ok, report_lines)."""
+    workflows = find_workflows(root)
+    map_path = root / WORKFLOW_MAP_REL
+    workflow_map_text = (
+        map_path.read_text(encoding="utf-8") if map_path.exists() else ""
+    )
+
+    lines: list[str] = ["# Workflow Posture Check", ""]
+    if not workflows:
+        lines.append("No workflow files found under .github/workflows/.")
+        return True, lines
+
+    all_ok = True
+    for wf in workflows:
+        problems = check_workflow(wf, workflow_map_text)
+        rel = wf.relative_to(root) if wf.is_relative_to(root) else wf
+        if problems:
+            all_ok = False
+            lines.append(f"FAIL {rel}")
+            for problem in problems:
+                lines.append(f"  - {problem}")
+        else:
+            lines.append(f"PASS {rel}")
+
+    lines.append("")
+    if all_ok:
+        lines.append(f"PASS: {len(workflows)} workflow(s) meet the posture contract.")
+    else:
+        lines.append("FAIL: workflow posture drift detected. See items above.")
+    return all_ok, lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify GitHub Actions workflows declare permissions and "
+        "concurrency guards (deterministic, read-only).",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help=f"Repository root to scan (default: {REPO_ROOT}).",
+    )
+    args = parser.parse_args(argv)
+
+    ok, lines = build_results(args.root)
+    print("\n".join(lines))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
FOKUS: CI/CD posture drift prevention

## 1. Summary

Adds a small, read-only checker that prevents CI/CD membrane drift. It verifies that every GitHub Actions workflow keeps the hardening contract that PR #220 established by hand: explicit `permissions`, a `concurrency` block, `cancel-in-progress: true`, and documented exceptions for any permission broader than `contents: read`.

This turns a manual review discipline into a deterministic, automatable check — so future workflow edits can't silently regress the posture.

## 2. Files changed

- `tools/workflow_posture_check.py` — the scanner. Read-only, deterministic, no network. Scans `.github/workflows/*.yml|*.yaml`, prints a PASS/FAIL summary, exits non-zero on drift.
- `tests/test_workflow_posture_check.py` — unit tests for each rule plus a test that the real repository workflows satisfy the contract.
- `Makefile` — new `workflow-posture-check` target (added to `.PHONY` and `help`).
- `docs/runbooks/pipeline_essentials.md` — documents and links the target.
- `docs/ci/WORKFLOW_MAP.md` — a `[FACT]` note that the checker enforces the existing maintenance rule.

## 3. Why this improves operational integrity

The permissions/concurrency contract was previously preserved only by reviewer memory and the prose rule in `WORKFLOW_MAP.md`. A new or edited workflow that forgot a `permissions` block, dropped `cancel-in-progress`, or quietly widened a token scope would pass review unnoticed. The checker makes that drift visible locally (`make workflow-posture-check`) and is wired so it can later become a CI gate. It reduces reliance on manual discipline without expanding any permissions.

## 4. What was intentionally NOT changed

- No workflow YAML was rewritten or auto-fixed — the checker only observes and reports.
- No CI gate was added or loosened; the check is opt-in via Make for now (additive).
- No conceptual / framework / receipt / GOLD content touched.
- No permission was widened; documented exceptions (`release.yml`, `void-sync.yml`) remain as-is.
- No new broad dependencies (uses PyYAML, already a repo dependency).

## 5. Verification steps

- `make workflow-posture-check` → PASS for all 11 workflows, exit 0.
- `python -m pytest tests/test_workflow_posture_check.py -q` → 9 passed.
- `python -m pytest tests/ -q` → 186 passed (after installing `pytest`, `pyyaml`, `numpy`, `scipy` into the fresh container; these were missing from the ephemeral environment, not removed by this change).

## Remaining risks / follow-ups

- The "broader than `contents: read`" rule is satisfied by the workflow filename appearing in `WORKFLOW_MAP.md`; it does not parse the table per-scope. This is intentionally simple and robust. A stricter table-aware variant could be a follow-up if desired.
- Optional follow-up PR: wire `workflow-posture-check` into a PR-stage CI job once it has settled as advisory.

https://claude.ai/code/session_01H3EERUiT8NbFwiv6NpHTCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3EERUiT8NbFwiv6NpHTCZ)_