### PR TITLE
Fix SSR hydration and focus duration edge case; update TypeScript config

### DIFF
--- a/ui-app/components/guards/GuardGrid.tsx
+++ b/ui-app/components/guards/GuardGrid.tsx
@@ -6,16 +6,23 @@ import { GuardStatusCard } from './GuardStatus';
 import { getGuardsWithStatus } from '@/lib/guard-definitions';
 
 export function GuardGrid() {
-  const [guards, setGuards] = useState<Guard[]>(() => getGuardsWithStatus());
+  const [guards, setGuards] = useState<Guard[]>([]);
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  // Simulate real-time updates (every 10 seconds)
+  // Keep SSR hydration deterministic; simulated statuses begin only after mount.
   useEffect(() => {
+    const initialRefresh = setTimeout(() => {
+      setGuards(getGuardsWithStatus());
+    }, 0);
+
     const interval = setInterval(() => {
       setGuards(getGuardsWithStatus());
     }, 10000);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearTimeout(initialRefresh);
+      clearInterval(interval);
+    };
   }, []);
 
   // Count statuses

--- a/ui-app/components/metatron/FocusIndicator.tsx
+++ b/ui-app/components/metatron/FocusIndicator.tsx
@@ -20,8 +20,8 @@ export function FocusIndicator({ focusState }: FocusIndicatorProps) {
     return () => clearInterval(interval);
   }, []);
 
-  // Calculate duration
-  const durationMs = now - since.getTime();
+  // Clamp duration because focus changes can arrive between minute ticks.
+  const durationMs = Math.max(0, now - since.getTime());
   const durationMin = Math.floor(durationMs / 60000);
   const durationHrs = Math.floor(durationMin / 60);
 

--- a/ui-app/tsconfig.json
+++ b/ui-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ES2017",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -21,6 +22,12 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Motivation

- Prevent SSR/client hydration mismatches by avoiding non-deterministic initial state on mount for guards.
- Avoid negative durations shown when focus changes arrive between minute ticks by clamping the computed interval.
- Ensure the app compiles with the newer JSX transform and includes dev-generated type files from Next.js.

### Description

- Initialize `guards` to an empty array in `GuardGrid` and schedule an immediate `setTimeout` to call `getGuardsWithStatus()` after mount, while keeping the existing 10s interval and cleaning up both timers. 
- Change duration calculation in `FocusIndicator` to `Math.max(0, now - since.getTime())` to prevent negative elapsed times.
- Update `ui-app/tsconfig.json` to set `target` to `ES2017`, switch `jsx` to `react-jsx`, and add `".next/dev/types/**/*.ts"` to the `include` list.

### Testing

- Ran TypeScript typecheck with `tsc --noEmit`, which completed successfully.
- Performed a production build with `npm run build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b8b6a7d6083259c93820665ae5388)