### PR TITLE
ci: pin JS workspace checkout action SHA

### DIFF
--- a/.github/workflows/ci-js-workspace.yml
+++ b/.github/workflows/ci-js-workspace.yml
@@ -37,7 +37,7 @@ jobs:
   workspace:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       # Use the pnpm version pinned in package.json#packageManager via Corepack.
       - name: Enable Corepack


### PR DESCRIPTION
## Summary

- Pins the remaining mutable JS workspace checkout reference from `actions/checkout@v6` to the reviewed checkout SHA `df4cb1c069e1874edd31b4311f1884172cec0e10`.
- Addresses the valid Codex review finding from superseded PR #242.
- Keeps this PR intentionally minimal: no dependency updates, no lockfile refresh, no VOID rebaseline, and no ANNEX/docs work.

## Context

PR #242 was stale/duplicated after merged PR #241 and should not be merged. It was closed to avoid replaying stale dependency/VOID changes. This PR carries forward only the remaining CI hardening finding.

## Verification

Prepared locally by Codex before auth failed:

- `make workflow-posture-check` ✅
- `make pipeline-essentials` ✅
- `pytest tests/test_pipeline_essentials.py` ✅
- `pnpm --filter entaengelment-ui typecheck` ✅
- `pnpm --filter entaengelment-ui lint` ✅

GitHub CI should re-run on this minimal branch.