### PR TITLE
FOKUS: align verifier membranes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ H ?= 0.84
 DMI ?= 4.7
 PHI ?= 0.72
 REFRACTORY ?= 120
+JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build
 
-.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials workflow-posture-check verify verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials workflow-posture-check verify verify-core verify-governance verify-js verify-all verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -35,7 +36,11 @@ help:
 	@echo "  make gate-test       Test gate toggle functionality"
 	@echo ""
 	@echo "DeepJump Protocol v1.2:"
-	@echo "  make verify          Phase 1: Verify pointers, claims, and tests"
+	@echo "  make verify          Phase 1: Core verify (ports, tests, pointers, claims)"
+	@echo "  make verify-core     Same core membrane as make verify, without status/snapshot"
+	@echo "  make verify-governance Check workflow posture and VOID backlog drift"
+	@echo "  make verify-js       Check JS/TS workspace with frozen pnpm lockfile + Turbo"
+	@echo "  make verify-all      Run core + governance + JS/TS verifier layers"
 	@echo "  make verify-pointers Check for dead pointers in index/modules"
 	@echo "  make claim-lint      Detect untagged claims in core artefacts"
 	@echo "  make status          Phase 2: Emit HMAC status (use status_emit.py for receipts)"
@@ -137,14 +142,37 @@ gate-test:
 # === DeepJump Protocol v1.2 ===
 
 # Phase 1: VERIFY (vor jedem Arbeitsschritt)
-verify: port-lint test verify-pointers claim-lint
+# Keep `verify` as the stable core membrane. Governance and JS/TS checks are
+# explicit layered gates so dependency PRs cannot be treated as covered by a
+# Python-only run, while small local edits stay ergonomically verifiable.
+verify: verify-core
 	@echo ""
 	@echo "=== VERIFY COMPLETE ==="
-	@echo "✅ Port-Matrix linter ran"
-	@echo "✅ Tests ran"
-	@echo "✅ Pointers checked"
-	@echo "✅ Claims linted"
+	@echo "✅ Core verify membrane passed"
 	@echo ""
+	@echo "Next layered gates when relevant:"
+	@echo "  make verify-governance  # workflow posture + VOID backlog drift"
+	@echo "  make verify-js          # ui-app / packages / pnpm workspace"
+	@echo ""
+
+verify-core: port-lint test verify-pointers claim-lint
+	@echo "✅ Core: ports, tests, pointers, and claims checked"
+
+verify-governance: workflow-posture-check voids-backlog-check
+	@echo "✅ Governance membrane checked"
+
+verify-js:
+	@echo "=== JS/TS WORKSPACE VERIFY ==="
+	@command -v pnpm >/dev/null 2>&1 || { \
+		echo "pnpm not found. Run 'corepack enable' so packageManager can provide pnpm."; \
+		exit 2; \
+	}
+	@pnpm install --frozen-lockfile
+	@$(JS_VERIFY_CMD)
+	@echo "✅ JS/TS workspace verified with frozen lockfile"
+
+verify-all: verify verify-governance verify-js
+	@echo "✅ All verifier layers passed"
 
 verify-pointers:
 	@echo "=== VERIFY POINTERS ==="

--- a/docs/ci/WORKFLOW_MAP.md
+++ b/docs/ci/WORKFLOW_MAP.md
@@ -25,6 +25,7 @@ Exception: `release.yml` keeps `contents: write` because it creates GitHub Relea
 |---------------|---------|-------------|-------------|
 | `.github/workflows/ci.yml` | Legacy/advisory CI plus non-PR verify/build/security/gate-policy jobs | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/ci-evidence-bundle.yml` | Evidence bundle generation | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/ci-js-workspace.yml` | JS/TS workspace membrane: frozen pnpm install plus Turbo typecheck/lint/build for UI/package changes | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/ci-policy-lint.yml` | Policy JSON lint | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/ci-smoke.yml` | Python smoke tests | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/deepjump-audit.reusable.yml` | Reusable DeepJump audit core | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |

--- a/docs/runbooks/pipeline_essentials.md
+++ b/docs/runbooks/pipeline_essentials.md
@@ -26,11 +26,32 @@ make workflow-posture-check
 
 Der Befehl ruft `tools/workflow_posture_check.py` auf und prüft read-only, ob jede Datei unter `.github/workflows/` einen expliziten `permissions`-Block sowie einen `concurrency`-Block mit `cancel-in-progress: true` deklariert. Berechtigungen, die breiter als `contents: read` sind, müssen in [`docs/ci/WORKFLOW_MAP.md`](../ci/WORKFLOW_MAP.md) als Ausnahme dokumentiert sein (der Workflow-Dateiname muss dort genannt werden). Der Check verändert keine Dateien, braucht kein Netzwerk und endet bei Drift mit Exit-Code 1.
 
+## Lokale Verifier-Membranen
+
+```bash
+make verify
+make verify-governance
+make verify-js
+make verify-all
+```
+
+[FACT] `make verify` bleibt der stabile Core-Entry-Point für Ports, Tests, Pointer und Claim-Lint. Governance- und JS/TS-Workspace-Checks sind eigene Membranen, damit kleine lokale Änderungen bedienbar bleiben und UI-/Dependency-PRs nicht versehentlich durch einen Python-only-Run als geprüft gelten.
+
+[FACT] `make verify-js` erzwingt `pnpm install --frozen-lockfile` und danach `pnpm turbo run typecheck lint build`. Damit werden UI-App- und Package-Änderungen an die gleiche Lockfile-/Workspace-Disziplin gebunden wie die PR-CI.
+
+[FACT] `make verify-governance` bündelt Workflow-Posture-Check und VOID-Backlog-Drift-Check. Es prüft keine inhaltliche VOID-Schließung, sondern ob die Repo-Artefakte synchron und posture-stabil bleiben.
+
+## Dependency-PR-Leseregel
+
+[FACT] Bei `ui-app/**`, `packages/**`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`, `package.json`, `turbo.json` oder `tsconfig.base.json` ist ein grüner Core-Verify allein nicht ausreichend. Vor Merge braucht es die JS/TS-Workspace-Membran: frozen lockfile install, typecheck, lint und build.
+
+[MODEL] Für das Repository ist das die F7-kompatible Lesart: kein `False OK` aus einem falschen Prüfraum. Ein Dependency-PR darf nicht durch Claims-/Pointer-/Python-Checks als ausreichend validiert erscheinen, wenn seine eigentliche Wirkung im UI-/Workspace-Membranraum liegt.
+
 ## Konkrete Ausbau-Möglichkeiten
 
 | ID | Möglichkeit | Nutzen | Nächster Schritt |
 |----|-------------|--------|------------------|
-| ESS-001 | `make verify` als lokaler Single-Entry-Point | Weniger Bedienfehler vor PRs | Im Contributor-Flow weiter als Pflichtschritt kommunizieren |
+| ESS-001 | `make verify` als lokaler Core-Entry-Point | Weniger Bedienfehler vor PRs | Im Contributor-Flow weiter als Pflichtschritt kommunizieren |
 | ESS-002 | Receipt-Lint früher laufen lassen | Audit-Drift wird vor Release sichtbar | Scope für `receipts/` und `ark/p4/receipts/` festlegen |
 | ESS-003 | VOID-Backlog-Drift in PR-CI prüfen | Governance-Doku bleibt synchron zur `VOIDMAP.yml` | `make voids-backlog-check` in eine PR-Workflow-Stufe aufnehmen |
 | ESS-004 | Frame-Lint kanonisch scopen | Operative Frames werden maschinell konsistent | `FRAME_LINT_PATHS` verbindlich festlegen |
@@ -38,6 +59,10 @@ Der Befehl ruft `tools/workflow_posture_check.py` auf und prüft read-only, ob j
 | ESS-006 | Snapshot-Artefakte konsequent hochladen | Reproduzierbarkeit wird leichter auditierbar | Manifest-Upload für geplante Runs prüfen |
 | ESS-007 | Lokale Dependency-Audit-Vorstufe | Release-Prep erkennt Risiko früher | Optionales Make-Target für leichte Audits ergänzen |
 | ESS-008 | Gepinnte Actions rotieren | Supply-Chain-Risiko bleibt reviewbar | SHA-Rotation über dedizierte Dependency-PRs planen |
+| ESS-009 | Lokaler JS/TS-Workspace-Verifier | UI-/Package-Änderungen werden im richtigen Prüfraum validiert | `make verify-js` bei Dependency-/UI-PRs verpflichtend lesen |
+| ESS-010 | Blocking JS/TS Workspace PR Gate | Dependabot-PRs laufen gegen frozen Lockfile + Turbo | CI-Ergebnisse vor Merge prüfen; kein Merge bei Package-/Lockfile-Drift |
+| ESS-011 | Workflow Map synchron halten | Verifier-Membranen bleiben auditierbar | Neue Workflows sofort in `docs/ci/WORKFLOW_MAP.md` eintragen |
+| ESS-012 | Einheitliche Node-Major-Version | Verhindert split-brain zwischen UI-Build und Workspace-CI | JS-Testworkflow und Workspace-CI auf dieselbe Node-Major-Version halten |
 
 ## Härtungsregel
 

--- a/tests/test_pipeline_essentials.py
+++ b/tests/test_pipeline_essentials.py
@@ -9,11 +9,16 @@ def test_build_report_lists_all_essentials(tmp_path: Path) -> None:
     (tmp_path / "Makefile").write_text(
         "\n".join(
             [
-                "verify: port-lint test verify-pointers claim-lint",
+                "JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build",
+                "verify: verify-core",
+                "verify-core: port-lint test verify-pointers claim-lint",
                 "voids-backlog-check:",
                 "frame-lint: FRAME_LINT_PATHS",
                 "status-verify: status tools/status_verify.py",
                 "snapshot: --strict",
+                "verify-js:",
+                "\tpnpm install --frozen-lockfile",
+                "\t$(JS_VERIFY_CMD)",
             ]
         ),
         encoding="utf-8",
@@ -23,6 +28,17 @@ def test_build_report_lists_all_essentials(tmp_path: Path) -> None:
     (workflows / "release.yml").write_text("tools/receipt_lint.py", encoding="utf-8")
     (workflows / "ci.yml").write_text(
         "pip-audit\nactions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",
+        encoding="utf-8",
+    )
+    (workflows / "ci-js-workspace.yml").write_text(
+        "node-version: 22\npnpm install --frozen-lockfile\npnpm turbo run typecheck lint build",
+        encoding="utf-8",
+    )
+    (workflows / "test.yml").write_text("node-version: '22'", encoding="utf-8")
+    docs_ci = tmp_path / "docs" / "ci"
+    docs_ci.mkdir(parents=True)
+    (docs_ci / "WORKFLOW_MAP.md").write_text(
+        ".github/workflows/ci-js-workspace.yml\nJS/TS workspace membrane",
         encoding="utf-8",
     )
 

--- a/tools/pipeline_essentials.py
+++ b/tools/pipeline_essentials.py
@@ -27,8 +27,8 @@ CHECKS: tuple[EssentialCheck, ...] = (
         id="ESS-001",
         title="Canonical local verify entrypoint",
         path="Makefile",
-        needles=("verify: port-lint test verify-pointers claim-lint",),
-        recommendation="Keep `make verify` as the single local pre-merge command.",
+        needles=("verify: verify-core", "verify-core: port-lint test verify-pointers claim-lint"),
+        recommendation="Keep `make verify` as the stable core pre-merge command and name additional membranes explicitly.",
     ),
     EssentialCheck(
         id="ESS-002",
@@ -78,6 +78,34 @@ CHECKS: tuple[EssentialCheck, ...] = (
         path=".github/workflows/ci.yml",
         needles=("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10",),
         recommendation="Keep action SHAs pinned and rotate them through reviewable dependency PRs.",
+    ),
+    EssentialCheck(
+        id="ESS-009",
+        title="Local JS/TS workspace verifier",
+        path="Makefile",
+        needles=("verify-js:", "pnpm install --frozen-lockfile", "JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build"),
+        recommendation="Use `make verify-js` before merging UI/package dependency PRs so package changes do not get a Python-only OK.",
+    ),
+    EssentialCheck(
+        id="ESS-010",
+        title="Blocking JS/TS workspace PR gate",
+        path=".github/workflows/ci-js-workspace.yml",
+        needles=("pnpm install --frozen-lockfile", "pnpm turbo run typecheck lint build", "node-version: 22"),
+        recommendation="Keep UI dependency PRs bound to frozen-lockfile install plus typecheck/lint/build.",
+    ),
+    EssentialCheck(
+        id="ESS-011",
+        title="Workflow map includes JS workspace membrane",
+        path="docs/ci/WORKFLOW_MAP.md",
+        needles=(".github/workflows/ci-js-workspace.yml", "JS/TS workspace membrane"),
+        recommendation="Keep the workflow map synchronized when verifier membranes are added or split.",
+    ),
+    EssentialCheck(
+        id="ESS-012",
+        title="JS test workflow uses the workspace Node major",
+        path=".github/workflows/test.yml",
+        needles=("node-version: '22'",),
+        recommendation="Avoid split-brain JS verification by using the same Node major for workspace and UI build checks.",
     ),
 )
 

--- a/tools/pipeline_essentials.py
+++ b/tools/pipeline_essentials.py
@@ -83,14 +83,22 @@ CHECKS: tuple[EssentialCheck, ...] = (
         id="ESS-009",
         title="Local JS/TS workspace verifier",
         path="Makefile",
-        needles=("verify-js:", "pnpm install --frozen-lockfile", "JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build"),
+        needles=(
+            "verify-js:",
+            "pnpm install --frozen-lockfile",
+            "JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build",
+        ),
         recommendation="Use `make verify-js` before merging UI/package dependency PRs so package changes do not get a Python-only OK.",
     ),
     EssentialCheck(
         id="ESS-010",
         title="Blocking JS/TS workspace PR gate",
         path=".github/workflows/ci-js-workspace.yml",
-        needles=("pnpm install --frozen-lockfile", "pnpm turbo run typecheck lint build", "node-version: 22"),
+        needles=(
+            "pnpm install --frozen-lockfile",
+            "pnpm turbo run typecheck lint build",
+            "node-version: 22",
+        ),
         recommendation="Keep UI dependency PRs bound to frozen-lockfile install plus typecheck/lint/build.",
     ),
     EssentialCheck(


### PR DESCRIPTION
## Summary

- Keep `make verify` as the stable core verifier.
- Add explicit layered gates: `verify-governance`, `verify-js`, and `verify-all`.
- Add JS workspace essentials to the pipeline scanner.
- Document the JS workspace workflow in the CI map.
- Align JS/UI test jobs with the workspace Node major.

## Notes

- Review open dependency PRs #245, #246, and #247 with the JS workspace verifier before merge.
- Issue #240 remains open governance work.
- No merge or issue closure was performed.

## Validation

- Not run locally in this environment; CI should validate the draft branch.
