### PR TITLE
chore(repo): scope audit ignore rule to root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,19 +98,19 @@ out/
 # Claude local config
 CLAUDE.local.md
 
-# Audit reports (temporary)
-audit/
-!audit/METATRON_COMPLIANCE_BACKLOG.md
-!audit/DEEP_AUDIT_REPORT_*.md
-!audit/SESSION.yaml
-!audit/INVENTORY.md
-!audit/STRUCTURE_MAP.md
-!audit/MISSING_FILES.md
-!audit/DUPLICATES.md
-!audit/WORKFLOW_AUDIT.md
-!audit/VERIFY_MATRIX.md
-!audit/SECURITY_NOTES.md
-!audit/SWOT.md
-!audit/CONCLUSION.md
-!audit/ACTION_PLAN.md
-!audit/FILE_MANIFEST.csv
+# Audit reports (temporary) — root-level only, so docs/audit/ stays tracked.
+/audit/
+!/audit/METATRON_COMPLIANCE_BACKLOG.md
+!/audit/DEEP_AUDIT_REPORT_*.md
+!/audit/SESSION.yaml
+!/audit/INVENTORY.md
+!/audit/STRUCTURE_MAP.md
+!/audit/MISSING_FILES.md
+!/audit/DUPLICATES.md
+!/audit/WORKFLOW_AUDIT.md
+!/audit/VERIFY_MATRIX.md
+!/audit/SECURITY_NOTES.md
+!/audit/SWOT.md
+!/audit/CONCLUSION.md
+!/audit/ACTION_PLAN.md
+!/audit/FILE_MANIFEST.csv

--- a/docs/decisions/ADR-0001-audit-directory-consolidation.md
+++ b/docs/decisions/ADR-0001-audit-directory-consolidation.md
@@ -38,6 +38,17 @@ Alle neuen Audit-Deliverables (Auditbericht, Ergebnisbericht) werden in das
 Reine Verzeichnis-/Ablageentscheidung. Keine inhaltliche Umdeutung, kein
 Kanon-Begriff berührt. Claim-Disziplin und symbolische Architektur unverändert.
 
+## Update 2026-06-16 (Follow-up nach PR #252)
+
+- [FAKT] `docs/audit/` bleibt vorerst der **bestätigte** kanonische Audit-Pfad.
+  Eine spätere Pluralisierung (`docs/audits/`) wäre Gegenstand einer eigenen ADR.
+- [FAKT] Die `.gitignore`-Regel `audit/` (erfasste auch `docs/audit/` und erzwang
+  `git add -f`) wurde auf Root-Ebene eingegrenzt: `/audit/` (inkl. anker-korrekter
+  Negationen `!/audit/…`). Neue Reports unter `docs/audit/` sind jetzt ohne `-f`
+  trackbar; top-level `audit/`-Verhalten bleibt identisch.
+- [FAKT] Rein struktureller Safe Patch — kein Kanon-, Spec-, VOID-, Claim- oder
+  Roadmap-Inhalt verändert.
+
 ## Linked VOID / Spec / Claim
 
 - Audit: `docs/audit/revolutionary_repo_audit_2026-06-16.md` §4, §8, §10


### PR DESCRIPTION
FOKUS: .gitignore-Falle abdichten

> FOKUS-SWITCH: keiner. Kleiner Folge-Patch nach PR #252 — Abdichtung, keine Expansion.

## Was

Behebt **ausschließlich** die in PR #252 entdeckte Repo-Hygiene-Falle:
Die `.gitignore`-Regel `audit/` erfasste auch `docs/audit/`, sodass neue
Auditberichte nur mit `git add -f` trackbar waren.

- `audit/` → `/audit/` (Root-Ebene)
- Negationen `!audit/…` → `!/audit/…` (anker-konsistent)
- Kurze Update-Notiz in `docs/decisions/ADR-0001-audit-directory-consolidation.md`

## Verifikation (`git check-ignore --no-index`)

| Pfad | vorher | nachher |
|------|--------|---------|
| `docs/audit/<neuer-report>.md` | ignoriert (`audit/`) | **nicht** ignoriert ✓ |
| top-level `audit/<temp>.md` | ignoriert | ignoriert ✓ (unverändert) |
| getrackte `docs/audit/*` | getrackt | getrackt ✓ |

`git status` sieht eine neue `docs/audit/`-Datei jetzt als `??` (untracked, addbar
ohne `-f`). Lokale Guards grün (exit 0): `claim_lint --strict`, `verify_pointers
--strict`, `workflow_posture_check`.

## Essenz

Rein struktureller Safe Patch. **Kein** Kanon-, Spec-, VOID-, Claim- oder
Roadmap-Inhalt verändert. `docs/audit/` bleibt bestätigter kanonischer Pfad
(eine etwaige Pluralisierung wäre eine eigene ADR).

## Bewusst NICHT in diesem PR (offene nächste Review-Punkte)

1. Advisory CI-Gates (YAML → Linkcheck → VOIDMAP-Schema → Claim/Receipt/Exchange) — erst warnend, später blockierend
2. Registries / Glossary
3. `docs/spec/` vs. `docs/specs/`
4. R4 / G3-Archivierung vermeintlich toter Module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oLHijJhXPrbpk8sbN6YG7)_