### PR TITLE
docs(security): security posture baseline + ADR-0003 (code scanning)

### DIFF
--- a/docs/audit/security_posture_baseline_2026-06-16.md
+++ b/docs/audit/security_posture_baseline_2026-06-16.md
@@ -1,0 +1,140 @@
+# Security Posture Baseline — entaENGELment-
+
+**Datum:** 2026-06-16
+**Fokus:** Security-Posture sichtbar machen (Read-Only Baseline)
+**Branch:** `chore/security-posture-baseline`
+**Basis-HEAD:** `3fefe82` (main nach PR #252, #253)
+
+> Zielsatz: Dieser PR behauptet keine Sicherheit, sondern macht sichtbar, welche
+> Membranen bereits tragen — und welche nur als **offene Toggles außerhalb des
+> Repo-Codes** markiert sind. Anti-F7: keine unmarkierte falsche Sicherheit.
+
+---
+
+## 0. Claim-Disziplin
+
+- **[FAKT]** verifizierbar aus Repo-Dateien / CI-Konfiguration.
+- **[INFERENZ]** abgeleitet, nicht direkt gemessen.
+- **[MODELL]** Deutung / Empfehlung.
+- **[HYPOTHESE]** Erwartung, unbelegt.
+
+**Limitierung:** Repo-/Org-**Settings** (Branch-Protection, Secret-Scanning,
+Dependabot-Alerts/Security-Updates, „allow auto-merge", Code-Scanning-Aktivierung)
+sind **nicht** aus dem Dateibaum verifizierbar und konnten in diesem Read-Only-Lauf
+**nicht** bestätigt werden. Sie sind unten als **OFFENER TOGGLE** markiert. **[FAKT]**
+
+---
+
+## 1. Was bereits trägt (dateibasiert verifizierbar)
+
+| # | Mechanismus | Beleg | Status |
+|---|-------------|-------|--------|
+| S1 | Dependency-Audit (JS+Py), blockierend ab `high` | `.github/workflows/security-audit.yml` (`pnpm audit --audit-level=high`, `pip-audit`) | [FAKT] aktiv |
+| S2 | Dependabot Version-Updates (pip, npm `/ui-app`, github-actions) | `.github/dependabot.yml` | [FAKT] konfiguriert |
+| S3 | SBOM-Generierung | `.github/workflows/sbom.yml` | [FAKT] aktiv |
+| S4 | Static-Security-Lint (Python) | `bandit` in `ci.yml` `security`-Job, `.bandit.yaml` | [FAKT] aktiv |
+| S5 | Actions auf **SHA gepinnt** | z. B. `actions/checkout@df4cb1c…`, `setup-node@48b55a…` | [FAKT] durchgehend |
+| S6 | Minimale Workflow-Permissions + Concurrency | alle 13 Workflows; `tools/workflow_posture_check.py` (13/13 PASS) | [FAKT] erzwungen lokal |
+| S7 | Nur 2 Workflows mit Schreibrecht, dokumentiert | `release.yml` (`contents: write`), `void-sync.yml` (`issues: write`) in `docs/ci/WORKFLOW_MAP.md` | [FAKT] |
+| S8 | Pre-commit-Guards | `.githooks/pre-commit`, `make install-hooks` | [FAKT] vorhanden (opt-in) |
+| S9 | Security-Policy | `SECURITY.md` | [FAKT] vorhanden |
+| S10 | HMAC-signierte Status-Receipts | `tools/status_emit.py`, `tools/status_verify.py` | [FAKT] vorhanden |
+
+**[INFERENZ]** Die dateibasierte Supply-Chain-/CI-Membran ist für ein Repo dieser
+Größe überdurchschnittlich gehärtet.
+
+---
+
+## 2. Fehlende dateibasierte Bausteine
+
+| # | Lücke | Wirkung | Empfehlung |
+|---|-------|---------|------------|
+| G1 | **Kein CodeQL / Code Scanning** | Keine semantische Schwachstellenanalyse (SAST über Datenfluss) | Code Scanning aktivieren — siehe §4 + ADR-0003 |
+| G2 | SHA-Pin-Invariante nicht maschinell geprüft | Drift möglich (neue Workflows mit Tag-Pins) | optionaler advisory Lint (Roadmap §4) |
+
+**[FAKT]** Erkannte Sprachen (für Code Scanning relevant): Python (99 `*.py`),
+JavaScript/TypeScript (28 `*.ts/tsx`, 18 `*.js/jsx`; Next.js `ui-app`, `packages/*`).
+CodeQL-Zielsprachen wären `python` und `javascript-typescript`.
+
+---
+
+## 3. OFFENE TOGGLES — Repo-Settings (NICHT dateibasiert; deine Hand)
+
+> **[FAKT]** Diese Punkte sind **keine** Dateiänderungen und konnten hier **nicht**
+> verifiziert werden. Sie müssen in den GitHub-Repo-Settings geprüft/aktiviert
+> werden. Status hier = **UNBEKANNT/OFFENER TOGGLE**, nicht „erledigt".
+
+| # | Toggle | Wo | Empfohlener Zielzustand |
+|---|--------|----|--------------------------|
+| T1 | **Branch Protection / Ruleset für `main`** | Settings → Rules/Branches | keine Force-Pushes; keine Deletion; required status checks; required PR review | 
+| T2 | **Required status checks** auf `main` | Ruleset | mind. DeepJump CI, Tests, Smoke, Policy Lint, Metatron Guard |
+| T3 | **Secret Scanning** (+ Push Protection) | Settings → Code security | aktiv |
+| T4 | **Dependabot Alerts** | Settings → Code security | aktiv (Voraussetzung für T5) |
+| T5 | **Dependabot Security Updates** | Settings → Code security | aktiv (öffnet PRs für patchbare Alerts) |
+| T6 | **Code Scanning Aktivierung** | Settings → Code security | Default Setup (empfohlen) oder Advanced (ADR-0003) |
+| T7 | **Allow auto-merge** | Settings → General | **bewusst NICHT jetzt** (siehe §5) |
+
+**Checkliste zum Abhaken (durch dich):**
+
+- [ ] ☐ T1 Branch-Ruleset `main`: Force-Push aus, Deletion aus
+- [ ] ☐ T2 Required checks gesetzt
+- [ ] ☐ T3 Secret Scanning + Push Protection aktiv
+- [ ] ☐ T4 Dependabot Alerts aktiv
+- [ ] ☐ T5 Dependabot Security Updates aktiv
+- [ ] ☐ T6 Code Scanning aktiviert (Default Setup oder ADR-0003-Workflow)
+- [ ] ☐ T7 Auto-Merge: **bleibt aus** (eigener späterer Entscheid)
+
+---
+
+## 4. Code Scanning — empfohlener Weg
+
+**[MODELL]** Zwei dokumentierte Pfade (Details + Workflow-Vorlage in ADR-0003):
+
+1. **Default Setup (empfohlen, wartungsarm):** in den Repo-Settings aktivieren.
+   GitHub wählt Sprachen/Queries automatisch, läuft auf Push/PR + Zeitplan. Kein
+   Action-Pinning, keine Workflow-Pflege.
+2. **Advanced Setup (versioniert):** committete `.github/workflows/codeql.yml` mit
+   minimalen Permissions. Mehr Kontrolle, aber: **`github/codeql-action` muss auf
+   einen aktuellen Release-SHA gepinnt** werden, um die Repo-SHA-Pin-Invariante zu
+   wahren.
+
+**[FAKT] Bewusste Entscheidung dieses PRs:** Es wird **keine aktive `codeql.yml`
+committet**, weil ein aktueller `github/codeql-action`-SHA in dieser Read-Only-
+Umgebung **nicht verifizierbar** ist. Einen SHA zu raten wäre falsche Sicherheit
+(Anti-F7). Die Advanced-Vorlage liegt in ADR-0003 mit explizitem Pin-Hinweis;
+primär empfohlen ist Default Setup (T6).
+
+---
+
+## 5. Auto-Merge — bewusst nicht jetzt
+
+**[FAKT]** Dieser PR aktiviert **kein** Auto-Merge und ändert `dependabot.yml` nicht.
+**[MODELL]** Empfehlung für einen späteren, eigenen Entscheid: höchstens
+*patch-only* Dependabot-Auto-Merge unter grüner CI, niemals Major/Minor, keine
+neuen Dependencies, keine Workflow-/Permission-Änderungen ohne Review.
+
+---
+
+## 6. Offene Risiken
+
+- **[FAKT]** Settings-Toggles (§3) sind unverifiziert — Posture ist nur so stark
+  wie deren tatsächlicher Zustand. Dieser Bericht behauptet sie **nicht** als aktiv.
+- **[HYPOTHESE]** Ohne Branch-Protection auf `main` sind direkte Pushes/Force-Pushes
+  technisch möglich; Auswirkung abhängig vom realen Settings-Stand.
+- **[FAKT]** Dependabot meldete beim Push 4 Advisories auf dem Default-Branch
+  (2 high, 1 moderate, 1 low) — sichtbar in der GitHub-Security-Übersicht; deren
+  Behebung ist ein eigener Vorgang (nicht Teil dieses Baseline-PRs).
+
+---
+
+## 7. Nächste Schritte (separiert)
+
+1. Settings-Toggles §3 durch dich; danach Checkliste abhaken.
+2. Code Scanning aktivieren (Default Setup empfohlen).
+3. Später eigener PR/Entscheid: Dependabot patch-only Auto-Merge unter grüner CI.
+4. Optional: advisory SHA-Pin-Lint (Roadmap).
+
+## 8. Artefakte
+
+- `docs/audit/security_posture_baseline_2026-06-16.md` (dieser Bericht)
+- `docs/decisions/ADR-0003-security-baseline-and-code-scanning.md`

--- a/docs/decisions/ADR-0003-security-baseline-and-code-scanning.md
+++ b/docs/decisions/ADR-0003-security-baseline-and-code-scanning.md
@@ -1,0 +1,122 @@
+# ADR-0003: Security Baseline & Code Scanning
+
+- **Status:** Accepted (Baseline-Dokumentation) / Proposed (Code-Scanning-Aktivierung)
+- **Datum:** 2026-06-16
+- **Kontext-Fokus:** Security-Posture-Baseline (PR #254)
+
+## Context
+
+Nach PR #252 (Audit/Zukunftsarchitektur) und PR #253 (`.gitignore`-Fix) ist der
+nächste reife Schritt eine **Security-Posture-Baseline** — nicht ein Feature-Sprung.
+Das Repo besitzt bereits Dependency-Audits, SBOM, Bandit, Dependabot-Version-Updates,
+SHA-gepinnte Actions und minimale Workflow-Permissions (siehe
+`docs/audit/security_posture_baseline_2026-06-16.md`). Es fehlt **Code Scanning
+(CodeQL)**. Mehrere Härtungspunkte sind **Repo-Settings**, keine Dateien.
+
+## Decision
+
+1. **Baseline sichtbar machen** statt Sicherheit behaupten: vorhandene Stärken,
+   fehlende dateibasierte Bausteine und **offene Settings-Toggles** werden
+   explizit als solche markiert (Anti-F7).
+2. **Code Scanning:** primär **Default Setup** in den Repo-Settings empfehlen
+   (wartungsarm, kein Action-Pinning). **Keine aktive `codeql.yml`** wird in diesem
+   PR committet, weil ein aktueller `github/codeql-action`-SHA in der Read-Only-
+   Audit-Umgebung **nicht verifizierbar** ist; ein geratener SHA wäre falsche
+   Sicherheit. Die Advanced-Variante liegt unten als **Vorlage** (vor Aktivierung
+   SHA-pinnen).
+3. **Kein Auto-Merge** in diesem PR; `dependabot.yml` bleibt unverändert.
+4. **Keine** Framework-Kanon-, Spec-, VOID-, Claim- oder Roadmap-Inhalte berührt.
+
+## Consequences
+
+- (+) Ehrliche Posture: „trägt bereits" vs. „offener Toggle" klar getrennt.
+- (+) Kein Workflow mit unverifiziertem SHA; keine falsche Sicherheit.
+- (−) Code Scanning ist erst aktiv, wenn du Default Setup togglest **oder** die
+  Vorlage SHA-gepinnt aktivierst.
+- (−) Settings-Härtung (Branch-Protection etc.) bleibt manuell (außerhalb dieses PRs).
+
+## Alternatives Considered
+
+1. **Aktive `codeql.yml` mit geratenem/Tag-Pin committen** — verworfen: verletzt die
+   SHA-Pin-Invariante bzw. riskiert falsche Sicherheit (Anti-F7).
+2. **Branch-Protection per PR setzen** — nicht möglich: Rulesets sind Repo-Settings,
+   nicht dateibasiert und nicht über die hier verfügbaren Tools schaltbar.
+3. **Auto-Merge jetzt aktivieren** — verworfen: erst Baseline, separater späterer
+   Entscheid (patch-only, grüne CI).
+
+## Essence Preservation Note
+
+Reine Infrastruktur-/Governance-Entscheidung. Kein Kanon-Begriff, keine symbolische
+Architektur, keine Claim-Grenze verändert.
+
+## Linked VOID / Spec / Claim
+
+- Baseline: `docs/audit/security_posture_baseline_2026-06-16.md`
+- Kein VOID, keine Spec berührt.
+
+---
+
+## Appendix A — CodeQL Advanced-Setup Vorlage (NICHT aktiv)
+
+> [FAKT] Dies ist eine **Vorlage**, kein aktiver Workflow. Vor Verwendung:
+> `github/codeql-action/*` auf einen **aktuellen Release-SHA pinnen** (Kommentar
+> mit Versionstag), passend zur Repo-Konvention. Datei dann nach
+> `.github/workflows/codeql.yml` legen und committen.
+
+```yaml
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "0 4 * * 1"   # wöchentlich, Montag
+  workflow_dispatch:
+
+# Minimale Permissions: nur was Code Scanning braucht.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # Upload der Scan-Ergebnisse
+      packages: read           # private CodeQL packs
+      actions: read            # private repo workflow metadata
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python", "javascript-typescript"]
+    steps:
+      - name: Checkout
+        # SHA bereits im Repo verwendet (actions/checkout v6.0.3) — wiederverwendbar:
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Initialize CodeQL
+        # TODO(pin): auf aktuellen github/codeql-action-Release-SHA pinnen.
+        uses: github/codeql-action/init@<SHA>  # vX.Y.Z
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@<SHA>  # vX.Y.Z
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@<SHA>  # vX.Y.Z
+        with:
+          category: "/language:${{ matrix.language }}"
+```
+
+> Hinweis: Bei reinem Python/JS/TS ist i. d. R. kein Build nötig; `autobuild` kann
+> entfallen. Vor Aktivierung mit `tools/workflow_posture_check.py` und
+> `docs/ci/WORKFLOW_MAP.md` abgleichen (neuer Workflow muss dort eingetragen werden,
+> da `security-events: write` über `contents: read` hinausgeht).


### PR DESCRIPTION
FOKUS: Security-Posture sichtbar machen

> FOKUS-SWITCH: keiner. Eng geschnittener Baseline-PR (#254) — Tragfähigkeit vor Glanz, kein Feature-Feuerwerk.

## Was

Rein **dokumentierender** Security-Posture-Baseline-PR. Zwei neue Dateien, **0 Bestandsdateien geändert**:
- `docs/audit/security_posture_baseline_2026-06-16.md` — read-only Audit der Security-Mechanismen
- `docs/decisions/ADR-0003-security-baseline-and-code-scanning.md` — Baseline-Entscheid + CodeQL-Vorlage

## Goldener Satz

> Dieser PR behauptet keine Sicherheit, sondern macht sichtbar, welche Membranen bereits tragen — und welche nur als offene Toggles außerhalb des Repo-Codes markiert sind.

## Was bereits trägt (verifiziert)

Dependency-Audits (`security-audit.yml`, blockierend ab high), Dependabot Version-Updates, SBOM, Bandit, **SHA-gepinnte Actions**, minimale Workflow-Permissions (13/13 posture PASS), `SECURITY.md`, HMAC-Receipts.

## Bewusste Entscheidungen (Anti-F7)

- **Code Scanning:** Default Setup empfohlen. **Keine aktive `codeql.yml` committet**, weil ein aktueller `github/codeql-action`-SHA offline **nicht verifizierbar** ist — ein geratener SHA wäre falsche Sicherheit. Advanced-Setup liegt als **SHA-zu-pinnende Vorlage** in ADR-0003 (Appendix A). Erkannte Zielsprachen: `python` + `javascript-typescript`.
- **Repo-Settings bleiben deine Toggles** (nicht dateibasiert, nicht über meine Tools schaltbar): Branch-Protection/Ruleset, Required checks, Secret Scanning, Dependabot Alerts/Security Updates, Code-Scanning-Aktivierung, Allow auto-merge. Als **OFFENE TOGGLES** mit Abhak-Checkliste markiert — Status *unbekannt*, **nicht** „erledigt".
- **Auto-Merge: bewusst NICHT jetzt.** `dependabot.yml` unverändert. Patch-only-Automerge bleibt späterer eigener Entscheid.

## Essenz

Reine Infrastruktur-/Governance-Dokumentation. **Kein** Kanon-, Spec-, VOID-, Claim- oder Roadmap-Inhalt verändert. Lokale Guards grün (claim_lint --strict, verify_pointers --strict, workflow_posture_check).

## Offene Risiken (transparent)

- Settings-Toggles unverifiziert — Posture ist nur so stark wie deren realer Zustand.
- 4 Dependabot-Advisories auf dem default branch (2 high / 1 mod / 1 low) — eigener Vorgang, nicht Teil dieses PRs.

## Nicht in diesem PR (separierte nächste Stufen)

PR #255 Dependabot/Automerge-Entscheid · PR #256 README-Eingangsmembran · `docs/spec` vs `docs/specs` · R4/G3-Archivierung · advisory CI-Gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oLHijJhXPrbpk8sbN6YG7)_