### PR TITLE
docs(intake): calm document intake layer + local helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,16 @@ VOIDMAP.yml konsultieren für:
 - Nicht-Ziele respektieren
 ```
 
+### Pattern F: Intake-First für unverortete Artefakte
+```
+Wenn in einer Session neue Dokumente, Entwürfe, Wrap-ups oder Modellantworten
+entstehen und KEIN expliziter kanonischer Zielpfad genannt wurde:
+1. Als Intake-Kandidat behandeln → docs/intake/raw/ bzw. tools/intake_add.py
+2. Niemals automatisch nach canon/spec/VOIDMAP/glossary/roadmap migrieren
+3. Ablegen ist erlaubt; Kanonisierung nur nach menschlichem Review
+→ Details: docs/intake/README.md
+```
+
 ---
 
 ## Stop Conditions

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PHI ?= 0.72
 REFRACTORY ?= 120
 JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build
 
-.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials workflow-posture-check verify verify-core verify-governance verify-js verify-all verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials workflow-posture-check verify verify-core verify-governance verify-js verify-all verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay intake
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -63,6 +63,10 @@ help:
 	@echo "  make voids-backlog-check Verify docs/voids_backlog.md is in sync (exit 1 on drift)"
 	@echo "  make pipeline-essentials  Report pipeline essentials and next expansion options"
 	@echo "  make workflow-posture-check Verify workflows declare permissions + concurrency (exit 1 on drift)"
+	@echo ""
+	@echo "Intake (Calm Intake Layer):"
+	@echo "  make intake FILE=<path> TITLE=\"<title>\" SOURCE=\"<source>\""
+	@echo "                       Capture a document into docs/intake/raw/ (no canonisation)"
 
 # === Setup ===
 install:
@@ -196,6 +200,15 @@ pipeline-essentials:
 # CI/CD posture drift check: verify workflows declare permissions + concurrency.
 workflow-posture-check:
 	@$(PY) tools/workflow_posture_check.py
+
+# Calm Intake Layer: capture a document into docs/intake/raw/ (no canonisation).
+# Thin wrapper around tools/intake_add.py. See docs/intake/README.md.
+intake:
+	@if [ -z "$(FILE)" ] || [ -z "$(TITLE)" ] || [ -z "$(SOURCE)" ]; then \
+		echo "Usage: make intake FILE=<path> TITLE=\"<title>\" SOURCE=\"<source>\""; \
+		exit 2; \
+	fi
+	@$(PY) tools/intake_add.py --file "$(FILE)" --title "$(TITLE)" --source "$(SOURCE)"
 
 # Phase 2: STATUS (HMAC Receipt)
 status:

--- a/docs/audit/intake_layer_result_2026-06-16.md
+++ b/docs/audit/intake_layer_result_2026-06-16.md
@@ -1,0 +1,103 @@
+# Calm Intake Layer — Result Report (PR #255)
+
+**Datum:** 2026-06-16
+**Fokus:** Intake-/Flow-Fänger einziehen (additiv)
+**Branch:** `chore/intake-layer`
+**Basis-HEAD:** `2ec5f3f` (main nach #252, #253, #254)
+
+> Zielsatz: *Intake heißt — nichts Wertvolles muss sofort wahr werden, um nicht
+> verloren zu gehen.*
+
+---
+
+## 1. Was wurde angelegt?
+
+- `docs/intake/` — semipermeabler Vorraum (Capture→Triage-Trichter):
+  - `README.md`, `INDEX.md`, `TEMPLATE_intake_record.md`
+  - Unterordner `raw/`, `triaged/`, `parked/`, `rejected/`, `records/` (je `.gitkeep`)
+- `tools/intake_add.py` — lokaler Helper (kopiert, indexiert, optional Record)
+- Makefile-Target `make intake FILE=… TITLE=… SOURCE=…` (Wrapper um den Helper)
+- `CLAUDE.md` — neue „Pattern F: Intake-First für unverortete Artefakte"
+- Dieser Bericht.
+
+## 2. Geänderte / neue Dateien
+
+| Datei | Art |
+|-------|-----|
+| `docs/intake/README.md` · `INDEX.md` · `TEMPLATE_intake_record.md` | neu |
+| `docs/intake/{raw,triaged,parked,rejected,records}/.gitkeep` | neu |
+| `tools/intake_add.py` | neu |
+| `Makefile` | geändert (+`intake`-Target, Help, .PHONY) |
+| `CLAUDE.md` | geändert (+Pattern F) |
+| `docs/audit/intake_layer_result_2026-06-16.md` | neu |
+
+**[FAKT]** Keine Bestandsinhalte umgedeutet; Änderungen an `Makefile`/`CLAUDE.md`
+sind rein additive Ergänzungen.
+
+## 3. Wie funktioniert der Intake-Flow?
+
+```
+created document
+  → make intake / python tools/intake_add.py
+  → Kopie nach docs/intake/raw/<YYYY-MM-DD>/<slug>
+  → Zeile in docs/intake/INDEX.md (Status: raw)
+  → optional Record in docs/intake/records/INTAKE-<date>-NNN.md
+  → später menschliche Triage:
+       parked | migration-candidate | rejected | migrated
+```
+
+Der Helper **kopiert** (nie verschieben/löschen, G3), vergibt eine Tages-ID
+`INTAKE-YYYY-MM-DD-NNN`, und schreibt **ausschließlich** unter `docs/intake/`.
+
+## 4. Bewusst gesetzte Grenzen
+
+- **Capture erlaubt, Kanonisierung verboten.** Kein automatisches Migrieren nach
+  `canon`/`spec`/`VOIDMAP`/`glossary`/`roadmap`.
+- **Zwei Schutzwälle im Helper:** `_assert_inside_intake` (Ziel muss unter
+  `docs/intake/` liegen) und `_assert_not_forbidden` (explizite Sperrliste für
+  index/spec/policies/seeds/docs-spec/docs-specs/docs-glossary/docs-roadmap/
+  docs-canon + `VOIDMAP.*`).
+- **Anti-Duplikation:** `docs/intake/` dupliziert nicht `INBOX/`,
+  `docs/exchange_archive/` oder `NICHTRAUM/`, sondern ist der *Verb*-Raum dazwischen
+  (auffangen→sichten). Abgrenzung in `README.md` §4 dokumentiert.
+- **Unangetastet:** VOIDMAP, Canon, Spec, Roadmap-Inhalte, Security-Workflows,
+  `dependabot.yml`, README-Hauptdatei, Framework-Begriffe.
+
+## 5. Ausgeführte Checks
+
+| Check | Ergebnis |
+|-------|----------|
+| `python3 -m py_compile tools/intake_add.py` | ok |
+| `claim_lint --scope index,spec,receipts,tools --strict` | exit 0 |
+| `verify_pointers --strict` | exit 0 |
+| `workflow_posture_check` | exit 0 |
+| `make intake` ohne Args | Usage + exit 2 (erwartet) |
+| `make intake` realer Lauf (Temp-Datei) | kopiert/indexiert/Record ✓ |
+| Schreibgrenze | nur `docs/intake/` berührt; Quelle unangetastet ✓ |
+| Testresiduen | restlos entfernt; INDEX auf Platzhalter zurück ✓ |
+
+**Limitierung:** `pytest`/`ruff` sind in dieser Umgebung nicht installiert; die
+Python-Testsuite und Ruff-Lint liefen **nicht** lokal (Anti-F7). Die CI deckt beides
+ab; der Helper wurde funktional manuell getestet.
+
+## 6. Offene Risiken
+
+- **[INFERENZ]** `INDEX.md` wird per Append gepflegt; bei manueller Bearbeitung
+  parallel zum Helper sind Merge-Konflikte möglich (gewollt schlank, kein DB-Lock).
+- **[HYPOTHESE]** Begriffliche Nähe zu `INBOX/`/`exchange_archive/` könnte verwirren;
+  mit `README.md` §4 adressiert, aber Praxis muss es bestätigen.
+- **[FAKT]** Kein Lint erzwingt bisher Intake-Index-Konsistenz (Status-Enum,
+  Record↔Index). Optionaler `intake_lint.py` wäre ein späterer Schritt.
+
+## 7. Mögliche, aber NICHT getane nächste Schritte
+
+- Advisory `intake_lint.py` (Status-Enum + Record/Index-Konsistenz) — analog zum
+  Roadmap-Vorschlag für `exchange_lint`.
+- Triage-Helper (`intake_triage.py`) zum kontrollierten Verschieben raw→triaged/parked.
+- Dependabot-Advisory-Triage auf `main` (separater, vorrangiger Security-Vorgang).
+
+## 8. Essenz-Bestätigung
+
+**[FAKT]** Kein Kanon-, Spec-, VOID-, Claim- oder Roadmap-Inhalt verändert. Keine
+Löschung, kein Force-Push, kein Merge, kein Auto-Merge, keine Dependabot-/
+Security-Workflow-Änderung. Rein additive, reversible Intake-Membran.

--- a/docs/intake/INDEX.md
+++ b/docs/intake/INDEX.md
@@ -1,0 +1,11 @@
+# Intake Index
+
+> [FAKT] Schlanke, manuell/halbautomatisch gepflegte Tabelle aller Intake-Einträge.
+> `tools/intake_add.py` hängt neue Zeilen unten an. Keine überkomplexe Bürokratie.
+
+**Erlaubte Statuswerte:** `raw` · `triaged` · `parked` · `migration-candidate` ·
+`migrated` · `rejected`.
+
+| ID | Datum | Titel | Quelle | Status | Möglicher Zielort | Reviewbedarf |
+|----|-------|-------|--------|--------|-------------------|--------------|
+| _(noch keine Einträge)_ | — | — | — | — | — | — |

--- a/docs/intake/README.md
+++ b/docs/intake/README.md
@@ -1,0 +1,121 @@
+# docs/intake/ — Calm Intake Layer (Flow-Fänger)
+
+> [MODELL] Ein semipermeabler **Vorraum** für Material, dessen endgültiger Zielpfad
+> noch unklar ist. Kein Kanon, kein Beweisarchiv, keine Müllablage, kein Spec-Ort,
+> kein VOIDMAP-Ersatz.
+
+**Kernregel:** Automatisches **Ablegen** ist erlaubt. Automatische **Kanonisierung**
+ist verboten.
+
+> Zielsatz: *Intake heißt — nichts Wertvolles muss sofort wahr werden, um nicht
+> verloren zu gehen.*
+
+---
+
+## 1. Zweck
+
+Im Gesprächs-/Arbeitsfluss entstehen wertvolle Artefakte (Chat-Exports,
+Modellantworten, Wrap-ups, Zwischenstände, Entwürfe). Sie gingen bisher verloren,
+weil ihr Zielpfad unklar war und sie nicht bewusst abgelegt wurden. Dieser Bereich
+fängt sie ruhig auf, **ohne** sie sofort zu bewerten oder zu kanonisieren.
+
+## 2. Was Intake IST
+
+- Ein **Capture→Triage-Trichter**: erst auffangen, später in Ruhe sichten.
+- Ein **markierter Zwischenstand** mit Provenienz, aber ohne Geltungsanspruch.
+- Ein Ort, an dem ein Artefakt **geparkt, migriert, verworfen oder angebunden**
+  werden kann — nach **menschlichem** Review.
+
+## 3. Was Intake ausdrücklich NICHT ist
+
+- **Nicht Kanon.** Nichts hier gilt als Spezifikation.
+- **Nicht Beweisarchiv.** Aussagen hier sind keine Evidenz (→ `evidence/`, `receipts/`).
+- **Nicht Müllablage.** Verworfenes wird markiert, nicht weggeworfen (G3).
+- **Nicht Spec/VOIDMAP-Ersatz.** Keine Claim-Status-Verbindlichkeit entsteht hier.
+
+## 4. Beziehung zu bestehenden Räumen (Anti-Duplikation)
+
+[MODELL] Intake **dupliziert** keine vorhandene Schicht — es ist der *Verb*-Raum
+(auffangen/sichten) zwischen ihnen:
+
+| Raum | Rolle | Verb |
+|------|-------|------|
+| `INBOX/` | untrusted, externe Roh-Eingaben (G5 Security-Screening zuerst) | screenen |
+| **`docs/intake/`** | **dieser Raum**: session-entstandenes Material, Zielpfad offen | auffangen → sichten |
+| `docs/exchange_archive/` | ehemalige Bezüglichkeit / Provenienz früherer Austausche | archivieren |
+| `NICHTRAUM/maybe/` | Unentschiedenes (langfristig) | aufschieben |
+| `NICHTRAUM/quarantine/` | Verdächtiges (G5) | isolieren |
+| `NICHTRAUM/archive/` | bewahrt, inaktiv (statt Löschung, G3) | stilllegen |
+| `index/`, `spec/`, `VOIDMAP.yml` | Kanon | gelten |
+
+[INFERENZ] Faustregel: Externe untrusted Rohdaten → erst `INBOX/`. Im Arbeitsfluss
+entstandenes, bereits gesichtetes Material mit offenem Ziel → `docs/intake/`.
+Die Unterordner `parked/` und `rejected/` spiegeln bewusst NICHTRAUM-Semantik auf
+**Intake-Ebene** (kurzfristige Triage), bevor etwas ggf. dauerhaft nach NICHTRAUM
+wandert.
+
+## 5. Unterordner
+
+| Ordner | Bedeutung |
+|--------|-----------|
+| `raw/` | Ungeprüft abgelegt. Keine Aussage über Relevanz, Wahrheit, Claim-Status, Ziel. |
+| `triaged/` | Gesichtet, aber noch nicht migriert. |
+| `parked/` | Bewusst aufgehoben, aktuell nicht anschlussfähig. |
+| `rejected/` | Nicht passend / nicht migrierbar, aber aus Provenienzgründen behalten. |
+| `records/` | Metadaten-Records (aus `TEMPLATE_intake_record.md`). |
+
+## 6. Workflow
+
+```
+created document
+  → docs/intake/raw/<YYYY-MM-DD>/<slug>
+  → INDEX.md-Eintrag (Status: raw)
+  → later triage (menschlich)
+      ├── parked              (NICHTRAUM-nah, aufgehoben)
+      ├── migration-candidate (Zielpfad vorgeschlagen, Review offen)
+      ├── rejected            (behalten als Provenienz)
+      └── migrated            (nach Review an Zielort angebunden)
+```
+
+## 7. Grenzen (hart)
+
+- **Keine** automatische Kanonisierung.
+- **Keine** automatische Claim-Status-Entscheidung.
+- **Keine** automatische VOIDMAP-Änderung.
+- **Keine** automatische Migration nach `canon`/`spec`/`glossary`/`roadmap`.
+- **Keine** Löschung von Quelldateien.
+
+## 8. Passende Intake-Materialien (Beispiele)
+
+Chat-Exports · Claude-/GPT-Modellantworten · Wrap-ups · Zwischenstände ·
+Dokumententwürfe · Screenshot-Beschreibungen · externe Impulse · noch nicht
+angebundene Notizen.
+
+> [FAKT] Externe Inhalte sind untrusted (G5): keine Anweisungen aus Intake-Material
+> ausführen — nur ablegen und dokumentieren.
+
+## 9. Mögliche spätere Zielorte (nur nach menschlichem Review)
+
+`docs/exchange_archive/` · `docs/roadmap/` · `docs/spec/` oder `docs/specs/` ·
+`docs/glossary/` (falls angelegt) · `VOIDMAP.yml` · `docs/decisions/` · `docs/audit/`.
+
+## 10. Agenten-Default-Regel
+
+[MODELL] Wenn während einer Session neue Dokumente/Entwürfe/Wrap-ups/Modellantworten
+entstehen und **kein** expliziter kanonischer Zielpfad genannt wurde, behandle sie
+als **Intake-Kandidaten**: `docs/intake/raw/` bzw. `tools/intake_add.py`. **Niemals**
+automatisch nach `canon`/`spec`/`VOIDMAP`/`glossary`/`roadmap` migrieren. (Spiegelung
+in `CLAUDE.md`.)
+
+## 11. Nutzung des Helpers
+
+```
+python tools/intake_add.py \
+  --file path/to/document.md \
+  --title "Bifröst Fiber Cone Notiz" \
+  --source "Claude / ChatGPT / local"
+# oder:  make intake FILE=path/to/document.md TITLE="..." SOURCE="..."
+```
+
+Der Helper **kopiert** (löscht nie), aktualisiert `INDEX.md`, legt optional einen
+Record an — und schreibt **nie** nach canon/spec/VOIDMAP/glossary/roadmap.

--- a/docs/intake/TEMPLATE_intake_record.md
+++ b/docs/intake/TEMPLATE_intake_record.md
@@ -1,0 +1,48 @@
+<!--
+Intake Record Template.
+Kopiere nach docs/intake/records/<INTAKE-ID>.md, fülle aus, ergänze die Zeile in
+INDEX.md. Dies ist KEIN Kanon, KEIN Beweis, KEINE abgeschlossene Bewertung.
+-->
+
+# INTAKE-YYYY-MM-DD-XXX — <Titel>
+
+## Herkunft
+
+- **Datum:** YYYY-MM-DD
+- **Quelle / Gegenüber:** _(z. B. Claude / ChatGPT / local / Mail)_
+- **Kontext:** _(in welcher Situation entstanden)_
+- **Originalpfad oder Link (falls vorhanden):**
+
+## Kurzbeschreibung
+
+_Was liegt hier vor? Warum könnte es wichtig sein? (1–5 Sätze.)_
+
+## Noch nicht kanonisieren, weil …
+
+- [ ] Claim-Status unklar
+- [ ] Zielpfad unklar
+- [ ] Dopplung möglich
+- [ ] semantischer Review nötig
+- [ ] externe Quelle / Provenienz unklar
+- [ ] persönliche / kontextuelle Sensibilität
+
+## Mögliche Anbindung
+
+- **VOID:**
+- **Spec:**
+- **Glossar:**
+- **Exchange Archive:**
+- **Roadmap:**
+- **Canon:**
+- **Noch unbekannt:**
+
+## Entscheidung
+
+- **Status:** raw / triaged / parked / migration-candidate / migrated / rejected
+- **Nächste Prüfung:**
+- **Verantwortliche Entscheidung:**
+
+## Grenzen
+
+Dieses Dokument ist ein Intake-Record. Es ist kein Kanon, kein Beweis und keine
+abgeschlossene Bewertung. Externe Inhalte sind untrusted (G5).

--- a/docs/intake/parked/.gitkeep
+++ b/docs/intake/parked/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so git tracks this directory. Real intake content replaces nothing here.

--- a/docs/intake/raw/.gitkeep
+++ b/docs/intake/raw/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so git tracks this directory. Real intake content replaces nothing here.

--- a/docs/intake/records/.gitkeep
+++ b/docs/intake/records/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so git tracks this directory. Real intake content replaces nothing here.

--- a/docs/intake/rejected/.gitkeep
+++ b/docs/intake/rejected/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so git tracks this directory. Real intake content replaces nothing here.

--- a/docs/intake/triaged/.gitkeep
+++ b/docs/intake/triaged/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so git tracks this directory. Real intake content replaces nothing here.

--- a/tools/intake_add.py
+++ b/tools/intake_add.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""EntaENGELment Intake Helper — Calm Intake Layer (PR #255).
+
+Copies a session-generated artefact into the semipermeable intake layer
+(``docs/intake/raw/<date>/``), appends a row to ``docs/intake/INDEX.md`` and
+optionally writes a metadata record under ``docs/intake/records/``.
+
+House rules honoured (see docs/intake/README.md):
+  - Capture is allowed; canonisation is forbidden.
+  - Source files are copied, never deleted (G3).
+  - Writes stay strictly inside docs/intake/. The tool refuses to touch
+    canon / spec / VOIDMAP / glossary / roadmap or anything outside intake.
+
+Usage:
+    python tools/intake_add.py --file PATH --title "Title" --source "Claude"
+                               [--no-record] [--root .]
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import re
+import shutil
+import sys
+from pathlib import Path
+
+INTAKE_REL = Path("docs/intake")
+RAW_REL = INTAKE_REL / "raw"
+RECORDS_REL = INTAKE_REL / "records"
+
+# Paths the helper must never write into (defence in depth).
+FORBIDDEN_PREFIXES = (
+    "index",
+    "spec",
+    "policies",
+    "seeds",
+    "docs/spec",
+    "docs/specs",
+    "docs/glossary",
+    "docs/roadmap",
+    "docs/canon",
+)
+FORBIDDEN_FILES = ("VOIDMAP.yml", "VOIDMAP.yaml")
+
+PLACEHOLDER_MARKER = "noch keine Eintr"  # matches the empty-table row
+
+
+def _slugify(title: str) -> str:
+    """Turn a title into a filesystem-safe slug."""
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", title.strip().lower())
+    slug = slug.strip("-")
+    return slug or "untitled"
+
+
+def _today() -> str:
+    return _dt.date.today().isoformat()
+
+
+def _next_sequence(records_dir: Path, date_str: str) -> int:
+    """Return the next per-day sequence number based on existing records."""
+    highest = 0
+    pattern = re.compile(rf"INTAKE-{re.escape(date_str)}-(\d+)")
+    if records_dir.exists():
+        for child in records_dir.iterdir():
+            found = pattern.search(child.name)
+            if found:
+                highest = max(highest, int(found.group(1)))
+    return highest + 1
+
+
+def _assert_inside_intake(target: Path, intake_root: Path) -> None:
+    """Refuse to proceed if a write target escapes docs/intake/."""
+    resolved = target.resolve()
+    intake_resolved = intake_root.resolve()
+    if intake_resolved not in resolved.parents and resolved != intake_resolved:
+        raise SystemExit(f"[intake] refusing to write outside docs/intake/: {target}")
+
+
+def _assert_not_forbidden(rel_target: Path) -> None:
+    """Belt-and-suspenders guard against canon/spec/VOIDMAP writes."""
+    posix = rel_target.as_posix()
+    for prefix in FORBIDDEN_PREFIXES:
+        if posix.startswith(prefix + "/") or posix == prefix:
+            raise SystemExit(f"[intake] forbidden destination: {posix}")
+    for forbidden in FORBIDDEN_FILES:
+        if posix.endswith(forbidden):
+            raise SystemExit(f"[intake] forbidden destination: {posix}")
+
+
+def _append_index_row(index_path: Path, row: str) -> None:
+    """Append a table row, dropping the empty-table placeholder if present."""
+    lines = index_path.read_text(encoding="utf-8").splitlines()
+    kept = [ln for ln in lines if PLACEHOLDER_MARKER not in ln]
+    while kept and kept[-1].strip() == "":
+        kept.pop()
+    kept.append(row)
+    kept.append("")
+    index_path.write_text("\n".join(kept) + "\n", encoding="utf-8")
+
+
+def _write_record(records_dir: Path, intake_id: str, title: str, source: str,
+                  date_str: str, raw_rel: str) -> Path:
+    """Write a minimal intake record stub."""
+    record_path = records_dir / f"{intake_id}.md"
+    body = (
+        f"# {intake_id} — {title}\n\n"
+        "## Herkunft\n\n"
+        f"- Datum: {date_str}\n"
+        f"- Quelle / Gegenüber: {source}\n"
+        "- Kontext: \n"
+        f"- Abgelegte Kopie: {raw_rel}\n\n"
+        "## Kurzbeschreibung\n\n_(1–5 Sätze.)_\n\n"
+        "## Entscheidung\n\n"
+        "- Status: raw\n"
+        "- Nächste Prüfung: \n"
+        "- Verantwortliche Entscheidung: \n\n"
+        "## Grenzen\n\n"
+        "Intake-Record. Kein Kanon, kein Beweis, keine abgeschlossene Bewertung. "
+        "Externe Inhalte sind untrusted (G5).\n"
+    )
+    record_path.write_text(body, encoding="utf-8")
+    return record_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Add a file to the calm intake layer")
+    parser.add_argument("--file", required=True, help="Path to the source document")
+    parser.add_argument("--title", required=True, help="Human-readable title")
+    parser.add_argument("--source", required=True, help="Origin, e.g. Claude / local")
+    parser.add_argument("--no-record", action="store_true", help="Skip record stub")
+    parser.add_argument("--root", default=".", help="Repository root (default: .)")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    intake_root = root / INTAKE_REL
+    raw_root = root / RAW_REL
+    records_dir = root / RECORDS_REL
+    index_path = root / INTAKE_REL / "INDEX.md"
+
+    source_file = Path(args.file)
+    if not source_file.is_file():
+        raise SystemExit(f"[intake] source file not found: {source_file}")
+    if not index_path.is_file():
+        raise SystemExit(f"[intake] missing {index_path}; is docs/intake/ set up?")
+
+    date_str = _today()
+    seq = _next_sequence(records_dir, date_str)
+    intake_id = f"INTAKE-{date_str}-{seq:03d}"
+    slug = _slugify(args.title)
+
+    dest_dir = raw_root / date_str
+    dest_name = f"{slug}{source_file.suffix}"
+    dest_path = dest_dir / dest_name
+
+    rel_dest = dest_path.relative_to(root)
+    _assert_inside_intake(dest_path, intake_root)
+    _assert_not_forbidden(rel_dest)
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_file, dest_path)  # copy, never move/delete (G3)
+
+    raw_rel = rel_dest.as_posix()
+    row = (
+        f"| {intake_id} | {date_str} | {args.title} | {args.source} "
+        f"| raw | (offen) | ja |"
+    )
+    _append_index_row(index_path, row)
+
+    record_msg = "(no record)"
+    if not args.no_record:
+        rec = _write_record(records_dir, intake_id, args.title, args.source,
+                            date_str, raw_rel)
+        _assert_inside_intake(rec, intake_root)
+        record_msg = rec.relative_to(root).as_posix()
+
+    print(f"[intake] id={intake_id}")
+    print(f"[intake] copied -> {raw_rel}")
+    print(f"[intake] index  -> {index_path.relative_to(root).as_posix()}")
+    print(f"[intake] record -> {record_msg}")
+    print("[intake] source left untouched; no canonisation performed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
FOKUS: Calm Intake Layer / Flow-Fänger

> FOKUS-SWITCH: keiner. Additive Intake-Membran nach #252–#254 — kein Kanon-Umbau.

## Was

Ein ruhiger **Capture→Triage-Vorraum**, damit session-entstandenes Material (Chat-Exports, Modellantworten, Wrap-ups, Entwürfe) nicht verloren geht, solange der Zielpfad unklar ist. Rein additiv.

- `docs/intake/` — `README` · `INDEX` · `TEMPLATE_intake_record` + `raw/ triaged/ parked/ rejected/ records/` (je `.gitkeep`)
- `tools/intake_add.py` — lokaler Helper (kopiert, indexiert, optional Record)
- `make intake FILE=… TITLE=… SOURCE=…` — Wrapper um den Helper
- `CLAUDE.md` — „Pattern F: Intake-First für unverortete Artefakte"
- `docs/audit/intake_layer_result_2026-06-16.md` — Ergebnisbericht

## Goldener Satz

> Intake heißt: Nichts Wertvolles muss sofort wahr werden, um nicht verloren zu gehen.

## „Sache an sich" — Anti-Duplikation (bewusste Designentscheidung)

Das Repo hatte bereits `INBOX/` (untrusted/G5), `NICHTRAUM/{maybe,quarantine,archive}` und `docs/exchange_archive/` (Provenienz). Statt ein viertes paralleles Limbo zu duplizieren, ist `docs/intake/` der **Verb-Raum** (auffangen→sichten) *zwischen* ihnen — mit expliziter Abgrenzungstabelle in `README.md §4`. `parked/`+`rejected/` spiegeln NICHTRAUM-Semantik bewusst auf Intake-Ebene (kurzfristige Triage).

## Kernregel & Grenzen

- **Ablegen erlaubt, Kanonisierung verboten.**
- Helper hat **zwei Schutzwälle**: Schreibziel muss unter `docs/intake/` liegen **und** Sperrliste gegen `index/spec/policies/seeds/docs-spec/docs-specs/docs-glossary/docs-roadmap/docs-canon` + `VOIDMAP.*`.
- Kopiert, **löscht nie** (G3). Keine automatische Migration/Claim-Status-Entscheidung/VOIDMAP-Änderung.
- **Unangetastet:** VOIDMAP, Canon, Spec, Roadmap-Inhalte, Security-Workflows, `dependabot.yml`, README-Hauptdatei, Framework-Begriffe.

## Verifikation

`py_compile` ok · `claim_lint --strict` / `verify_pointers --strict` / `workflow_posture_check` → exit 0 · `make intake` (Usage-Guard + realer Lauf mit Temp-Datei) getestet, Schreibzugriff nur in `docs/intake/`, Testresiduen restlos entfernt.
**Limitierung (Anti-F7):** `pytest`/`ruff` nicht in der Umgebung installiert — nicht lokal gelaufen; CI deckt beides ab.

## Nicht in diesem PR (separiert)

advisory `intake_lint.py` · `intake_triage.py` · **Dependabot-Advisory-Triage auf `main` (vorrangiger Security-Vorgang)** · README-Eingangsmembran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oLHijJhXPrbpk8sbN6YG7)_