### PR TITLE
tools(intake): automatic shadow-copy briefkasten via PostToolUse hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 tools/intake_shadow_copy.py",
+            "async": true
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ entstehen und KEIN expliziter kanonischer Zielpfad genannt wurde:
 2. Niemals automatisch nach canon/spec/VOIDMAP/glossary/roadmap migrieren
 3. Ablegen ist erlaubt; Kanonisierung nur nach menschlichem Review
 → Details: docs/intake/README.md
+
+Hinweis Shadow-Copy-Hook: Ist der PostToolUse-Hook aktiv (.claude/settings.json),
+muss der Agent den Flow NICHT unterbrechen, um Intake aktiv auszuführen — der Hook
+legt async eine Kopie dokumentartiger Dateien nach docs/intake/raw/auto/. Der Agent
+darf dennoch bewusst `make intake` nutzen, wenn ein Dokument mit Titel/Quelle in die
+kuratierte INDEX.md eingetragen werden soll.
 ```
 
 ---

--- a/docs/audit/intake_shadow_copy_result_2026-06-16.md
+++ b/docs/audit/intake_shadow_copy_result_2026-06-16.md
@@ -1,0 +1,109 @@
+# Intake Shadow-Copy Hook — Result Report (PR #256)
+
+**Datum:** 2026-06-16
+**Fokus:** Automatischer Briefkasten via Claude-Code PostToolUse-Hook (additiv)
+**Branch:** `chore/intake-shadow-copy-hook`
+**Basis-HEAD:** `64e29f0` (main nach #252–#255)
+
+> Zielsatz: *Der Briefkasten soll schneller sein als das Vergessen, aber langsamer
+> als die Wahrheit.*
+
+---
+
+## 1. Was wurde angelegt?
+
+- `tools/intake_shadow_copy.py` — fail-soft Hook-Helper (liest Hook-JSON von stdin).
+- `.claude/settings.json` — projektlokaler PostToolUse-Hook (`async`).
+- `docs/intake/raw/auto/.gitkeep` — Briefkasten-Zielordner.
+- `docs/intake/README.md` §12 — „Automatic Shadow Copy / Briefkasten-Hook".
+- `CLAUDE.md` Pattern F — Hinweis zum aktiven Hook.
+- Dieser Bericht.
+
+## 2. Wie funktioniert der Hook?
+
+```
+Claude schreibt/ändert Datei (Write|Edit|MultiEdit)
+  → PostToolUse-Hook feuert ASYNC (Hintergrund)
+  → python3 tools/intake_shadow_copy.py liest {tool_name, tool_input.file_path, cwd} von stdin
+  → wenn dokumentartig UND nicht ausgeschlossen:
+       Kopie → docs/intake/raw/auto/<YYYY-MM-DD>/<stem>__<sha8><ext>
+       Zeile → docs/intake/raw/auto/<date>/_shadow_log.jsonl  (status: raw/auto)
+  → Claude arbeitet ununterbrochen weiter
+```
+
+[FAKT] Hook-Schema gemäß offizieller Claude-Code-Doku verifiziert
+(`hooks.PostToolUse[].{matcher, hooks:[{type,command,async}]}`; stdin-Felder
+`tool_name`, `tool_input.file_path`, `cwd`; `async: true` = nicht-blockierend,
+Output verworfen).
+
+## 3. Welche Dateien/Pfade werden erfasst?
+
+Dokumentartig: `.md` `.txt` `.docx` `.pdf` `.json` `.yml` `.yaml`,
+nur bei Tool `Write`/`Edit`/`MultiEdit`, nur Dateien **innerhalb** des Repos.
+
+## 4. Welche Pfade sind ausgeschlossen?
+
+- **Mechanisch/Build/Cache:** `docs/intake/**`, `.git/**`, `node_modules/**`,
+  `.venv|venv/**`, `dist/**`, `build/**`, `__pycache__/**`, `.pytest_cache/**`,
+  `.mypy_cache/**`, `htmlcov/**`, Lockfiles, Temp-/Scratch-Dateien.
+- **GOLD/Kanon (Verfeinerung):** `VOIDMAP.yml/.yaml`, `index/`, `spec/`,
+  `policies/`, `seeds/`, `docs/spec|specs|canon|glossary|roadmap/`.
+  **[MODELL]** Begründung: Kanon hat bereits ein Zuhause; der Briefkasten ist für
+  das Heimatlose. So sammelt er keine Kanon-Kopien an (Anti-Staubsauger). Dies
+  ergänzt die reine Write-Sperre aus der Auftragsvorgabe um eine **Source**-Sperre.
+
+## 5. Warum unterbricht das den Flow nicht?
+
+[FAKT] Der Hook ist `async: true` → läuft im Hintergrund, Claude wartet nicht, der
+Output wird verworfen. Zusätzlich ist der Helper **fail-soft**: jeder Fehler (inkl.
+JSON-Parse-Fehler) endet in `sys.exit(0)`; nie Exit 2, also nie blockierend.
+
+## 6. Welche Tests wurden ausgeführt?
+
+Simuliertes Hook-JSON über stdin, 10/10 PASS:
+
+| Test | Ergebnis |
+|------|----------|
+| Doc-Datei → Shadow-Copy erzeugt | ✓ |
+| Exit 0 (fail-soft) | ✓ |
+| Quelle nicht gelöscht/verschoben | ✓ |
+| Ledger `_shadow_log.jsonl` geschrieben | ✓ |
+| Re-Edit gleicher Inhalt → Dedupe (keine Duplikate) | ✓ |
+| `docs/intake/**` ausgeschlossen | ✓ |
+| `VOIDMAP.yml` nicht geshadowt, Quelle unverändert | ✓ |
+| Nicht-Doc (`.js`) ignoriert | ✓ |
+| Nicht-passendes Tool (`Bash`) ignoriert | ✓ |
+| Malformed stdin → fail-soft Exit 0 | ✓ |
+
+Zusätzlich: `py_compile` ok · `claim_lint --strict` / `verify_pointers --strict` /
+`workflow_posture_check` → exit 0 · `.claude/settings.json` ist valides JSON.
+**Alle Testresiduen entfernt** (Cleanup verifiziert via `git status`).
+
+**Limitierung (Anti-F7):** `pytest`/`ruff` nicht in der Umgebung installiert; nicht
+lokal gelaufen. CI deckt beide ab. Der Hook selbst hat noch keinen pytest-Test
+(siehe Risiken).
+
+## 7. Welche Risiken bleiben offen?
+
+- **[INFERENZ]** `async`-Feld ist laut Doku unterstützt; sollte eine Claude-Code-
+  Version es ignorieren, läuft der Hook synchron — bleibt aber schnell und
+  fail-soft, also unkritisch.
+- **[FAKT]** Committeter Hook führt `python3 tools/intake_shadow_copy.py` in jeder
+  Contributor-Session aus. Das Skript ist transparent, lokal, ohne Netzwerk und
+  fail-soft; Deaktivierung in README §12 dokumentiert.
+- **[HYPOTHESE]** `_shadow_log.jsonl` und `raw/auto/` können über Zeit wachsen;
+  bewusst getrennt von der kuratierten `INDEX.md`. Ein späterer Aufräum-/Rotations-
+  Helfer wäre möglich (nicht in diesem PR).
+- **[FAKT]** Kein `intake_lint` erzwingt Ledger-/Briefkasten-Konsistenz (Roadmap).
+
+## 8. Warum keine Essenzänderung?
+
+[FAKT] Kein Kanon-, Spec-, VOID-, Claim-, Glossary- oder Roadmap-Inhalt verändert.
+Rein additiv: ein Helper, eine Hook-Config, ein Zielordner, Doku-Ergänzungen. GOLD
+wird nicht nur nicht beschrieben, sondern nicht einmal kopiert.
+
+## 9. Warum keine Kanonisierung?
+
+[FAKT] Der Hook setzt ausschließlich `raw/auto`, deutet nichts, vergibt keinen
+verbindlichen Claim-Status, migriert nichts. Kopie ja — Deutung nein —
+Kanonisierung verboten. Spätere Triage bleibt menschlich.

--- a/docs/intake/README.md
+++ b/docs/intake/README.md
@@ -119,3 +119,44 @@ python tools/intake_add.py \
 
 Der Helper **kopiert** (löscht nie), aktualisiert `INDEX.md`, legt optional einen
 Record an — und schreibt **nie** nach canon/spec/VOIDMAP/glossary/roadmap.
+
+## 12. Automatic Shadow Copy / Briefkasten-Hook
+
+> [FAKT] Ein optionaler Claude-Code **PostToolUse-Hook** legt automatisch eine
+> *Shadow-Copy* dokumentartiger Dateien ab, damit nichts vergessen wird, bevor es
+> bewusst abgelegt ist. *Der Briefkasten soll schneller sein als das Vergessen,
+> aber langsamer als die Wahrheit.*
+
+**Was automatisch passiert:** Nach jedem `Write`/`Edit`/`MultiEdit` ruft Claude Code
+`tools/intake_shadow_copy.py` **async** (im Hintergrund) auf. Bei dokumentartigen,
+nicht ausgeschlossenen Dateien wird eine **Kopie** nach
+`docs/intake/raw/auto/<YYYY-MM-DD>/` gelegt und eine Zeile in `_shadow_log.jsonl`
+geschrieben.
+
+**Erfasste Dateitypen:** `.md` · `.txt` · `.docx` · `.pdf` · `.json` · `.yml` · `.yaml`.
+
+**Ausgeschlossen:** `docs/intake/**`, `.git/**`, `node_modules/**`, `.venv|venv/**`,
+`dist/**`, `build/**`, `__pycache__/**`, `.pytest_cache/**`, Lockfiles
+(`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `poetry.lock`, `uv.lock`),
+Temp-/Scratch-Dateien — **und** GOLD/Kanon (`VOIDMAP.yml`, `index/`, `spec/`,
+`policies/`, `seeds/`, `docs/spec|specs|canon|glossary|roadmap/`), denn Kanon hat
+bereits ein Zuhause; der Briefkasten ist für das Heimatlose.
+
+**Es ist nur eine Kopie:** Quelldateien werden **nie** verschoben oder gelöscht (G3).
+Bei gleichem Inhalt (Content-Hash) wird **nicht** erneut kopiert (Dedupe).
+
+**Intake bleibt kein Kanon:** Der Hook setzt nur Status `raw/auto`. Keine semantische
+Deutung, kein Claim-Status, keine Migration. Die **kuratierte** `INDEX.md` und
+`records/` werden vom Hook **nicht** angefasst — dafür gibt es das separate
+`_shadow_log.jsonl`-Ledger. Spätere Triage bleibt **menschlich**.
+
+**Fail-soft:** Der Hook läuft async und beendet sich immer mit Exit 0; Fehler
+blockieren den Claude-Code-Flow nie.
+
+**Deaktivieren:** Den `PostToolUse`-Block in `.claude/settings.json` entfernen oder
+auskommentieren (bzw. die Datei löschen). Lokale Overrides gehen in
+`.claude/settings.local.json`.
+
+**Manuell weiterhin möglich:** Für bewusste Ablage mit Titel/Quelle weiterhin
+`make intake …` bzw. `tools/intake_add.py` nutzen (schreibt in die kuratierte
+`INDEX.md`/`records/`).

--- a/docs/intake/raw/auto/.gitkeep
+++ b/docs/intake/raw/auto/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder so git tracks the auto shadow-copy briefkasten. Captures land in <YYYY-MM-DD>/ subfolders.

--- a/tools/intake_shadow_copy.py
+++ b/tools/intake_shadow_copy.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""EntaENGELment Intake Shadow-Copy — Claude Code PostToolUse hook (PR #256).
+
+Reads a Claude Code hook payload from stdin and, for document-like files written
+or edited during a session, drops a *shadow copy* into the intake briefkasten at
+``docs/intake/raw/auto/<YYYY-MM-DD>/`` plus a line in a machine ledger
+(``_shadow_log.jsonl``).
+
+Design notes (see docs/intake/README.md):
+  - Capture is allowed; interpretation and canonisation are forbidden.
+  - Copies only. Source files are never moved or deleted (G3).
+  - Writes stay strictly inside docs/intake/raw/auto/. The human-curated
+    INDEX.md and records/ are NOT touched by the hook (no vacuum effect).
+  - Content-hash dedupe: re-editing the same file does not pile up duplicates.
+  - Fail-soft: any error exits 0 so Claude Code is never blocked.
+
+The hook is wired async in .claude/settings.json, so its output is discarded.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import hashlib
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Document-like extensions worth catching in the briefkasten.
+DOC_SUFFIXES = {".md", ".txt", ".docx", ".pdf", ".json", ".yml", ".yaml"}
+
+# Tool names this hook reacts to.
+DOC_TOOLS = {"Write", "Edit", "MultiEdit"}
+
+# Path prefixes (repo-relative, posix) that must never be captured.
+# Two groups: (a) mechanical noise/build/temp, (b) GOLD/canon that already has a
+# home -- intake is for the *un-homed*, so canonical sources are not shadowed.
+EXCLUDE_DIR_PREFIXES = (
+    # (a) mechanical / build / cache
+    "docs/intake/",
+    ".git/",
+    "node_modules/",
+    ".venv/",
+    "venv/",
+    "dist/",
+    "build/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    "htmlcov/",
+    # (b) GOLD / already-homed canon (never write AND never shadow-capture)
+    "index/",
+    "spec/",
+    "policies/",
+    "seeds/",
+    "docs/canon/",
+    "docs/spec/",
+    "docs/specs/",
+    "docs/glossary/",
+    "docs/roadmap/",
+)
+
+# Exact filenames never captured (lockfiles + GOLD registries).
+EXCLUDE_FILENAMES = {
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock",
+    "poetry.lock",
+    "uv.lock",
+    "VOIDMAP.yml",
+    "VOIDMAP.yaml",
+}
+
+# Destinations the hook must never write to (defence in depth; it only writes
+# under docs/intake/raw/auto/ anyway).
+FORBIDDEN_DEST_PREFIXES = (
+    "docs/canon/",
+    "docs/spec/",
+    "docs/specs/",
+    "docs/glossary/",
+    "docs/roadmap/",
+)
+
+AUTO_REL = Path("docs/intake/raw/auto")
+
+
+def _is_temp_name(name: str) -> bool:
+    """True for editor/temp scratch filenames."""
+    lowered = name.lower()
+    return (
+        name.startswith("~")
+        or name.startswith(".~")
+        or lowered.endswith(".tmp")
+        or lowered.endswith(".temp")
+        or lowered.endswith(".swp")
+        or lowered.endswith(".bak")
+        or lowered.endswith("~")
+    )
+
+
+def _should_skip(rel_posix: str, name: str, suffix: str) -> bool:
+    """Decide whether a repo-relative path is out of scope for shadow copy."""
+    if suffix.lower() not in DOC_SUFFIXES:
+        return True
+    if name in EXCLUDE_FILENAMES or _is_temp_name(name):
+        return True
+    for prefix in EXCLUDE_DIR_PREFIXES:
+        if rel_posix.startswith(prefix):
+            return True
+    return False
+
+
+def _safe_dest(auto_dir: Path, src: Path, digest8: str) -> Path:
+    """Collision-safe, dedupe-friendly destination name (stem__hash.ext)."""
+    return auto_dir / f"{src.stem}__{digest8}{src.suffix}"
+
+
+def _append_ledger(ledger: Path, entry: dict) -> None:
+    with ledger.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def run(payload: dict) -> None:
+    """Core logic; assumes a parsed hook payload. Raises only on bugs."""
+    tool_name = payload.get("tool_name", "")
+    if tool_name not in DOC_TOOLS:
+        return
+
+    tool_input = payload.get("tool_input") or {}
+    raw_path = tool_input.get("file_path")
+    if not raw_path:
+        return
+
+    root = Path(payload.get("cwd") or os.getcwd()).resolve()
+    src = Path(raw_path)
+    if not src.is_absolute():
+        src = (root / src)
+    src = src.resolve()
+
+    if not src.is_file():
+        return
+
+    try:
+        rel = src.relative_to(root)
+    except ValueError:
+        return  # outside the repo -> not our briefkasten
+
+    rel_posix = rel.as_posix()
+    if _should_skip(rel_posix, src.name, src.suffix):
+        return
+
+    content = src.read_bytes()
+    digest8 = hashlib.sha256(content).hexdigest()[:8]
+
+    today = _dt.date.today().isoformat()
+    auto_dir = root / AUTO_REL / today
+
+    dest = _safe_dest(auto_dir, src, digest8)
+    dest_rel = dest.relative_to(root).as_posix()
+    for prefix in FORBIDDEN_DEST_PREFIXES:
+        if dest_rel.startswith(prefix):
+            return  # never happens by construction, but guard anyway
+
+    if dest.exists():
+        return  # identical content already captured today -> idempotent
+
+    auto_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)  # copy, never move/delete (G3)
+
+    entry = {
+        "ts": _dt.datetime.now().isoformat(timespec="seconds"),
+        "event": "intake_shadow_copy",
+        "tool": tool_name,
+        "source": rel_posix,
+        "shadow": dest_rel,
+        "sha256_8": digest8,
+        "status": "raw/auto",
+    }
+    _append_ledger(auto_dir / "_shadow_log.jsonl", entry)
+
+
+def main() -> None:
+    # Fail-soft wrapper: nothing here may block Claude Code.
+    try:
+        data = sys.stdin.read()
+        if not data.strip():
+            return
+        payload = json.loads(data)
+        run(payload)
+    except Exception:  # noqa: BLE001 - advisory hook must never raise
+        pass
+    finally:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
FOKUS: Intake Shadow-Copy Hook / automatischer Briefkasten

> FOKUS-SWITCH: keiner. Unaufdringliche Automatisierung über #255 — kein Kanon-Umbau.

## Was

Ein async **PostToolUse-Hook**, der nach jedem `Write`/`Edit`/`MultiEdit` automatisch eine **Shadow-Copy** dokumentartiger Dateien in den Intake-Briefkasten legt — ohne den Claude-Code-Flow zu unterbrechen.

- `tools/intake_shadow_copy.py` — fail-soft Hook-Helper (stdin-JSON → Kopie + `_shadow_log.jsonl`)
- `.claude/settings.json` — PostToolUse-Hook, `matcher: Write|Edit|MultiEdit`, `async: true`
- `docs/intake/raw/auto/.gitkeep` — Briefkasten-Zielordner
- `docs/intake/README.md §12` + `CLAUDE.md` Pattern-F-Hinweis + Ergebnisbericht

## Goldener Satz

> Der Briefkasten soll schneller sein als das Vergessen, aber langsamer als die Wahrheit.

## Kernformel

**Automatische Kopie ja. Automatische Deutung nein. Automatische Kanonisierung verboten.**

## „Sache an sich" — bewusste Verfeinerungen

- **Kein Vacuum-Effekt:** Der Hook schreibt **nicht** in die kuratierte `INDEX.md`/`records/`, sondern in ein separates Maschinen-Ledger `_shadow_log.jsonl`. Menschliche Triage bleibt sauber.
- **Content-Hash-Dedupe:** dieselbe Datei mehrfach editiert → keine Duplikate.
- **GOLD-Source-Ausschluss (über die Vorgabe hinaus):** `VOIDMAP.yml`, `index/`, `spec/`, `policies/`, `seeds/`, `docs/spec|specs|canon|glossary|roadmap/` werden nicht nur nicht beschrieben, sondern **nicht einmal kopiert** — Kanon hat bereits ein Zuhause.

## Grenzen

Kopiert, **löscht/verschiebt nie** (G3). `async` + fail-soft (immer Exit 0) → blockiert nie. Keine semantische Deutung, kein verbindlicher Claim-Status, keine Migration. Unangetastet: VOIDMAP, Canon, Spec, Roadmap, Security-Workflows, `dependabot.yml`, Haupt-README.

## Verifikation

Hook-Schema gegen **offizielle Claude-Code-Doku** verifiziert (kein Raten). **10/10** Hook-Simulationstests (Doc-Copy, Dedupe, `docs/intake/**`-Ausschluss, VOIDMAP nicht geshadowt + Quelle unverändert, Nicht-Doc/Nicht-Tool ignoriert, malformed stdin → Exit 0). `py_compile` ok · `claim_lint --strict`/`verify_pointers --strict`/`workflow_posture_check` → exit 0 · `settings.json` valides JSON. Alle Testresiduen entfernt.

**Bonus — Live-Bestätigung:** Der Hook hat sich während dieser Session im echten Harness selbst validiert (er erfasste die `CLAUDE.md`-Edit + den Result-Report automatisch). Diese Laufzeit-Captures sind **nicht** committet — nur `.gitkeep` ist getrackt.

**Limitierung (Anti-F7):** `pytest`/`ruff` nicht in der Umgebung installiert; CI deckt beides ab.

## Nicht in diesem PR (separiert)

`intake_lint.py` · `intake_triage.py` · Auto-Ledger-Rotation · **Dependabot-Advisory-Triage (vorrangig)** · README-Eingangsmembran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014oLHijJhXPrbpk8sbN6YG7)_