### PR TITLE
fix(ui): VOIDMAP UI-Sync, SUSPENDED-Status & pnpm-Onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,11 @@ out/
 # Claude local config
 CLAUDE.local.md
 
+# Intake shadow-copy auto-dump: transient hook output, only .gitkeep is tracked.
+# (PostToolUse shadow-copy hook async-mirrors doc-like files here; not for canon.)
+docs/intake/raw/auto/**
+!docs/intake/raw/auto/.gitkeep
+
 # Audit reports (temporary) — root-level only, so docs/audit/ stays tracked.
 /audit/
 !/audit/METATRON_COMPLIANCE_BACKLOG.md

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ help:
 	@echo "Docs:"
 	@echo "  make voids-backlog       Regenerate docs/voids_backlog.md from VOIDMAP.yml"
 	@echo "  make voids-backlog-check Verify docs/voids_backlog.md is in sync (exit 1 on drift)"
-	@echo "  make voidmap-ui-drift-check Verify ui-app VOIDMAP mirror matches VOIDMAP.yml"
+	@echo "  make voidmap-ui-drift-check Verify ui-app VOIDMAP mirror (status/priority/title) matches VOIDMAP.yml"
 	@echo "  make pipeline-essentials  Report pipeline essentials and next expansion options"
 	@echo "  make workflow-posture-check Verify workflows declare permissions + concurrency (exit 1 on drift)"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PHI ?= 0.72
 REFRACTORY ?= 120
 JS_VERIFY_CMD ?= pnpm turbo run typecheck lint build
 
-.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check pipeline-essentials workflow-posture-check verify verify-core verify-governance verify-js verify-all verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay intake
+.PHONY: help install install-dev install-hooks test test-unit test-integration test-ethics coverage lint format type-check clean gate-test port-lint frame-lint voids-backlog voids-backlog-check voidmap-ui-drift-check pipeline-essentials workflow-posture-check verify verify-core verify-governance verify-js verify-all verify-pointers claim-lint verify-json status status-verify snapshot all deepjump benchmark-replay intake
 
 help:
 	@echo "entaENGELment Framework - Development Commands"
@@ -61,6 +61,7 @@ help:
 	@echo "Docs:"
 	@echo "  make voids-backlog       Regenerate docs/voids_backlog.md from VOIDMAP.yml"
 	@echo "  make voids-backlog-check Verify docs/voids_backlog.md is in sync (exit 1 on drift)"
+	@echo "  make voidmap-ui-drift-check Verify ui-app VOIDMAP mirror matches VOIDMAP.yml"
 	@echo "  make pipeline-essentials  Report pipeline essentials and next expansion options"
 	@echo "  make workflow-posture-check Verify workflows declare permissions + concurrency (exit 1 on drift)"
 	@echo ""
@@ -162,7 +163,7 @@ verify: verify-core
 verify-core: port-lint test verify-pointers claim-lint
 	@echo "✅ Core: ports, tests, pointers, and claims checked"
 
-verify-governance: workflow-posture-check voids-backlog-check
+verify-governance: workflow-posture-check voids-backlog-check voidmap-ui-drift-check
 	@echo "✅ Governance membrane checked"
 
 verify-js:
@@ -193,6 +194,10 @@ voids-backlog:
 
 voids-backlog-check:
 	@$(PY) tools/voids_backlog_gen.py --check
+
+# Drift check: ensure ui-app/lib/voidmap-parser.ts mirrors VOIDMAP.yml statuses.
+voidmap-ui-drift-check:
+	@$(PY) tools/voidmap_ui_drift_check.py
 
 pipeline-essentials:
 	@$(PY) tools/pipeline_essentials.py

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ make verify         # Alles prüfen
 
 **Optional: UI starten**
 ```bash
-cd ui-app
-npm ci
-npm run dev
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter entaengelment-ui dev
 # → http://localhost:3000
 ```
 
@@ -95,7 +95,7 @@ npm run dev
 | `tools/` | DeepJump-Tools | `tools/verify_pointers.py`, `tools/status_emit.py` |
 | `tests/` | Unit/Integration/Ethics Tests | `tests/ethics/`, `tests/unit/` |
 | **UI & Visualisierung** | | |
-| `ui-app/` | Next.js Web-App | `cd ui-app && npm run dev` |
+| `ui-app/` | Next.js Web-App | `pnpm --filter entaengelment-ui dev` |
 | `bio_spiral_viewer/` | Console Spiral-Explorer | `python -m bio_spiral_viewer` |
 | `Fractalsense/` | Fractal Color Generator | siehe `ui-app/fractalsense` |
 | **Development** | | |
@@ -211,9 +211,9 @@ Next.js Web-App mit mehreren Dashboards und Explorern.
 
 **Wie starten:**
 ```bash
-cd ui-app
-npm ci
-npm run dev
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter entaengelment-ui dev
 # → http://localhost:3000
 ```
 

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -31,9 +31,9 @@ make verify
 For the optional UI:
 
 ```bash
-cd ui-app
-npm ci
-npm run dev
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter entaengelment-ui dev
 ```
 
 Then open:

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,7 +12,7 @@
 // -----------------------------------------------------------------------------
 // VOIDMAP Types (mirror of VOIDMAP.yml)
 // -----------------------------------------------------------------------------
-export type VoidStatus = 'OPEN' | 'IN_PROGRESS' | 'CLOSED';
+export type VoidStatus = 'OPEN' | 'IN_PROGRESS' | 'SUSPENDED' | 'CLOSED';
 export type VoidPriority = 'critical' | 'high' | 'medium' | 'med' | 'low';
 export type VoidDomain = '[BIO]' | '[MATH]' | '[PHYS]' | '[CHEM]' | '[COMP]' | '[META]' | '[DEV]';
 

--- a/tools/voidmap_ui_drift_check.py
+++ b/tools/voidmap_ui_drift_check.py
@@ -3,9 +3,16 @@
 
 The UI keeps a hand-synced, read-only copy of the VOID registry in
 ``ui-app/lib/voidmap-parser.ts`` so it can render without a build-time YAML
-parse. This script compares the ``id`` -> ``status`` mapping of that mirror
-against ``VOIDMAP.yml`` and fails (exit code 1) if they disagree, so a stale
-UI copy cannot silently show an outdated VOID reality.
+parse. This script compares the verbatim-mirrored fields of that copy against
+``VOIDMAP.yml`` and fails (exit code 1) if they disagree, so a stale UI copy
+cannot silently show an outdated VOID reality.
+
+Checked fields (must match byte-for-byte): ``status``, ``priority``, ``title``.
+These are short, prominently rendered, and intended to be exact mirrors.
+
+NOT checked: the free-form ``notes`` field is intentionally **abridged** in the
+UI mirror (a human-readable summary of the multi-line YAML note), so it is not
+byte-compared here. Everything the checker does compare it requires to be exact.
 
 It is intentionally dependency-light: YAML is parsed with PyYAML (already used
 elsewhere in the repo) and the TypeScript mirror is scanned with a small regex
@@ -27,32 +34,43 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 VOIDMAP_YML = REPO_ROOT / "VOIDMAP.yml"
 UI_MIRROR = REPO_ROOT / "ui-app" / "lib" / "voidmap-parser.ts"
 
-# Matches an object entry like:  id: 'VOID-002', ... status: 'CLOSED',
+# Fields compared byte-for-byte between VOIDMAP.yml and the UI mirror.
+CHECKED_FIELDS = ("status", "priority", "title")
+
+# Matches a UI mirror object entry. The mirror keeps the fields in the order
+# id, title, status, priority on consecutive lines, e.g.:
+#   id: 'VOID-002',
+#   title: 'CI Pipeline Integration',
+#   status: 'CLOSED',
+#   priority: 'high',
 _ENTRY_RE = re.compile(
-    r"id:\s*'(?P<id>[^']+)'.*?status:\s*'(?P<status>[^']+)'",
+    r"id:\s*'(?P<id>[^']+)',\s*"
+    r"title:\s*'(?P<title>[^']*)',\s*"
+    r"status:\s*'(?P<status>[^']+)',\s*"
+    r"priority:\s*'(?P<priority>[^']+)'",
     re.DOTALL,
 )
 
 
-def load_yaml_statuses() -> dict[str, str]:
+def load_yaml_voids() -> dict[str, dict[str, str]]:
     data = yaml.safe_load(VOIDMAP_YML.read_text(encoding="utf-8"))
-    statuses: dict[str, str] = {}
+    voids: dict[str, dict[str, str]] = {}
     for void in data.get("voids", []) or []:
         if not isinstance(void, dict):
             continue
         vid = void.get("id")
-        status = void.get("status")
-        if vid and status:
-            statuses[str(vid)] = str(status)
-    return statuses
+        if not vid:
+            continue
+        voids[str(vid)] = {f: str(void.get(f, "")) for f in CHECKED_FIELDS}
+    return voids
 
 
-def load_ui_statuses() -> dict[str, str]:
+def load_ui_voids() -> dict[str, dict[str, str]]:
     text = UI_MIRROR.read_text(encoding="utf-8")
-    statuses: dict[str, str] = {}
+    voids: dict[str, dict[str, str]] = {}
     for match in _ENTRY_RE.finditer(text):
-        statuses[match.group("id")] = match.group("status")
-    return statuses
+        voids[match.group("id")] = {f: match.group(f) for f in CHECKED_FIELDS}
+    return voids
 
 
 def main() -> int:
@@ -63,25 +81,25 @@ def main() -> int:
         print(f"ERROR: {UI_MIRROR} not found", file=sys.stderr)
         return 2
 
-    yaml_statuses = load_yaml_statuses()
-    ui_statuses = load_ui_statuses()
+    yaml_voids = load_yaml_voids()
+    ui_voids = load_ui_voids()
 
     problems: list[str] = []
 
-    missing_in_ui = sorted(set(yaml_statuses) - set(ui_statuses))
-    for vid in missing_in_ui:
+    for vid in sorted(set(yaml_voids) - set(ui_voids)):
         problems.append(f"  - {vid}: present in VOIDMAP.yml but missing in UI mirror")
 
-    extra_in_ui = sorted(set(ui_statuses) - set(yaml_statuses))
-    for vid in extra_in_ui:
+    for vid in sorted(set(ui_voids) - set(yaml_voids)):
         problems.append(f"  - {vid}: present in UI mirror but missing in VOIDMAP.yml")
 
-    for vid in sorted(set(yaml_statuses) & set(ui_statuses)):
-        if yaml_statuses[vid] != ui_statuses[vid]:
-            problems.append(
-                f"  - {vid}: status drift "
-                f"(VOIDMAP.yml={yaml_statuses[vid]}, UI={ui_statuses[vid]})"
-            )
+    for vid in sorted(set(yaml_voids) & set(ui_voids)):
+        for field in CHECKED_FIELDS:
+            expected = yaml_voids[vid][field]
+            actual = ui_voids[vid][field]
+            if expected != actual:
+                problems.append(
+                    f"  - {vid}: {field} drift " f"(VOIDMAP.yml={expected!r}, UI={actual!r})"
+                )
 
     if problems:
         print("VOIDMAP <-> UI drift detected:", file=sys.stderr)
@@ -92,7 +110,10 @@ def main() -> int:
         )
         return 1
 
-    print(f"OK: {len(yaml_statuses)} VOIDs in sync between VOIDMAP.yml and UI mirror.")
+    print(
+        f"OK: {len(yaml_voids)} VOIDs in sync between VOIDMAP.yml and UI mirror "
+        f"(fields checked: {', '.join(CHECKED_FIELDS)})."
+    )
     return 0
 
 

--- a/tools/voidmap_ui_drift_check.py
+++ b/tools/voidmap_ui_drift_check.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Detect drift between VOIDMAP.yml (GOLD source of truth) and the UI mirror.
+
+The UI keeps a hand-synced, read-only copy of the VOID registry in
+``ui-app/lib/voidmap-parser.ts`` so it can render without a build-time YAML
+parse. This script compares the ``id`` -> ``status`` mapping of that mirror
+against ``VOIDMAP.yml`` and fails (exit code 1) if they disagree, so a stale
+UI copy cannot silently show an outdated VOID reality.
+
+It is intentionally dependency-light: YAML is parsed with PyYAML (already used
+elsewhere in the repo) and the TypeScript mirror is scanned with a small regex
+rather than a JS parser.
+
+Usage:
+    python tools/voidmap_ui_drift_check.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VOIDMAP_YML = REPO_ROOT / "VOIDMAP.yml"
+UI_MIRROR = REPO_ROOT / "ui-app" / "lib" / "voidmap-parser.ts"
+
+# Matches an object entry like:  id: 'VOID-002', ... status: 'CLOSED',
+_ENTRY_RE = re.compile(
+    r"id:\s*'(?P<id>[^']+)'.*?status:\s*'(?P<status>[^']+)'",
+    re.DOTALL,
+)
+
+
+def load_yaml_statuses() -> dict[str, str]:
+    data = yaml.safe_load(VOIDMAP_YML.read_text(encoding="utf-8"))
+    statuses: dict[str, str] = {}
+    for void in data.get("voids", []) or []:
+        if not isinstance(void, dict):
+            continue
+        vid = void.get("id")
+        status = void.get("status")
+        if vid and status:
+            statuses[str(vid)] = str(status)
+    return statuses
+
+
+def load_ui_statuses() -> dict[str, str]:
+    text = UI_MIRROR.read_text(encoding="utf-8")
+    statuses: dict[str, str] = {}
+    for match in _ENTRY_RE.finditer(text):
+        statuses[match.group("id")] = match.group("status")
+    return statuses
+
+
+def main() -> int:
+    if not VOIDMAP_YML.exists():
+        print(f"ERROR: {VOIDMAP_YML} not found", file=sys.stderr)
+        return 2
+    if not UI_MIRROR.exists():
+        print(f"ERROR: {UI_MIRROR} not found", file=sys.stderr)
+        return 2
+
+    yaml_statuses = load_yaml_statuses()
+    ui_statuses = load_ui_statuses()
+
+    problems: list[str] = []
+
+    missing_in_ui = sorted(set(yaml_statuses) - set(ui_statuses))
+    for vid in missing_in_ui:
+        problems.append(f"  - {vid}: present in VOIDMAP.yml but missing in UI mirror")
+
+    extra_in_ui = sorted(set(ui_statuses) - set(yaml_statuses))
+    for vid in extra_in_ui:
+        problems.append(f"  - {vid}: present in UI mirror but missing in VOIDMAP.yml")
+
+    for vid in sorted(set(yaml_statuses) & set(ui_statuses)):
+        if yaml_statuses[vid] != ui_statuses[vid]:
+            problems.append(
+                f"  - {vid}: status drift "
+                f"(VOIDMAP.yml={yaml_statuses[vid]}, UI={ui_statuses[vid]})"
+            )
+
+    if problems:
+        print("VOIDMAP <-> UI drift detected:", file=sys.stderr)
+        print("\n".join(problems), file=sys.stderr)
+        print(
+            "\nRe-sync ui-app/lib/voidmap-parser.ts with VOIDMAP.yml.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {len(yaml_statuses)} VOIDs in sync between VOIDMAP.yml and UI mirror.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ui-app/app/voidmap/page.tsx
+++ b/ui-app/app/voidmap/page.tsx
@@ -20,7 +20,7 @@ export default function VoidMapPage() {
       </header>
 
       {/* Quick Stats */}
-      <div className="grid grid-cols-4 gap-2 md:gap-4">
+      <div className="grid grid-cols-5 gap-2 md:gap-4">
         <div className="bg-zinc-900/30 rounded-lg p-3 md:p-4 text-center">
           <div className="text-xl md:text-2xl font-bold text-zinc-100">
             {stats.total}
@@ -38,6 +38,12 @@ export default function VoidMapPage() {
             {stats.inProgress}
           </div>
           <div className="text-[10px] md:text-xs text-blue-500/70">Progress</div>
+        </div>
+        <div className="bg-violet-500/10 rounded-lg p-3 md:p-4 text-center border border-violet-500/20">
+          <div className="text-xl md:text-2xl font-bold text-violet-400">
+            {stats.suspended}
+          </div>
+          <div className="text-[10px] md:text-xs text-violet-500/70">Suspended</div>
         </div>
         <div className="bg-green-500/10 rounded-lg p-3 md:p-4 text-center border border-green-500/20">
           <div className="text-xl md:text-2xl font-bold text-green-400">

--- a/ui-app/components/voidmap/VoidFilter.tsx
+++ b/ui-app/components/voidmap/VoidFilter.tsx
@@ -9,6 +9,7 @@ interface VoidFilterProps {
     total: number;
     open: number;
     inProgress: number;
+    suspended: number;
     closed: number;
   };
 }
@@ -17,6 +18,7 @@ const STATUS_OPTIONS: { value: VoidStatus | 'ALL'; label: string; icon: string }
   { value: 'ALL', label: 'Alle', icon: '○' },
   { value: 'OPEN', label: 'Open', icon: '☐' },
   { value: 'IN_PROGRESS', label: 'In Progress', icon: '🔄' },
+  { value: 'SUSPENDED', label: 'Suspended', icon: '⏸' },
   { value: 'CLOSED', label: 'Closed', icon: '✓' },
 ];
 
@@ -38,6 +40,7 @@ export function VoidFilter({ filters, onFilterChange, stats }: VoidFilterProps) 
           const count = option.value === 'ALL' ? stats.total
             : option.value === 'OPEN' ? stats.open
             : option.value === 'IN_PROGRESS' ? stats.inProgress
+            : option.value === 'SUSPENDED' ? stats.suspended
             : stats.closed;
 
           return (

--- a/ui-app/components/voidmap/VoidList.tsx
+++ b/ui-app/components/voidmap/VoidList.tsx
@@ -38,7 +38,7 @@ export function VoidList() {
   // Sort: Open first, then by priority
   const sortedVoids = useMemo(() => {
     const priorityOrder = { critical: 0, high: 1, medium: 2, med: 2, low: 3 };
-    const statusOrder = { OPEN: 0, IN_PROGRESS: 1, CLOSED: 2 };
+    const statusOrder = { OPEN: 0, IN_PROGRESS: 1, SUSPENDED: 2, CLOSED: 3 };
 
     return [...filteredVoids].sort((a, b) => {
       // First by status

--- a/ui-app/lib/voidmap-parser.ts
+++ b/ui-app/lib/voidmap-parser.ts
@@ -10,10 +10,11 @@ import { Void, VoidMap, VoidStatus, VoidPriority } from '@/types';
 // `VOIDMAP.yml` — never edit a VOID's meaning here, only mirror what the GOLD
 // file already says.
 //
-// Drift between this file and `VOIDMAP.yml` is detected by
-// `tools/voidmap_ui_drift_check.py` (run via `make voidmap-ui-drift-check`).
-// If that check fails, re-sync the `status` (and other) fields below to match
-// `VOIDMAP.yml`.
+// Drift in the verbatim-mirrored fields (`status`, `priority`, `title`) is
+// detected by `tools/voidmap_ui_drift_check.py` (run via
+// `make voidmap-ui-drift-check`). The free-form `notes` field is intentionally
+// abridged here for display and is NOT byte-compared. If the check fails,
+// re-sync the affected fields below to match `VOIDMAP.yml`.
 // =============================================================================
 export const VOIDMAP_DATA: VoidMap = {
   version: '1.0',

--- a/ui-app/lib/voidmap-parser.ts
+++ b/ui-app/lib/voidmap-parser.ts
@@ -1,13 +1,26 @@
 import { Void, VoidMap, VoidStatus, VoidPriority } from '@/types';
 
-// Static VOIDMAP data (in production, this would be fetched from API)
-// Parsed from VOIDMAP.yml
+// =============================================================================
+// Static VOIDMAP mirror.
+//
+// ⚠️ SOURCE OF TRUTH IS `VOIDMAP.yml` (repo root, GOLD).
+//
+// This file is a hand-synced, read-only copy of `VOIDMAP.yml` so the UI can be
+// rendered without a build-time YAML parse. It MUST be kept in sync with
+// `VOIDMAP.yml` — never edit a VOID's meaning here, only mirror what the GOLD
+// file already says.
+//
+// Drift between this file and `VOIDMAP.yml` is detected by
+// `tools/voidmap_ui_drift_check.py` (run via `make voidmap-ui-drift-check`).
+// If that check fails, re-sync the `status` (and other) fields below to match
+// `VOIDMAP.yml`.
+// =============================================================================
 export const VOIDMAP_DATA: VoidMap = {
   version: '1.0',
   description: 'Central registry for tracking open voids (gaps) in the entaENGELment framework.',
   metadata: {
     maintainer: 'entaENGELment',
-    last_updated: '2026-01-25',
+    last_updated: '2026-06-11',
     generated_doc: 'docs/voids_backlog.md',
   },
   voids: [
@@ -28,58 +41,63 @@ export const VOIDMAP_DATA: VoidMap = {
     {
       id: 'VOID-002',
       title: 'CI Pipeline Integration',
-      status: 'OPEN',
+      status: 'CLOSED',
       priority: 'high',
-      owner: null,
+      owner: 'claude-code',
       domain: '[DEV]',
       symptom: 'CI does not run full verify/status/snapshot flow',
       closing_path: 'Update deepjump-ci.yml with verify_pointers and claim_lint steps',
-      evidence: null,
+      evidence: '.github/workflows/deepjump-ci.yml',
       created: '2026-01-04',
-      closed: null,
-      notes: '[TODO] Needs CI workflow update to include new tools.',
+      closed: '2026-02-15',
+      notes: '[CLOSED 2026-02-15] verify_pointers, claim_lint, port_lint now run as blocking CI steps in deepjump-ci.yml (no continue-on-error).',
     },
     {
       id: 'VOID-003',
       title: 'Status Emit Receipt Format',
-      status: 'OPEN',
+      status: 'CLOSED',
       priority: 'medium',
-      owner: null,
+      owner: 'claude-code',
       domain: '[DEV]',
       symptom: 'status_emit.py does not emit full receipt format per protocol',
       closing_path: 'Update status_emit.py with --claim, --tag, --module options',
-      evidence: null,
+      evidence: 'tools/status_emit.py',
       created: '2026-01-04',
-      closed: null,
-      notes: '[TODO] Protocol specifies receipt format v1.0 with additional fields.',
+      closed: '2026-03-06',
+      notes: '[FACT] tools/status_emit.py implements full receipt format v1.0 with --claim, --tag, --module options (tests/test_status_emit.py).',
     },
     {
       id: 'VOID-010',
       title: 'Taxonomie & Spektren (Empirie)',
-      status: 'OPEN',
+      status: 'IN_PROGRESS',
       priority: 'high',
-      owner: null,
+      owner: 'fleks',
       domain: '[PHYS]',
       symptom: 'Spektrale Zuordnung ohne belastbare Literatur-/Datenbasis',
       closing_path: 'Literatur-Scan + zitierte Tabelle (CSV) + Evidence-Bundle',
-      evidence: null,
+      evidence: ['docs/voids/VOID-010_taxonomy_and_spectra.md'],
       created: '2026-01-04',
       closed: null,
-      notes: '[BIO][PHYS] Empirie-Bridge für MOD_18/Taxonomie.',
+      notes: '[BIO][PHYS] Empirie-Bridge für MOD_18/Taxonomie. [2026-06-11] Re-baselined after issue #240: next verifier boundary is a sources-first CSV/schema bundle.',
     },
     {
       id: 'VOID-011',
       title: 'Metriken der Resonanz (MI, PLV, FD)',
-      status: 'OPEN',
+      status: 'IN_PROGRESS',
       priority: 'high',
-      owner: null,
+      owner: 'fleks',
       domain: '[MATH]',
-      symptom: 'MI/FD sind aktuell Minimal-Stubs; keine Toy-Simulation als Proof',
-      closing_path: 'Option B: toy_resonance_dataset + robuste Implementierung + Tests',
-      evidence: null,
+      symptom: 'MI/FD implementation exists; evidence boundary needs simulation receipt and claim-tagged metric export',
+      closing_path: 'Option B: toy_resonance_dataset + robust implementation + tests + SIMULATION_PROXY evidence receipt',
+      evidence: [
+        'src/core/metrics.py',
+        'src/tools/toy_resonance_dataset.py',
+        'tests/unit/test_toy_resonance_dataset.py',
+        'docs/voids/VOID-011_resonance_metrics.md',
+      ],
       created: '2026-01-04',
       closed: null,
-      notes: '[COMP] Siehe src/tools/toy_resonance_dataset.py',
+      notes: '[COMP] MI (histogram) und FD (Higuchi) implementiert in src/core/metrics.py. [2026-06-11] Do not close until a deterministic metrics export/receipt carries the SIMULATION_PROXY boundary explicitly.',
     },
     {
       id: 'VOID-012',
@@ -90,10 +108,10 @@ export const VOIDMAP_DATA: VoidMap = {
       domain: '[DEV]',
       symptom: 'Keine einheitliche, testbare Checkliste für latent→manifest Übergänge',
       closing_path: 'policies/gateproof_v1.yaml + negative ethics tests',
-      evidence: 'policies/gateproof_v1.yaml',
+      evidence: ['policies/gateproof_v1.yaml', 'tests/ethics/test_fail_safe_expired_consent.py'],
       created: '2026-01-04',
-      closed: '2026-01-25',
-      notes: '[META] Governance als Judikative: Lint/Guards/Receipts müssen zusammen geprüft werden. [DRAFT] CLOSED with DRAFT placeholder v1.0 - full implementation requires review and integration.',
+      closed: '2026-03-06',
+      notes: '[META] Governance als Judikative. [CLOSED 2026-03-06] DRAFT-Status entfernt, alle Checks mit Verifikationspfad.',
     },
     {
       id: 'VOID-013',
@@ -104,24 +122,24 @@ export const VOIDMAP_DATA: VoidMap = {
       domain: '[DEV]',
       symptom: 'Kein BOM/Protokoll für Sensorik, falls Messschicht gebaut wird',
       closing_path: 'docs/sensors/bom.md + spec/sensors.spec.json',
-      evidence: 'docs/sensors/bom.md, spec/sensors.spec.json',
+      evidence: ['docs/sensors/bom.md', 'spec/sensors.spec.json'],
       created: '2026-01-04',
-      closed: '2026-01-25',
-      notes: '[BIO] Nur Komponenten-/Protokollebene, keine riskanten Anleitungen. [DRAFT] CLOSED with DRAFT placeholders v1.0 - component-level spec only, no operational procedures.',
+      closed: '2026-03-06',
+      notes: '[BIO] Nur Komponenten-/Protokollebene, keine riskanten Anleitungen. [CLOSED 2026-03-06] DRAFT-Status entfernt, Specs finalisiert.',
     },
     {
       id: 'VOID-014',
       title: 'Protein-Design (in-silico, safety-bounded)',
-      status: 'OPEN',
+      status: 'SUSPENDED',
       priority: 'medium',
-      owner: null,
+      owner: 'fleks',
       domain: '[BIO]',
       symptom: 'Exploration gewünscht, aber hohes Risiko bei operativen Laboranleitungen',
       closing_path: 'High-level Tool/Literatur-Übersicht + nicht-operative Demos',
       evidence: null,
       created: '2026-01-04',
       closed: null,
-      notes: '[SAFETY] Nur computational exploration.',
+      notes: '[SAFETY] Nur computational exploration; keine Nasslabor-Protokolle. [2026-04-04] Status auf SUSPENDED gesetzt. Kann bei Bedarf auf OPEN zurückgesetzt werden.',
     },
     {
       id: 'VOID-020',
@@ -129,7 +147,7 @@ export const VOIDMAP_DATA: VoidMap = {
       status: 'CLOSED',
       priority: 'high',
       owner: null,
-      domain: '[DEV]',
+      domain: '',
       symptom: 'Kein Port-Linter / keine Marker-Operationalisierung',
       closing_path: 'tools/port_lint.py',
       evidence: ['tools/port_lint.py', 'tests/test_port_lint.py'],
@@ -141,9 +159,9 @@ export const VOIDMAP_DATA: VoidMap = {
       id: 'VOID-021',
       title: 'Port-Codebooks fehlen',
       status: 'CLOSED',
-      priority: 'medium',
+      priority: 'med',
       owner: null,
-      domain: '[DEV]',
+      domain: '',
       symptom: 'Semantik/Marker nicht zentral dokumentiert',
       closing_path: 'policies/port_codebooks.yaml',
       evidence: 'policies/port_codebooks.yaml',
@@ -153,11 +171,11 @@ export const VOIDMAP_DATA: VoidMap = {
     },
     {
       id: 'VOID-022',
-      title: 'Flood-Guard Threshold fehlt',
+      title: 'Flood-Guard Threshold fehlt (MAX_CLAIMS_PER_RECEIPT)',
       status: 'CLOSED',
-      priority: 'medium',
+      priority: 'med',
       owner: null,
-      domain: '[DEV]',
+      domain: '',
       symptom: 'Keine harte Grenze gegen Receipt-Überflutung',
       closing_path: 'tools/port_lint.py',
       evidence: 'tools/port_lint.py',
@@ -168,16 +186,31 @@ export const VOIDMAP_DATA: VoidMap = {
     {
       id: 'VOID-023',
       title: 'MICRO/MESO/MACRO Tagging konsistent ausrollen',
-      status: 'OPEN',
+      status: 'CLOSED',
       priority: 'low',
-      owner: null,
-      domain: '[DEV]',
+      owner: 'claude-code',
+      domain: '',
       symptom: 'Scope-Tags nicht überall konsistent',
-      closing_path: null,
-      evidence: null,
+      closing_path: 'policies/port_codebooks.yaml scope_tags section',
+      evidence: 'policies/port_codebooks.yaml',
       created: '2026-01-13',
-      closed: null,
+      closed: '2026-03-06',
       layer: 'EXPLAIN',
+      notes: '[FACT] Scope-Tag-Definitionen [MICRO]/[MESO]/[MACRO] in policies/port_codebooks.yaml. [CLOSED 2026-03-06] Formale Definition etabliert.',
+    },
+    {
+      id: 'VOID-LOGZN-001',
+      title: 'LOG-ZN Orbit als Windungs-Gedächtnisoperator',
+      status: 'OPEN',
+      priority: 'high',
+      owner: 'fleks',
+      domain: '[MATH][META]',
+      symptom: 'Der entwickelte Winkel / log(z)-Orbit ist als neuer RZT-Operator erkannt, aber noch nicht in Tests, Metrics oder Receipts verankert.',
+      closing_path: 'docs/rzt/LOG_ZN_ORBIT_001.md + docs/tesser3takt/S4_LOGZN_bridge.md + Claim-Tags + optionaler Visual-/Replay-Test',
+      evidence: ['docs/rzt/LOG_ZN_ORBIT_001.md', 'docs/tesser3takt/S4_LOGZN_bridge.md'],
+      created: '2026-05-17',
+      closed: null,
+      notes: '[MODEL] Sichtbare Wiederkehr modulo 2π ist nicht identisch mit entwickelter Windungsgeschichte. [INFERENCE] Anschluss an RZT-0/Nektar-Maturation/A4-Reentry/tesser3TAKT-S4 ist prüfbar, aber nicht als Identitätsbehauptung zu lesen.',
     },
   ],
 };
@@ -209,6 +242,7 @@ export function getVoidStats() {
     total: voids.length,
     open: voids.filter(v => v.status === 'OPEN').length,
     inProgress: voids.filter(v => v.status === 'IN_PROGRESS').length,
+    suspended: voids.filter(v => v.status === 'SUSPENDED').length,
     closed: voids.filter(v => v.status === 'CLOSED').length,
     critical: voids.filter(v => v.priority === 'critical' && v.status !== 'CLOSED').length,
     high: voids.filter(v => v.priority === 'high' && v.status !== 'CLOSED').length,
@@ -219,6 +253,7 @@ export function getStatusIcon(status: VoidStatus): string {
   switch (status) {
     case 'OPEN': return '☐';
     case 'IN_PROGRESS': return '🔄';
+    case 'SUSPENDED': return '⏸';
     case 'CLOSED': return '✓';
   }
 }
@@ -237,6 +272,7 @@ export function getStatusColor(status: VoidStatus): string {
   switch (status) {
     case 'OPEN': return 'text-amber-400';
     case 'IN_PROGRESS': return 'text-blue-500';
+    case 'SUSPENDED': return 'text-violet-400';
     case 'CLOSED': return 'text-green-500';
   }
 }


### PR DESCRIPTION
## FOKUS: Repo-Hygiene & sichtbare Anwendungspolitur ohne Essenzänderung

Konservativ, additiv, minimal-invasiv. **Keine GOLD/IMMUTABLE-Änderung** — `VOIDMAP.yml` bleibt unangetastet (Source of Truth). Nur ANNEX (`ui-app/`, `packages/`, `tools/`, `docs`-artige `README`/`WELCOME`).

### Vorprüfung
- **PR #259** (ruff F401 `import sys` in `tools/intake_add.py`) ist bereits in `main` (kein `import sys` mehr vorhanden) → nicht dupliziert, nichts übernommen. PR #259 ist inzwischen diff-leer und wird als superseded geschlossen.

---

### Aufgabe 1 — UI-VOIDMAP-Synchronität (Option B + Drift-Guard)
`ui-app/lib/voidmap-parser.ts` enthielt eine veraltete statische Kopie. Der Status-Mirror wurde an `VOIDMAP.yml` angeglichen:

| VOID | vorher (UI) | jetzt (UI = VOIDMAP.yml) |
|------|-------------|--------------------------|
| VOID-002 | OPEN | **CLOSED** |
| VOID-003 | OPEN | **CLOSED** |
| VOID-010 | OPEN | **IN_PROGRESS** |
| VOID-011 | OPEN | **IN_PROGRESS** |
| VOID-014 | OPEN | **SUSPENDED** |
| VOID-023 | OPEN | **CLOSED** |
| VOID-LOGZN-001 | _fehlte_ | **OPEN** (ergänzt) |

- Klarer Sync-Kommentar im File: `VOIDMAP.yml` ist GOLD Source of Truth.
- **`tools/voidmap_ui_drift_check.py`** erkennt Drift zwischen `VOIDMAP.yml` und UI-Mirror (dependency-light: PyYAML + Regex). Verdrahtet via `make voidmap-ui-drift-check` und in `verify-governance`.

#### Geltungsbereich des Drift-Guards (Präzisierung)
> Der neue Drift-Guard prüft bewusst die Cockpit-kritische Präsenz- und Status-Synchronität (`id -> status`) zwischen `VOIDMAP.yml` und UI-Mirror. Konkret meldet er: fehlende VOIDs, zusätzliche UI-VOIDs und Status-Abweichungen (Exit 0 = in sync, 1 = Drift, 2 = Datei fehlt).
>
> Er prüft **nicht** vollständig auf strukturelle Gleichheit der Detailfelder (`notes`, `evidence`, `closing_path`, `owner`, `target_date`, `domain` etc.). Diese bleiben handgesynct und werden nicht als vollständige strukturelle Identität validiert. „Synchron“ bezieht sich hier also auf `id -> status`, nicht auf eine 1:1-Vollkopie aller Felder.

### Aufgabe 2 — `SUSPENDED` als gültiger Status in UI/Types
- `packages/types`: `VoidStatus` um `'SUSPENDED'` erweitert.
- Reihenfolge **OPEN → IN_PROGRESS → SUSPENDED → CLOSED** in Sort/Filter/Stats.
- Icon `⏸`, dezente `violet`-Farbe (nicht alarmistisch). Suspended-Stat-Kachel auf `/voidmap`.

### Aufgabe 3 — UI-Startbefehle auf pnpm harmonisiert
`README.md` / `WELCOME.md`: `npm ci` / `npm run dev` → `corepack enable` + `pnpm install --frozen-lockfile` + `pnpm --filter entaengelment-ui dev` (passt zu `packageManager: pnpm@10.33.0`). Auch der `cd ui-app && npm run dev`-Eintrag in der Repository-Map zeigt jetzt auf `pnpm --filter entaengelment-ui dev`.

### Aufgabe 4 — .gitignore: Intake-Shadow-Copy-Auto-Dump
`docs/intake/raw/auto/**` ignoriert (transiente Hook-Ausgabe), `!docs/intake/raw/auto/.gitkeep` bleibt trackbar. Manuell kuratierte Intake-Records unter `docs/intake/raw/` bleiben unberührt.

---

### Verifikation (tatsächlich gelaufen)
- `make voidmap-ui-drift-check` → **13 VOIDs in sync**
- `make verify-governance` → **PASS** (13 Workflows posture-OK · voids-backlog up to date · drift-check sync)
- `pnpm install --frozen-lockfile` + `pnpm turbo run typecheck lint build` → **4/4 successful** (keine TS-Fehler)
- Hinweis: `make verify` (verify-core/pytest) bricht in dieser Umgebung an einem **vorbestehenden, PR-fremden** Punkt ab (pytest aus uv-Tool-Env ohne PyYAML → `tools/workflow_posture_check.py` `sys.exit(2)` beim Import). Betrifft keine der hier geänderten Dateien.

### Keine Änderung
Keine inhaltliche Umdeutung von VOIDs, keine neuen VOIDs, keine VOID-Schließungen, keine GOLD/IMMUTABLE-Edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Frx2A2s5bjrUZwh2eJALn1)_