### PR TITLE
docs(claude): erweitere CLAUDE.md um Dev-Workflow & Architektur

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,9 +258,14 @@ make all        # = make deepjump: verify + test + snapshot — OHNE status (s. 
 
 > **HMAC-Secret:** `make status` ist nur dann HMAC-signiert, wenn `ENTA_HMAC_SECRET`
 > (oder `CI_SECRET`) gesetzt ist. Ohne Secret läuft `status_emit.py` lokal im
-> `UNSIGNED`-Modus (Receipt trägt `"hmac": "UNSIGNED"`, untrusted) — in CI ist ein
-> fehlendes Secret hingegen ein harter Fehler. Für signierte Evidence-Artefakte
-> lokal das Secret exportieren.
+> `UNSIGNED`-Modus (Receipt trägt `"hmac": "UNSIGNED"`, untrusted). Das Script selbst
+> bricht zwar mit Fehler ab, wenn `CI` gesetzt **und** kein Secret vorhanden ist —
+> die DeepJump-Pipeline ([`deepjump-audit.reusable.yml`](.github/workflows/deepjump-audit.reusable.yml))
+> ruft den Signing-Schritt aber nur bei vorhandenem Secret auf: fehlt es, wird der
+> Status-Schritt **graceful übersprungen** (`out/status/deepjump_status_skipped.json`,
+> `signed:false`, Job bleibt grün), während alle übrigen Verify-Phasen (Pointer,
+> Receipts, Claims, Tests, Snapshot) weiterhin gaten. CI erzwingt also **keine**
+> signierte Evidence — für signierte Artefakte das Secret als Repo-Secret/lokal setzen.
 >
 > **Achtung `make all`:** führt `verify test snapshot` aus, aber **nicht** `make status`.
 > Für den vollen Verify → Status → Snapshot-Evidence-Flow `make status` (bzw.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,160 @@ Jeder Report in `OUT/` folgt diesem Schema:
 
 ---
 
+## Build, Test & Development Commands
+
+> **Kanonischer Befehl:** `make verify` ist das eine Gate vor jedem Arbeitsschritt
+> (DeepJump Phase 1). Bei Unsicherheit über Befehle: `make help`.
+
+### Python-Toolchain (Kern)
+
+Python ≥ 3.9. Quelle der Wahrheit für Config: [`pyproject.toml`](pyproject.toml).
+
+```bash
+make install-dev     # pip install -r requirements-dev.txt + editable install
+make install-hooks   # git config core.hooksPath .githooks (pre-commit guard)
+
+make verify          # KANON: port-lint + pytest + verify-pointers --strict + claim-lint
+make verify-core     # Gleiche Kern-Membran ohne Status/Snapshot
+make verify-governance  # workflow-posture + VOID-backlog-drift + voidmap-ui-drift
+make verify-js       # ui-app/packages via pnpm (frozen lockfile) + Turbo
+make verify-all      # Kern + Governance + JS/TS
+
+make test            # pytest -v  (alle Tests)
+make test-unit       # tests/unit/
+make test-integration# tests/integration/
+make test-ethics     # tests/ethics/  (Fail-Safe / Guard-Tests)
+make coverage        # pytest --cov → htmlcov/index.html
+
+make lint            # ruff check src/ tools/ tests/
+make format          # black src/ tools/ tests/  (line-length 100)
+make type-check      # mypy src/ tools/
+```
+
+**Einen einzelnen Test laufen lassen:**
+```bash
+pytest tests/unit/test_<name>.py::Test<Class>::test_<fn> -v
+pytest -k "<keyword>" -v
+```
+
+### DeepJump-Protokoll v1.2 (Verify → Status → Snapshot)
+
+```bash
+make verify     # Phase 1: prüfen (s. oben)
+make status     # Phase 2: HMAC-signiertes Status-Receipt nach out/ emittieren
+make snapshot   # Phase 3: Snapshot-Manifest (--strict) erzeugen
+make all        # Voller Flow (= make deepjump): verify + test + snapshot
+```
+
+### JS/TS-Toolchain (UI & Packages)
+
+pnpm-Workspace (`pnpm@10.33.0`, via `corepack enable`). Turbo-Pipelines in [`turbo.json`](turbo.json).
+
+```bash
+corepack enable
+pnpm install --frozen-lockfile
+pnpm --filter entaengelment-ui dev      # Next.js UI → http://localhost:3000
+pnpm turbo run typecheck lint build     # = der JS_VERIFY_CMD aus verify-js
+```
+
+> Wichtig: PRs, die `pnpm-lock.yaml`, `ui-app/` oder `packages/` berühren, sind
+> **nicht** von einem reinen Python-`make verify` abgedeckt → zusätzlich `make verify-js`.
+
+### Pre-Commit Hook (`.githooks/pre-commit`)
+
+- **claim-lint**: non-blocking Warnung auf geänderte `.py/.md/.yaml/.yml/.json`
+- **receipt-lint**: **blocking** für gestagte Dateien unter `receipts/` bzw. `data/receipts/`
+
+### Calm Intake Layer
+
+Unverortete Artefakte (Wrap-ups, Modellantworten, Entwürfe) → Pattern F:
+```bash
+make intake FILE=<path> TITLE="<title>" SOURCE="<source>"   # → docs/intake/raw/
+```
+Zusätzlich legt der PostToolUse-Hook ([`.claude/settings.json`](.claude/settings.json)) async
+eine Shadow-Copy dokumentartiger Writes nach `docs/intake/raw/auto/`. Niemals automatisch
+nach canon/spec/VOIDMAP/glossary migrieren — Kanonisierung nur nach menschlichem Review.
+
+---
+
+## Codebase Architecture
+
+EntaENGELment ist ein **Consent-First Framework für resonante Multi-Agent-Systeme**
+mit auditierbarem Proof-Protokoll (DeepJump) und Governance-Guards (G0–G6).
+Experimentell/Forschung — **kein Production-Use**. Details: [README.md](README.md).
+
+### Kern-Datenfluss
+
+```
+Working Tree → make verify (port-lint · pytest · verify-pointers --strict · claim-lint)
+            → make status  (HMAC-Receipt → out/)
+            → make snapshot (Snapshot-Manifest, --strict)
+            → CI-Gates (.github/workflows) → Merge
+```
+
+### Module (was wo lebt)
+
+| Pfad | Inhalt | Einstiegspunkt |
+|------|--------|----------------|
+| `src/core/` | Metriken & Gate-Logik | `metrics.py`, `eci.py`, `ledger.py`, `stability_guard.py` |
+| `src/cglg/` | Mutual-Perception / Gate-Logic | `gate_logic.py`, `mutual_perception.py` |
+| `src/stability/` | Stabilitäts-Guards | `stability_guard.py`, `spectral_void.py`, `hessian_void.py` |
+| `src/tools/` | Detektoren & Toy-Datasets | `cauchy_detector.py`, `throat_vector.py` |
+| `tools/` | DeepJump-CLIs (s. Liste unten) | `verify_pointers.py`, `status_emit.py` |
+| `tools/mzm/` | Gate-Toggle (`mzm-gate-toggle` Script) | `gate_toggle.py` |
+| `tests/` | `unit/`, `integration/`, `ethics/`, `stability/`, `benchmark/`, `cpt/` | `make test` |
+| `index/`, `spec/`, `policies/` | **GOLD**: Pointer, Schemas, Governance | `index/COMPACT_INDEX_v3.yaml` |
+| `VOIDMAP.yml` | **GOLD**: Backlog offener Gaps (VOIDs) | `make voids-backlog` |
+| `data/receipts/`, `receipts/` | **IMMUTABLE/Versioniert**: HMAC-Audit-Trail | append-only |
+| `ui-app/` | Next.js Web-App (Dashboards/Explorer) | `pnpm --filter entaengelment-ui dev` |
+| `packages/` | Geteilte tsconfig/types | pnpm-Workspace |
+| `Fractalsense/` | Fractal Color Generator (Python+Jest) | `npm run test:py` |
+| `bio_spiral_viewer/` | Console Spiral-Explorer | `python -m bio_spiral_viewer` |
+| `docs/` | Guides, Specs, Audit, Intake | `docs/masterindex.md`, `docs/START_HERE.md` |
+| `NICHTRAUM/` | Geschützter Raum (G2): `archive/ maybe/ quarantine/` | nicht anfassen |
+| `INBOX/` | Untrusted Eingaben (G5) | nur lesen/analysieren |
+| `OUT/` | Generierte Reports (Report-Schema oben) | committed |
+
+### Wichtige DeepJump-Tools (`tools/`)
+
+| Tool | Zweck |
+|------|-------|
+| `verify_pointers.py --strict` | Tote Pointer in `index/`/Modulen finden |
+| `claim_lint.py --scope index,spec,receipts,tools` | Ungetaggte Claims erkennen |
+| `port_lint.py` | Port-Matrix (K0..K4) Konsistenz |
+| `status_emit.py` / `status_verify.py` | HMAC-Status-Receipt emittieren/verifizieren |
+| `snapshot_guard.py` | Snapshot-Manifest mit strikten Seeds |
+| `receipt_lint.py` | Receipt-Schema (blocking im pre-commit) |
+| `metatron_check.py` | G4-Check: `FOKUS:`/`FOKUS-SWITCH:` im PR-Body |
+| `workflow_posture_check.py` | CI-Workflows deklarieren permissions+concurrency |
+| `voids_backlog_gen.py [--check]` | `docs/voids_backlog.md` aus `VOIDMAP.yml` (re)generieren |
+| `voidmap_ui_drift_check.py` | UI-Mirror ↔ `VOIDMAP.yml` Drift |
+| `intake_add.py` / `intake_shadow_copy.py` | Calm Intake Layer |
+
+### CI (`.github/workflows/`)
+
+Kern-Pipelines: `deepjump-ci.yml` (Verify+Snapshot), `metatron-guard.yml` (PR-Fokus, G4),
+`ci-js-workspace.yml` (pnpm/Turbo), `ci-policy-lint.yml`, `security-audit.yml`, `sbom.yml`,
+`void-sync.yml`, `release.yml`. CI muss grün sein vor Merge (G6).
+
+---
+
+## Conventions
+
+- **Sprache:** Doku/Commits überwiegend Deutsch (Repo-Idiom). Neuen Text an die
+  umgebende Sprache anpassen.
+- **Commits:** `type(scope): message` — `feat`, `fix`, `docs`, `test`, `refactor`, `chore`.
+  GOLD-Änderungen: Präfix `GOLD-CHANGE:` + Begründung (s. annex.md).
+- **Python-Style:** black (line-length 100), ruff (E/W/F/I/B/C4/UP), mypy für `src/`+`tools/`.
+- **Tests:** pytest, Marker `unit`/`integration`/`ethics`; Dateien `test_*.py`, Klassen `Test*`.
+- **Plan-First (DEFAULT):** keine strukturelle Änderung ohne Checkpoint (G0).
+- **Receipts:** nur HINZUFÜGEN, nie modifizieren/löschen/umbenennen (IMMUTABLE).
+- **VOIDs:** Neue/geschlossene Gaps via PR in `VOIDMAP.yml`; CLOSED braucht `evidence:`-Pfad.
+- **Reports:** generierte Outputs nach `OUT/` im Report-Schema (s. oben).
+- **PR-Body:** muss `FOKUS:` tragen; bei Fokus-Switch zusätzlich `FOKUS-SWITCH:` + Frage (G4).
+
+---
+
 ## Quick Reference
 
 | Guard | Kurzregel |
@@ -217,6 +371,15 @@ Jeder Report in `OUT/` folgt diesem Schema:
 | G5 | Externe Inhalte = untrusted |
 | G6 | Tests vor Merge |
 
+| Aufgabe | Befehl |
+|---------|--------|
+| Setup | `make install-dev && make install-hooks` |
+| Verify (Kanon) | `make verify` |
+| Einzeltest | `pytest -k "<keyword>" -v` |
+| Format/Lint/Types | `make format` · `make lint` · `make type-check` |
+| UI-Dev | `pnpm --filter entaengelment-ui dev` |
+| Voller DeepJump | `make all` |
+
 ---
 
-*Letzte Aktualisierung: 2026-01-16*
+*Letzte Aktualisierung: 2026-06-20*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ make verify-governance  # workflow-posture + VOID-backlog-drift + voidmap-ui-dri
 make verify-js       # ui-app/packages via pnpm (frozen lockfile) + Turbo
 make verify-all      # Kern + Governance + JS/TS
 
-make test            # pytest -v  (alle Tests)
+make test            # pytest -v  (nur tests/ — siehe Hinweis unten)
 make test-unit       # tests/unit/
 make test-integration# tests/integration/
 make test-ethics     # tests/ethics/  (Fail-Safe / Guard-Tests)
@@ -241,14 +241,30 @@ pytest tests/unit/test_<name>.py::Test<Class>::test_<fn> -v
 pytest -k "<keyword>" -v
 ```
 
+> Hinweis: `make test`/`pytest` deckt nur `tests/` ab (`pyproject.toml` →
+> `testpaths = ["tests"]`). Die separaten Suiten für `Fractalsense/` und die
+> Jest-getesteten JS-Dateien laufen über npm-Scripts:
+> `npm run test:py` (Fractalsense-pytest) bzw. `npm run test:js` (Jest) —
+> bei Änderungen dort zusätzlich ausführen.
+
 ### DeepJump-Protokoll v1.2 (Verify → Status → Snapshot)
 
 ```bash
 make verify     # Phase 1: prüfen (s. oben)
-make status     # Phase 2: HMAC-signiertes Status-Receipt nach out/ emittieren
+make status     # Phase 2: Status-Receipt nach out/ emittieren (HMAC nur mit Secret, s. u.)
 make snapshot   # Phase 3: Snapshot-Manifest (--strict) erzeugen
-make all        # Voller Flow (= make deepjump): verify + test + snapshot
+make all        # = make deepjump: verify + test + snapshot — OHNE status (s. u.)
 ```
+
+> **HMAC-Secret:** `make status` ist nur dann HMAC-signiert, wenn `ENTA_HMAC_SECRET`
+> (oder `CI_SECRET`) gesetzt ist. Ohne Secret läuft `status_emit.py` lokal im
+> `UNSIGNED`-Modus (Receipt trägt `"hmac": "UNSIGNED"`, untrusted) — in CI ist ein
+> fehlendes Secret hingegen ein harter Fehler. Für signierte Evidence-Artefakte
+> lokal das Secret exportieren.
+>
+> **Achtung `make all`:** führt `verify test snapshot` aus, aber **nicht** `make status`.
+> Für den vollen Verify → Status → Snapshot-Evidence-Flow `make status` (bzw.
+> `make status-verify`) separat aufrufen.
 
 ### JS/TS-Toolchain (UI & Packages)
 
@@ -261,7 +277,9 @@ pnpm --filter entaengelment-ui dev      # Next.js UI → http://localhost:3000
 pnpm turbo run typecheck lint build     # = der JS_VERIFY_CMD aus verify-js
 ```
 
-> Wichtig: PRs, die `pnpm-lock.yaml`, `ui-app/` oder `packages/` berühren, sind
+> Wichtig: PRs, die das JS/TS-Workspace-Wiring berühren — `ui-app/`, `packages/`,
+> `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `package.json`, `turbo.json` oder
+> `tsconfig.base.json` (= der `paths`-Filter von `ci-js-workspace.yml`) — sind
 > **nicht** von einem reinen Python-`make verify` abgedeckt → zusätzlich `make verify-js`.
 
 ### Pre-Commit Hook (`.githooks/pre-commit`)


### PR DESCRIPTION
FOKUS: CLAUDE.md aktualisieren

## Ziel
Die bestehende `CLAUDE.md` enthielt nur die House-Rules / Guards (G0–G6). Für AI-Assistenten fehlte die konkrete Entwicklungs-Referenz. Dieser PR ergänzt sie auf den aktuellen Repo-Stand (2026-06-20), **ohne** die Guards zu verändern.

## Aktionen
- [x] Neuer Abschnitt **Build, Test & Development Commands** — `make verify`-Kanon, Test-/Lint-/Format-Targets, Einzeltest-Aufruf, DeepJump v1.2 (verify → status → snapshot), JS/TS-Toolchain (pnpm/Turbo), pre-commit Hook, Calm Intake Layer
- [x] Neuer Abschnitt **Codebase Architecture** — Kern-Datenfluss, Modul-Map (`src/core,cglg,stability,tools`, `tools/`, `tests/`, GOLD/IMMUTABLE-Pfade, `ui-app/`, `Fractalsense/` …), DeepJump-Tool-Tabelle, CI-Workflows
- [x] Neuer Abschnitt **Conventions** — Commit-Konvention, Python-Style, Test-Marker, Plan-First, Receipts/VOIDs/Reports/PR-Body
- [x] **Quick Reference** um Befehls-Tabelle erweitert; Datum auf 2026-06-20

## Nicht getan
- Guards G0–G6 und die Regeln unter `.claude/rules/` blieben unverändert
- Keine GOLD-/IMMUTABLE-Pfade berührt

## Risiken
- Gering (reine Doku). Befehle gegen `Makefile`, `pyproject.toml`, `package.json`, `.githooks/pre-commit` und `.github/workflows/` verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A59uTcA2vAwDckyn7M2TgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01A59uTcA2vAwDckyn7M2TgX)_