### PR TITLE
fix(types): align VOIDMAP schema with v1.1 fields

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -22,14 +22,17 @@ export interface Void {
   status: VoidStatus;
   priority: VoidPriority;
   owner: string | null;
+  target_date?: string | null;
   domain: string;
+  layer?: string;
+  legacy_id?: string;
+  legacy_source?: string;
   symptom: string;
   closing_path: string | null;
   evidence: string | string[] | null;
   created: string;
   closed: string | null;
   notes?: string;
-  layer?: string;
 }
 
 export interface VoidMap {
@@ -39,6 +42,7 @@ export interface VoidMap {
     maintainer: string;
     last_updated: string;
     generated_doc: string;
+    reconciliation_notes?: string;
   };
   voids: Void[];
 }


### PR DESCRIPTION
## Was

Erweitert `@enta/types` so der TypeScript-Mirror die neue `VOIDMAP.yml` v1.1-Struktur typisiert abbilden kann.

## Warum

Nach dem VOIDMAP-Reconcile enthält GOLD neue, legitime Felder wie:

- `metadata.reconciliation_notes`
- `target_date`
- `legacy_id`
- `legacy_source`
- `layer`

Die bestehende `Void`/`VoidMap`-Definition war enger als die Registry. Sobald `ui-app/lib/voidmap-parser.ts` gegen `VOIDMAP.yml` v1.1 synchronisiert wird, kann TypeScript sonst an Excess-Property-Checks scheitern.

## Änderung

- `Void.target_date?: string | null`
- `Void.legacy_id?: string`
- `Void.legacy_source?: string`
- `VoidMap.metadata.reconciliation_notes?: string`
- `layer` bleibt explizit optional erhalten

## Nicht enthalten

- Keine GOLD/VOIDMAP-Änderung
- Kein Backlog-Regenerate
- Kein UI-Mirror-Sync
- Kein Lockfile-/Dependabot-Fix

## Nächster Schritt danach

Separater Sync-PR: `docs/voids_backlog.md` regenerieren und `ui-app/lib/voidmap-parser.ts` gegen `VOIDMAP.yml` v1.1 nachziehen.

Coach: Whisper — kleine Membranöffnung, keine Schleusenflutung: Typen nachziehen, ohne die Registry selbst umzuschreiben.