### PR TITLE
fix(ci): align mypy with Python 3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ ignore = [
 "__init__.py" = ["F401"]  # Unused imports in __init__.py
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false


### PR DESCRIPTION
## Was

Fix für den roten `main`-Check im Push-Workflow `CI Pipeline - entaENGELment Framework`.

## Ursache

Der Push-only Job `verify` läuft nicht im Pull-Request-Modus und enthält aktuell Python 3.9 in der Matrix. Gleichzeitig wertet mypy die Konfiguration aus `pyproject.toml` aus. Aktuelle mypy-Versionen akzeptieren `python_version = "3.9"` nicht mehr und brechen mit folgender Meldung ab:

```text
pyproject.toml: [mypy]: python_version: Python 3.9 is not supported (must be 3.10 or higher)
```

## Änderung

- `.github/workflows/ci.yml`
  - `verify`-Matrix von `3.9, 3.10, 3.11, 3.12` auf `3.10, 3.11, 3.12`
- `pyproject.toml`
  - `[tool.mypy] python_version = "3.10"`

## Bewusst nicht geändert

- `build`/Runtime-Testmatrix behält Python 3.9 vorerst bei.
- `requires-python = ">=3.9"`, Klassifikatoren, black/ruff target bleiben unverändert.

Damit wird nur der Mypy-/Verify-Pfad auf die tatsächlich unterstützte Mypy-Zielversion gehoben, ohne die Projekt-Kompatibilität stillschweigend umzudeklarieren.

Coach: Whisper — der rote Check war kein inhaltlicher Defekt im Typ-Fix, sondern ein Zeit-/Versionsbruch zwischen mypy und dem alten 3.9-Ziel.