### PR TITLE
docs: clarify welcome, GitHub use, anti-capture boundaries

### DIFF
--- a/ANTI_CAPTURE_POLICY.md
+++ b/ANTI_CAPTURE_POLICY.md
@@ -1,0 +1,95 @@
+# Anti-Capture Policy
+
+entaENGELment is developed in the open, but it is not intended to become infrastructure for extractive capture.
+
+This document states the project position against surveillance, profiling, hidden personalization loops and semantic extraction of private meaning.
+
+---
+
+## Claim status
+
+This is a governance policy draft. It is not legal advice and does not by itself create enforceable license obligations.
+
+Legal enforceability depends on the actual `LICENSE`, contribution rules, hosted-service terms and future policy documents.
+
+---
+
+## Commercial use vs. extractive capture
+
+Commercial use and extractive capture are not identical.
+
+A small cooperative, educator, nonprofit, independent practitioner or community project may receive money and still operate in alignment with the project values.
+
+The primary concern is not money flow as such. The primary concern is capture:
+
+- surveillance
+- behavioral manipulation
+- semantic profiling
+- hidden personalization
+- lock-in
+- private-user-data extraction
+- converting private meaning into commercial advantage
+
+---
+
+## Project position
+
+entaENGELment should not be used to support:
+
+- extractive personalization
+- surveillance or covert tracking
+- behavioral manipulation
+- psychological or symbolic profiling without explicit consent
+- enterprise lock-in architecture
+- hidden model training on private User-Claims
+- private User-Claim monetization
+- turning analogy or metaphor into empirical authority
+- GitHub feedback loops from private data into generated environments
+
+---
+
+## Anti-capture architecture
+
+Anti-capture is pursued through architecture and governance:
+
+1. **Claim status**  
+   No claim without visible status.
+
+2. **Receipt discipline**  
+   No silent overwriting of meaning. Revisions, forks, withdrawals and counter-claims should be additive.
+
+3. **Privacy boundary**  
+   Private claims, images, symbolic profiles and embeddings must not be uploaded to GitHub by default.
+
+4. **Witness-only GitHub**  
+   GitHub may witness reduced integrity anchors but must not become a semantic generator of private user data.
+
+5. **Open review**  
+   Claims, tests, policies and interfaces should remain reviewable.
+
+6. **Anti-overclaim language**  
+   The project must not claim stronger safety, cryptographic finality or non-manipulation guarantees than have actually been implemented and tested.
+
+---
+
+## What this policy does not do
+
+This policy does not claim that the current license forbids all commercial use.
+
+This policy does not claim that Apache-2.0 is an anti-capture license.
+
+This policy does not claim that AGPL forbids commercial use.
+
+This policy does not replace legal review.
+
+---
+
+## Future work
+
+Open questions for future review:
+
+- Should code remain Apache-2.0, move toward AGPL-3.0-or-later, or use another license?
+- Should non-code essence architecture use a different documentation/content license?
+- Should official hosted services use separate anti-surveillance and anti-profiling terms?
+- Should trademarks/naming be protected separately from code use?
+- Which anti-capture obligations should be legally enforceable and which should remain governance norms?

--- a/GITHUB_USE_POLICY.md
+++ b/GITHUB_USE_POLICY.md
@@ -1,0 +1,139 @@
+# GitHub Use Policy
+
+GitHub is a public development, documentation and witness layer for entaENGELment.
+
+It may hold the public essence architecture of the project. It must not become a semantic generator of private user data.
+
+---
+
+## Claim status
+
+This document is a governance policy draft. It is not legal advice and does not replace the repository license, contribution rules or hosted-service terms.
+
+---
+
+## Core rule
+
+> GitHub may witness integrity, but must not become a semantic generator of private user data.
+
+In project language:
+
+> GitHub may hold the public Lyra. It must not record the private heartbeat.
+
+---
+
+## Allowed by default
+
+GitHub may contain:
+
+- public source code
+- public documentation
+- public schemas
+- public tests
+- public governance documents
+- public essence/image architecture
+- prompt-compiler logic without private user data
+- visual grammar modules
+- reduced hash or snapshot manifests
+- public audit notes
+- policy hashes and reduced integrity anchors
+
+---
+
+## Not allowed by default
+
+GitHub must not receive by default:
+
+- private raw User-Claims
+- private user images
+- private generated outputs
+- personal symbolic profiles
+- embeddings of private content
+- inferred psychological profiles
+- private ledger exports
+- hidden personalization loops
+- generated prompt seeds derived from private user data
+- private material labels that reveal sensitive user context
+
+Private material may only be published after explicit, informed and reversible user action where technically possible.
+
+---
+
+## Witness-only anchor payload
+
+A GitHub anchor payload should be reduced and non-reconstructive.
+
+Allowed fields include:
+
+```json
+{
+  "schemaVersion": "receipt-anchor.v0.1",
+  "snapshotRootHash": "sha256:...",
+  "entryCount": 0,
+  "createdAt": "2026-01-01T00:00:00.000Z",
+  "previousSnapshotHash": "sha256:...",
+  "policyHash": "sha256:...",
+  "visibility": "public-anchor"
+}
+```
+
+The anchor proves only that a reduced ledger state was witnessed. It does not prove the truth of claims.
+
+---
+
+## Forbidden feedback loop
+
+The following loop is forbidden by default:
+
+```text
+private User-Claims
+  -> GitHub/public snapshot
+  -> generated inspirational environment
+  -> new user prompts/claims
+```
+
+This would turn GitHub into a zipper between private meaning and generated environment. That is not the intended architecture.
+
+Correct flow:
+
+```text
+private User-Claims
+  -> local Receipt-Ledger
+  -> verifyLedger / integrity check
+  -> reduced public anchor
+  -> GitHub witness
+```
+
+No automatic return path from GitHub witness data into personalization is allowed.
+
+---
+
+## Essence architecture
+
+GitHub may host the public essence architecture for image generation and symbolic interfaces:
+
+- public symbol modules
+- public prompt schemas
+- public visual operators
+- public negative prompts
+- public anti-overclaim rules
+- public tests and validation
+
+User input activates this architecture only at runtime. Private activation data must not be written back to GitHub by default.
+
+---
+
+## Review checklist
+
+Before any GitHub sync, export or anchor feature is merged, reviewers should ask:
+
+1. Does the payload contain raw private claims?
+2. Does it contain private images or generated outputs?
+3. Does it contain embeddings or profiles?
+4. Can the payload reconstruct private user meaning?
+5. Is the visibility explicitly `public-anchor`, `public`, `internal` or `private`?
+6. Does the UI explain what will be exported?
+7. Is public export opt-in rather than default?
+8. Is the payload reduced to integrity metadata where possible?
+
+If any answer is unclear, stop and add a VOID, test or policy note before merging.

--- a/LICENSE_REVIEW.md
+++ b/LICENSE_REVIEW.md
@@ -1,0 +1,99 @@
+# License Review Notes
+
+This document records the current governance question around open source, commercial use and anti-capture goals.
+
+It is not legal advice.
+
+---
+
+## Current state
+
+The repository currently uses Apache License 2.0.
+
+Apache-2.0 is a permissive open source license. It allows broad use, modification, distribution and sublicensing under its terms.
+
+This is compatible with open development, but it is not designed as an anti-capture or anti-commercial license.
+
+---
+
+## Open source and field-of-use restrictions
+
+Classic OSI open source licenses cannot restrict use by field of endeavor.
+
+That means an OSI-open-source license cannot simply forbid business use, commercial use or a specific sector while remaining OSI-open-source.
+
+Therefore, the project should avoid saying:
+
+> This is open source and forbids commercial use.
+
+A more accurate statement is:
+
+> The project supports open development and anti-capture governance. License choices require separate review.
+
+---
+
+## Commercial use is not the same as capture
+
+Commercial use and extractive capture are different questions.
+
+A commercial actor may operate responsibly. A noncommercial actor may still be extractive.
+
+The anti-capture concern is primarily about:
+
+- surveillance
+- profiling
+- hidden personalization loops
+- lock-in
+- semantic extraction of private meaning
+- behavioral manipulation
+- private data feedback into generated environments
+
+---
+
+## AGPL note
+
+AGPL-3.0-or-later may be useful if the project wants stronger transparency for modified network services.
+
+AGPL can reduce SaaS opacity because modified versions used over a network must provide corresponding source under the license.
+
+AGPL does not forbid commercial use.
+
+It is a transparency and copyleft tool, not an anti-commerce tool.
+
+---
+
+## Possible paths
+
+### Option A: OSI open source with stronger copyleft
+
+- Review AGPL-3.0-or-later for code.
+- Commercial use remains allowed.
+- Anti-capture is handled through governance, privacy architecture, trademarks and hosted-service terms.
+
+### Option B: Source-available / noncommercial / ethical-source approach
+
+- May better match strict anti-commercial goals.
+- Would not be OSI open source if it restricts fields of endeavor or commercial use.
+- Requires careful legal review and clear public wording.
+
+### Option C: Hybrid
+
+- Code license remains OSI-open-source or moves to AGPL after review.
+- Documentation, essence architecture and symbolic materials may use separate content licenses after review.
+- Official hosted service terms forbid surveillance, profiling and hidden personalization.
+- Trademark/name usage is governed separately.
+- GitHub remains an essence/witness layer, not a store for private user data.
+
+---
+
+## Recommended next step
+
+Do not change the license by vibe.
+
+Create a dedicated legal/governance review before any license migration:
+
+1. Inventory code, docs, generated assets and symbolic materials.
+2. Identify third-party license constraints.
+3. Decide which obligations must be legally enforceable and which remain governance norms.
+4. Compare Apache-2.0, AGPL-3.0-or-later and source-available options.
+5. Update README, WELCOME, CONTRIBUTING, NOTICE and policy files consistently.

--- a/PRIVACY_BOUNDARY.md
+++ b/PRIVACY_BOUNDARY.md
@@ -1,0 +1,154 @@
+# Privacy Boundary
+
+This document defines the privacy boundary for entaENGELment, especially around User-Claims, the Gläserne Agora, Receipt-Ledgers, material pointers, GitHub anchors and essence architecture.
+
+It is a governance and implementation guide, not legal advice.
+
+---
+
+## Core principle
+
+Private meaning must not be silently converted into system fuel.
+
+User-Claims, private images, personal symbolic profiles and embeddings belong behind a privacy boundary unless the user explicitly chooses otherwise.
+
+---
+
+## Data classes
+
+### Private by default
+
+- raw User-Claims
+- private user images
+- personal symbolic profiles
+- private material labels
+- private generated outputs
+- embeddings of private content
+- local Receipt-Ledger exports
+- inferred psychological or behavioral profiles
+
+### Internal / lab use
+
+- local test ledgers
+- local JSONL snapshots
+- local material pointers
+- local integrity-check reports
+- local tamper-drill outputs
+
+### Public by explicit action
+
+- public documentation
+- public code
+- public schemas
+- public tests
+- public essence architecture
+- public claim examples that contain no private data
+- reduced public anchors
+
+### Public-anchor only
+
+- `ledgerRootHash` or `snapshotRootHash`
+- `entryCount`
+- `schemaVersion`
+- `createdAt`
+- `previousSnapshotHash`
+- `policyHash`
+- `visibility: public-anchor`
+
+---
+
+## GitHub boundary
+
+GitHub must not receive private user meaning by default.
+
+Allowed GitHub payloads are reduced, non-reconstructive and explicitly marked.
+
+Disallowed by default:
+
+- raw claims
+- raw prompts
+- private images
+- private material labels
+- embeddings
+- profiles
+- private ledger entries
+- hidden personalization seeds
+
+---
+
+## Export boundary
+
+Before export, the UI should show:
+
+1. What will be exported?
+2. Is this private, internal, public or public-anchor?
+3. Does it contain raw claims?
+4. Does it contain material labels?
+5. Can it be reconstructed into private meaning?
+6. Is the export opt-in?
+
+Default export mode should be local/private unless explicitly changed.
+
+---
+
+## Ledger boundary
+
+The Receipt-Ledger may be append-only and tamper-evident, but that does not make it public.
+
+Hash-chaining proves consistency of a local or exported state. It does not remove privacy risk.
+
+A valid ledger can still contain private content.
+
+---
+
+## Material pointer boundary
+
+materialPointers may indicate which materials shaped a claim. They must not automatically be treated as evidence.
+
+Roles should be explicit where possible:
+
+- inspiration
+- analogy
+- evidence
+- counterpoint
+- artifact
+- source
+
+Analogy is not evidence. Inspiration is not proof.
+
+---
+
+## Generated environment boundary
+
+The inspirational environment must not be generated from private User-Claims unless the user explicitly activates that data for the current runtime.
+
+No private activation data should be written back to GitHub by default.
+
+Forbidden default loop:
+
+```text
+private user data -> public/github layer -> generated environment -> new private claim
+```
+
+Allowed runtime-only flow:
+
+```text
+public essence architecture + current user input -> temporary generation -> local user decision
+```
+
+---
+
+## Review checklist
+
+Before merging features that touch privacy-sensitive paths:
+
+- Are private claims ever logged?
+- Are private claims sent to third-party APIs?
+- Are private claims included in GitHub payloads?
+- Are material pointers safe and non-reconstructive?
+- Is export opt-in and visible?
+- Is public-anchor distinct from public content?
+- Is any generated personalization derived from private ledger data?
+- Is there a recovery/reset path for local data?
+
+If in doubt, default to private/local and add a VOID for review.

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -1,21 +1,36 @@
 # Welcome to entaENGELment
 
-entaENGELment is an experimental consent-first framework for auditable, human-guided multi-agent workflows.
+entaENGELment is an experimental consent-first, audit-first and anti-capture framework for human-guided, verifiable and mythopoetic systems.
 
-It combines three layers:
+It is not a finished product, not a production security system, and not empirical proof of its symbolic models.
 
-1. **Governance**
-   Clear boundaries, consent checks, evidence trails, and review gates.
+It is also not intended to become a surveillance engine, semantic profiling tool, hidden personalization loop, or enterprise lock-in architecture.
 
-2. **Verification**
-   Repeatable commands such as `make verify`, pointer validation, claim linting, tests, and receipts.
+This repository is a research and governance framework in active formation. This welcome file is a gentle orientation; authoritative rules remain in `README.md`, `CLAUDE.md`, policies, tests, schemas and CI gates.
 
-3. **Exploration**
-   A symbolic and conceptual research space for resonance, membranes, voids, and multi-agent coordination.
+---
 
-This repository is not production-ready software. It is a research and governance framework in active formation.
+## Core layers
 
-This guide is intentionally lightweight. Authoritative rules remain in `README.md`, `CLAUDE.md`, policies, tests, and CI gates.
+1. **Governance**  
+   Consent, boundaries, review gates, claim-status discipline and anti-overclaim rules.
+
+2. **Verification**  
+   Repeatable checks such as `make verify`, pointer validation, claim linting, tests, receipts and ledger-integrity checks where implemented.
+
+3. **Gläserne Agora & Receipt-Ledger**  
+   A user-sovereign claim space. The system must not define meaning for the user. Claims should be added with visible status, origin, membrane context and revision/fork paths. Where implemented, the Receipt-Ledger is append-only and tamper-evident rather than silently overwritable.
+
+4. **Essence Architecture**  
+   Public symbolic and image-generation grammar: schemas, prompt modules, visual operators, policy gates and tests. This layer may be open and auditable without receiving private user data.
+
+5. **Commons & Anti-Capture**  
+   The project supports open development while resisting extractive capture: surveillance, profiling, hidden personalization, private-user-data extraction and lock-in.
+
+6. **Exploration**  
+   A symbolic and conceptual research space for resonance, membranes, voids, tesser3TAKT, Grimm Narration 2.0 and multi-agent coordination.
+
+---
 
 ## Start here
 
@@ -28,7 +43,7 @@ make install-dev
 make verify
 ```
 
-For the optional UI:
+For the optional UI / lab interface:
 
 ```bash
 corepack enable
@@ -42,21 +57,81 @@ Then open:
 http://localhost:3000
 ```
 
+---
+
 ## What matters most
 
-The project follows a simple rule:
-
-> No claim without status.
-> No merge without verification.
-> No resonance without boundary.
+> No claim without status.  
+> No handover without receipt.  
+> No merge without verification.  
+> No resonance without boundary.  
+> No GitHub without privacy reduction.  
+> No open architecture without anti-capture guard.
 
 Important terms:
 
-- **VOIDMAP** tracks open gaps, risks, and unresolved system questions.
+- **User-Claim** means the claim belongs to the user, not to the system.
+- **Gläserne Agora** is the user-facing claim space where meanings may be added, forked, revised or withdrawn without silently overwriting prior claims.
+- **Receipt-Ledger** stores claim events without treating any single entry as the final definition.
+- **verifyLedger** is the intended integrity check for hash-chain, structure and references where the ledger implementation exists.
+- **materialPointers** may show which active lab materials shaped a claim, without turning those materials into authority or evidence by default.
+- **VOIDMAP** tracks open gaps, risks and unresolved system questions.
 - **DeepJump** describes the verify -> status -> snapshot workflow.
-- **Receipts** document evidence and state transitions.
-- **Guards G0-G6** define consent, focus, boundary, and merge discipline.
+- **Receipts** document evidence, state transitions or claim events, depending on module context.
+- **Guards G0-G6** define consent, focus, boundary and merge discipline.
 - **ANNEX vs GOLD** separates changeable work zones from protected canonical material.
+
+---
+
+## GitHub Use Policy
+
+GitHub is used as a public development, documentation and witness layer. It may contain public code, documentation, schemas, tests, visual grammar modules, prompt-compiler logic and reduced integrity anchors.
+
+GitHub must not become a semantic generator of private user data.
+
+Allowed in GitHub:
+
+- public source code
+- public schemas
+- public tests
+- public governance documents
+- public essence/image architecture
+- prompt-compiler logic without private user data
+- reduced hash or snapshot manifests
+- documentation and audit notes
+
+Not allowed in GitHub by default:
+
+- private raw User-Claims
+- private user images
+- personal symbolic profiles
+- embeddings of private content
+- inferred psychological profiles
+- private ledger exports
+- hidden personalization loops
+- generated prompt seeds derived from private user data
+
+Core rule:
+
+> GitHub may witness integrity, but must not become a semantic generator of private user data.
+
+See also: [`GITHUB_USE_POLICY.md`](GITHUB_USE_POLICY.md) and [`PRIVACY_BOUNDARY.md`](PRIVACY_BOUNDARY.md).
+
+---
+
+## Anti-Capture Position
+
+Commercial use and extractive capture are not identical. The project is primarily concerned with capture, surveillance, profiling, hidden personalization, semantic extraction and lock-in.
+
+entaENGELment should not be used to support extractive personalization, behavioral manipulation, semantic profiling, enterprise lock-in or the conversion of private meaning into commercial advantage.
+
+This is a governance position. Legal enforceability depends on the actual project license, contribution rules, hosted-service terms and separate policy documents.
+
+Current license review is required before claiming that anti-capture obligations are legally enforceable.
+
+See also: [`ANTI_CAPTURE_POLICY.md`](ANTI_CAPTURE_POLICY.md) and [`LICENSE_REVIEW.md`](LICENSE_REVIEW.md).
+
+---
 
 ## What this project is not
 
@@ -66,9 +141,17 @@ entaENGELment is not:
 - a general-purpose framework,
 - a production security system,
 - an empirical proof of its symbolic models,
-- or a claim that metaphor equals evidence.
+- a claim that metaphor equals evidence,
+- a startup funnel,
+- a surveillance engine,
+- a private-user-data extraction pipeline,
+- a semantic profiling tool,
+- an enterprise lock-in architecture,
+- or a system for turning user meaning into hidden personalization loops.
 
 Symbolic language is allowed here, but it must not replace verification.
+
+---
 
 ## Recommended paths
 
@@ -85,6 +168,20 @@ If you are reviewing governance, start with:
 - `policies/`
 - `VOIDMAP.yml`
 - `docs/guards/`
+- `GITHUB_USE_POLICY.md`
+- `ANTI_CAPTURE_POLICY.md`
+- `PRIVACY_BOUNDARY.md`
+- `LICENSE_REVIEW.md`
+
+If you are reviewing the claim-space architecture, look for:
+
+- the Gläserne Agora UI
+- the Receipt-Ledger implementation
+- ledger-integrity checks such as `verifyLedger`
+- Governance Cockpit / Ledger Integrity Block
+- JSONL export/import logic
+
+If a path does not exist yet, open a small PR or VOID instead of inventing structure silently.
 
 If you are exploring the conceptual layer, start with:
 
@@ -92,6 +189,8 @@ If you are exploring the conceptual layer, start with:
 - `docs/`
 - `index/`
 - `spec/`
+
+---
 
 ## Contribution style
 
@@ -102,8 +201,25 @@ Good PRs usually do one thing:
 - fix a typo,
 - add a test,
 - clarify a claim,
+- improve privacy boundaries,
+- improve anti-overclaim wording,
 - update one dependency,
 - close one VOID with evidence,
-- or improve one documented workflow.
+- improve one documented workflow,
+- strengthen GitHub witness-only separation,
+- improve UI accessibility,
+- improve schema validation,
+- or improve import/export safety.
+
+PRs must not:
+
+- upload private User-Claims to GitHub,
+- add telemetry for private claims,
+- create hidden personalization from private ledger data,
+- remove claim-status visibility,
+- mutate old receipts,
+- weaken ledger-integrity checks without explicit review,
+- turn analogy into evidence,
+- or turn GitHub into a user-data feedback loop.
 
 When unsure, choose the smaller change.


### PR DESCRIPTION
## Summary

This PR updates the public orientation/governance documentation for the current entaENGELment direction:

- rewrites `WELCOME.md` around six core layers instead of the older three-layer framing
- adds a GitHub witness/essence-use policy
- adds an anti-capture policy draft
- adds license-review notes clarifying Apache-2.0 / AGPL / noncommercial distinctions
- adds a privacy-boundary policy for User-Claims, ledgers, material pointers, GitHub anchors and generated environments

## Claim hygiene

This PR deliberately avoids saying that open source forbids commercial use.

It separates:

- commercial use
- extractive capture
- surveillance/profiling/hidden personalization
- private-user-data extraction

It also states that the anti-capture position is a governance position unless and until license/terms/legal review makes specific obligations enforceable.

## GitHub boundary

Core sentence added:

> GitHub may witness integrity, but must not become a semantic generator of private user data.

## Files changed

- `WELCOME.md` — updated orientation, six-layer model, GitHub policy, anti-capture position, contribution boundaries
- `GITHUB_USE_POLICY.md` — witness-only / essence-architecture policy
- `ANTI_CAPTURE_POLICY.md` — governance anti-capture policy draft
- `LICENSE_REVIEW.md` — license strategy notes, including Apache-2.0 and AGPL caveats
- `PRIVACY_BOUNDARY.md` — privacy classes, export boundary, ledger/material-pointer boundaries

## Not checked

- No code was changed.
- No build/test run was performed for this docs-only PR.
- Legal enforceability remains pending real legal review.
