### PR TITLE
docs: add recovery governance drafts

### DIFF
--- a/docs/annex/ROSETTA_INTERVALS_v0_1.md
+++ b/docs/annex/ROSETTA_INTERVALS_v0_1.md
@@ -1,0 +1,29 @@
+# ROSETTA_INTERVALS_v0_1
+
+**Status:** ANNEX / ROSETTA / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [ROSETTA] / [ANNEX]
+
+---
+
+## Zweck
+
+Dieses Dokument sammelt eine Bildsprache für relationale Arbeit. Es ist kein Evidence-Pfad und keine Policy.
+
+---
+
+## Kernidee
+
+Ein gutes System markiert Beziehungen, ohne Bedeutungen einzusperren. Tags können als Intervalle gelesen werden: Sie zeigen Positionen und Abstände, nicht Identität.
+
+---
+
+## Arbeitsdefinition
+
+Ein Intervall ist eine Differenz, die Beziehung möglich macht. In Governance-Sprache heißt das: Status klären, ohne Zustimmung zu erzwingen.
+
+---
+
+## Grenze
+
+Diese Rosetta-Sprache darf erklären und erinnern. Sie darf keine Policy ersetzen und keinen Claim beweisen.

--- a/docs/governance/BRANCH_EXPECTED_STATE.yml
+++ b/docs/governance/BRANCH_EXPECTED_STATE.yml
@@ -1,0 +1,28 @@
+version: "0.1"
+status: "draft"
+claim_status: "[SPEC-WIP]"
+updated: "2026-07-04"
+purpose: "Document expected repository review posture as policy-as-code. This file does not prove that settings are active."
+
+branch: "main"
+expected:
+  pull_request_review: true
+  include_admins: true
+  required_checks:
+    - "Verify Pointers & Lint"
+    - "DeepJump Verify"
+    - "Claim-Lint"
+    - "Receipt-Lint"
+  future_checks:
+    - "Guard-Check-Lint"
+    - "Branch-State-Drift-Check"
+  signed_evidence_status:
+    distinguish:
+      - "VERIFY_PASS"
+      - "VERIFY_PASS_UNSIGNED"
+      - "SIGNED_EVIDENCE_PASS"
+      - "SIGNED_EVIDENCE_SKIPPED"
+      - "SIGNED_EVIDENCE_FAIL"
+
+notes:
+  - "This file describes target posture and must be compared to live repository settings before enforcement is claimed."

--- a/docs/governance/BREADCRUMB_LINT_claim_tags_v0_2.md
+++ b/docs/governance/BREADCRUMB_LINT_claim_tags_v0_2.md
@@ -1,0 +1,53 @@
+# BREADCRUMB_LINT — claim_tags_v0_2
+
+**Status:** Simulation / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Bezug:** `policies/claim_tags_v0_2.yaml`, `docs/governance/CLAIM_LEITER_v0_1.md`
+
+---
+
+## Zweck
+
+Dieser Lint prüft, ob das Tag-System als offene Such- und Orientierungsstruktur funktioniert. Tags sollen Status klären, aber keine Zustimmung erzwingen und keine vollständige Übernahme des Frameworks verlangen.
+
+---
+
+## Prüfkriterien
+
+1. Klärt ein Tag Status statt Zustimmung zu verlangen?
+2. Kann ein externer Leser einzelne Tags verwenden, ohne das gesamte Framework zu übernehmen?
+3. Bleibt `[METAPHER]` klar von Evidence getrennt?
+4. Gibt es Raum für `ROHSEDIMENT`, Zweifel, `[VOID]` und Rücknahme?
+5. Wird Inspiration als Inspiration markiert, nicht als Beweis?
+6. Ist die Claim-Leiter ein Koordinatensystem statt einer Wert-Rangordnung?
+7. Kann ein Artefakt verworfen oder lokal angepasst werden, ohne dass dies als Ausschluss gilt?
+
+---
+
+## Befund
+
+Der Tag-Kanon ist gut ausgerichtet, wenn drei Regeln ausdrücklich erhalten bleiben:
+
+- partielle Nutzung ist erlaubt
+- Verwerfen ohne Ausschluss ist erlaubt
+- Leiter ist kein Werturteil
+
+Die wichtigste Lücke wäre eine fehlende Regel zu partieller Nutzung. Diese ist in `claim_tags_v0_2.yaml` deshalb als globale Regel aufgenommen.
+
+---
+
+## Empfohlene YAML-Schalter
+
+```yaml
+partial_use_allowed: true
+no_framework_adoption_required: true
+rejection_without_exclusion: true
+metaphor_is_not_evidence: true
+void_is_not_failure: true
+```
+
+---
+
+## Fazit
+
+Tags sind Intervalle, keine Käfige. Sie markieren Verhältnis und Status, nicht Identität oder Zugehörigkeit.

--- a/docs/governance/CLAIM_LEITER_v0_1.md
+++ b/docs/governance/CLAIM_LEITER_v0_1.md
@@ -1,0 +1,86 @@
+# CLAIM_LEITER_v0_1
+
+**Status:** Draft / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [SPEC-WIP]  
+**Bezug:** `policies/claim_tags_v0_2.yaml`
+
+---
+
+## 1. Zweck
+
+Die Claim-Leiter beschreibt mögliche Bewegungen zwischen Claim-Status. Sie ist kein Werturteil und kein Fortschrittszwang.
+
+Ein Claim darf dauerhaft `ROHSEDIMENT`, `[METAPHER]` oder `[VOID]` bleiben, wenn dies der sauberste Status ist.
+
+---
+
+## 2. Grundregel
+
+> Die Leiter ist ein epistemisches Koordinatensystem, keine Rangordnung.
+
+Höhere Tags bedeuten nicht höhere Wahrheit für fremde Nutzer. Sie bedeuten nur einen stärker eingegrenzten Status innerhalb dokumentierter Annahmen.
+
+---
+
+## 3. Typische Bewegungen
+
+```text
+ROHSEDIMENT
+  -> [METAPHER]
+  -> [HYPOTHESE]
+  -> [INFERENZ]
+  -> [MODEL]
+  -> [SPEC-WIP]
+  -> [SPEC]
+  -> [CANON]
+```
+
+Diese Darstellung ist nur eine Leseschneise. Seitensprünge, Rücknahmen und dauerhafte Grenzen sind erlaubt.
+
+---
+
+## 4. Dauerzustände
+
+### ROHSEDIMENT
+Raw material, Spur, Notiz, Intuition oder Chat-Treffer vor Review. ROHSEDIMENT ist kein Defizit.
+
+### [METAPHER]
+Metapher, Analogie, Bild oder Rosetta-Sprache. Wertvoll für Orientierung, aber keine Evidence.
+
+### [VOID]
+Offene Grenze, ungelöste Frage, Widerspruch oder bewusst nicht geschlossener Raum. VOID darf dauerhaft bleiben.
+
+---
+
+## 5. Anti-Capture-Regeln
+
+1. Partielle Nutzung ist erlaubt.
+2. Niemand muss das gesamte Framework übernehmen, um einzelne Tags zu verwenden.
+3. Verwerfen, Umbauen oder lokale Nutzung ist kein Ausschluss.
+4. Tags sind Intervalle, keine Käfige.
+5. Claim-Status klärt Beziehung, nicht Identität.
+
+---
+
+## 6. Provenienz-Schutz
+
+Ein Material Pointer, Receipt, Chat-Treffer oder späteres Artefakt kann Herkunft oder Einfluss zeigen. Er ist nicht automatisch Beweis für den Claim.
+
+Metapher, Inspiration und Analogie dürfen eine Hypothese motivieren, aber nicht direkt `[INFERENZ]`, `[MODEL]`, `[SPEC]` oder `[CANON]` begründen.
+
+---
+
+## 7. Empfohlene Review-Fragen
+
+- Erzwingt der Tag Zustimmung oder klärt er Status?
+- Kann ein fremder Leser den Tag nutzen, ohne die Symbolwelt zu übernehmen?
+- Bleibt Metapher von Evidence getrennt?
+- Gibt es Raum für Zweifel, VOID und Rücknahme?
+- Kann jemand das Artefakt verwerfen, ohne aus dem System herauszufallen?
+
+---
+
+## 8. Tooling-Hinweis
+
+Die vorhandenen Lint-Werkzeuge können enger sein als dieser Draft-Kanon. Harte Enforcement-Schritte brauchen erst Tool-Anpassung und Testabdeckung.

--- a/docs/governance/GUARD_CHECK_CONTRACT_v0_1.md
+++ b/docs/governance/GUARD_CHECK_CONTRACT_v0_1.md
@@ -1,0 +1,34 @@
+# GUARD_CHECK_CONTRACT_v0_1
+
+**Status:** Draft / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [SPEC-WIP]
+
+---
+
+## Kernregel
+
+Jede neue Guard-Regel braucht einen nachvollziehbaren Check. Eine Guard-Regel ohne Check bleibt Zielzustand und darf nicht als live enforced kommuniziert werden.
+
+---
+
+## Minimalfelder
+
+- Guard-ID
+- Check-ID
+- Scope
+- erwartetes Ergebnis
+- tatsächliches Ergebnis
+- Report- oder Receipt-Pfad
+
+---
+
+## Enforcement-Status
+
+Dieser Contract ist zunächst Draft. Ein späteres Tool kann advisory starten und nach Stabilisierung als Required Check eingesetzt werden.
+
+---
+
+## Nicht-Ziel
+
+Dieses Dokument behauptet nicht, dass ein entsprechender Check bereits live enforced ist.

--- a/docs/governance/RUNTIME_EVENTLOG_SPINE_v0_1.md
+++ b/docs/governance/RUNTIME_EVENTLOG_SPINE_v0_1.md
@@ -1,0 +1,47 @@
+# RUNTIME_EVENTLOG_SPINE_v0_1
+
+**Status:** Draft / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [SPEC-WIP]  
+**Bezug:** `spec/runtime_eventlog_v0_1.json`
+
+---
+
+## Zweck
+
+Das Runtime Eventlog dokumentiert Zustandsänderungen. Es ist Ereignisspur, nicht Wahrheitsquelle.
+
+---
+
+## Eventgruppen
+
+- `CLAIM_CREATED`
+- `CLAIM_RETAGGED`
+- `VOID_OPENED`
+- `VOID_CLOSED`
+- `GUARD_DRILL_RUN`
+- `R_DOWN_APPLIED`
+- `VERIFY_PASS`
+- `VERIFY_PASS_UNSIGNED`
+- `SIGNED_EVIDENCE_PASS`
+- `SIGNED_EVIDENCE_SKIPPED`
+- `SIGNED_EVIDENCE_FAIL`
+
+---
+
+## Grundregeln
+
+1. Events sollen append-only sein.
+2. Event-Hashes machen Änderungen prüfbar, aber nicht wahr.
+3. Öffentliche Snapshots müssen reduziert bleiben.
+4. Claim-Transitionen brauchen Status, Grund und Actor.
+5. VOID-Schließung braucht einen Evidence- oder Review-Pfad.
+6. Guard-Drills brauchen ein Ergebnis und möglichst ein Receipt.
+
+---
+
+## Nächste Schritte
+
+- Gegen bestehende Ledger-Implementierung prüfen.
+- Eventtypen zunächst als Draft behalten.
+- Später serverseitige Transition-Regeln definieren.

--- a/docs/governance/SOURCE_OF_TRUTH_SPINE_v0_2_1.md
+++ b/docs/governance/SOURCE_OF_TRUTH_SPINE_v0_2_1.md
@@ -1,0 +1,106 @@
+# SOURCE_OF_TRUTH_SPINE_v0_2_1
+
+**Status:** Draft / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [SPEC-WIP]  
+**Geltungsbereich:** Governance-Architektur und Source-of-Truth-Membranen  
+**Nicht-Ziel:** Dieses Dokument macht keine Claims wahr. Es beschreibt, wie Claim-Status nachvollziehbar wird.
+
+---
+
+## 1. Kernprinzip
+
+SoT ist kein einzelner Thron und keine statische Datei. SoT entsteht durch kontrollierte Kopplung zwischen vier Schichten:
+
+| Schicht | Hält | Hält nicht |
+|---|---|---|
+| Repo | Regeln, Policies, Specs, Guard-Definitionen | menschliche Bedeutung |
+| Backend / Runtime | Ereignisse, Claim-States, Hash-Chain, Snapshots | Interpretation oder Zustimmung |
+| Externe Quellen | Fakten, Messungen, Simulationen, Material Pointers | Geltung oder Sinn |
+| Mensch | Bedeutung, Consent, Rücknahme | maschinell erzwingbare Wahrheit |
+
+GitHub ist Witness/Kristall: Es dokumentiert reduced Anchors und Integritätshinweise. GitHub beweist nicht die Wahrheit von Claims.
+
+UI- und Agentenoutput sind Vorschläge und Projektionen, niemals Source of Truth.
+
+---
+
+## 2. Resonance-Glue
+
+„Resonance“ meint hier operative Kopplung und Rückkopplung zwischen Schichten, nicht einen Wahrheitsanspruch.
+
+Vier Glue-Arten:
+
+1. **Cryptographic Glue:** Hash, HMAC, `prev_hash`, `replay_hash`, `snapshotRootHash`; macht Veränderungen prüfbar und tamper-evident innerhalb dokumentierter Annahmen.
+2. **Semantic Glue:** Claim-Tags, VOID-Bezug, MaterialPointer-Rollen, Transitionen.
+3. **Procedural Glue:** Calm Intake, Sprechakt-Runbook, Claim-Lint, Agenten-Penetration, Guard-Drills, Review.
+4. **Human Glue:** Consent, Bedeutung, Rücknahme, Kontextfreigabe.
+
+Glue darf nie dazu führen, dass nicht freigegebene Bedeutung in öffentliche Artefakte diffundiert.
+
+---
+
+## 3. A/B-Trennung
+
+- **B-Schicht:** private Generatoren, innere Symbolik, kreative Experimente, Rosetta-Bilder.
+- **A-Schicht:** fremdfähige Policies, Specs, Runbooks, reduzierte Anchors und überprüfbare Prozessregeln.
+
+B kann A erzeugen. A muss allein verständlich bleiben. Rosetta-/Annex-Sprache darf erklären, aber keine Claim-Hochstufung begründen.
+
+---
+
+## 4. Intake-first
+
+Jeder neue Claim, Chat-Treffer oder Artefakt beginnt als ROHSEDIMENT im Calm Intake. Kanonisierung erfolgt nur nach Review, Claim-Status, Geltungsbereich, Evidence- oder VOID-Pfad und Rücknahme-Bedingung.
+
+**VOID-016 Recovery Gate:**
+
+> Ist dieser Treffer wirklich eine frühere Lösung, oder projizieren wir rückwirkend Kohärenz hinein?
+
+Wenn dieser Check nicht bestanden wird, bleibt der Treffer Intake-Sediment oder wird als VOID markiert.
+
+---
+
+## 5. SoT is not a truth-maker
+
+Eine Source of Truth macht Claims nicht wahr. Sie macht ihren Status nachvollziehbar:
+
+- behauptet
+- getaggt
+- belegt
+- offen
+- widerlegt
+- zurückgenommen
+- als VOID akzeptiert
+
+Wahrheit bleibt abhängig von Evidenz, Quelle, Messung, Modellgrenzen und menschlicher Interpretation.
+
+---
+
+## 6. Enforcement-Status
+
+**Already enforced / partially enforced:** bestehender Claim-Lint, Verify-Pointers, DeepJump Verify, Receipt-Lint in vorhandenen Scopes, Intake-Pattern.
+
+**Target enforcement:** Guard-Drill-Lint, Branch-Protection Drift-Check, Runtime Eventlog Claim-Transition Enforcement, vollständige Provenienz-Inversion-Erkennung.
+
+Nur bereits implementierte Checks dürfen als live kommuniziert werden.
+
+---
+
+## 7. Nachgelagerte Artefakte
+
+- `policies/claim_tags_v0_2.yaml`
+- `docs/governance/CLAIM_LEITER_v0_1.md`
+- `docs/governance/ANTI_CAPTURE_BREADCRUMB_LINT_claim_tags_v0_2.md`
+- `docs/governance/GUARD_DRILL_CONTRACT_v0_1.md`
+- `spec/runtime_eventlog_v0_1.json`
+- `docs/runbooks/AGENT_PENETRATION_RUNBOOK_v0_1.md`
+- `docs/runbooks/BODENTEST_PROTOCOL_v0_1.md`
+- `docs/governance/BRANCH_PROTECTION_EXPECTED_STATE.yml`
+- `docs/annex/RESONANCE_WITHOUT_CAPTURE_zN_SATURN_HEXAGON_v0_1.md`
+
+---
+
+## 8. Motto
+
+> SoT macht Claims nicht wahr. SoT macht ihren Status nachvollziehbar.

--- a/docs/intake/records/INTAKE-2026-07-04-recovery-roadmap-v0_1.md
+++ b/docs/intake/records/INTAKE-2026-07-04-recovery-roadmap-v0_1.md
@@ -1,0 +1,47 @@
+# INTAKE-2026-07-04-recovery-roadmap-v0_1
+
+**Status:** ROHSEDIMENT / Shadow-Copy / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Zweck:** Intake-Record für den Recovery-Zyklus rund um SoT-Spine, Claim-Tags, Breadcrumb-Lint, Runtime Eventlog, Agenten-Penetration, Boden-Test und Rosetta-Annex.
+
+---
+
+## Zugehörige neue PR-Artefakte
+
+- `docs/governance/SOURCE_OF_TRUTH_SPINE_v0_2_1.md`
+- `policies/claim_tags_v0_2.yaml`
+- `docs/governance/CLAIM_LEITER_v0_1.md`
+- `docs/governance/BREADCRUMB_LINT_claim_tags_v0_2.md`
+- `spec/runtime_eventlog_v0_1.json`
+- `docs/governance/RUNTIME_EVENTLOG_SPINE_v0_1.md`
+- `docs/governance/GUARD_CHECK_CONTRACT_v0_1.md`
+- `docs/runbooks/AGENT_PENETRATION_RUNBOOK_v0_1.md`
+- `docs/runbooks/BODENTEST_PROTOCOL_v0_1.md`
+- `docs/governance/BRANCH_EXPECTED_STATE.yml`
+- `docs/annex/ROSETTA_INTERVALS_v0_1.md`
+
+---
+
+## Kurzbefund
+
+Der Recovery-Zyklus trennt drei Zonen:
+
+1. Bereits vorhandene Repo-Anker wie Privacy Boundary, GitHub Use Policy, VOIDMAP, Intake, Runtime Ledger, F7/QM und Consent-Re-Entry.
+2. Neue Governance-Drafts wie SoT-Spine, Claim-Tags, Claim-Leiter, Breadcrumb-Lint und Runtime Eventlog.
+3. Rosetta-/Annex-Material, das die Begriffsarbeit erklärt, aber keine Claims beweist.
+
+---
+
+## VOID-016 Check
+
+Frage: Wird rückwirkend Kohärenz in alte Spuren projiziert?
+
+Vorläufige Antwort: Risiko reduziert, aber nicht null. Der Zyklus bleibt deshalb Intake-Kandidat und braucht Review, Claim-Lint und später Boden-Test.
+
+---
+
+## Nächste Gates
+
+- PR-Checks abwarten.
+- Keine Zielzustände als already enforced kommunizieren.
+- Nach Merge: Folge-PRs für Tooling und eventuelle Linter-Integration planen.

--- a/docs/runbooks/AGENT_PENETRATION_RUNBOOK_v0_1.md
+++ b/docs/runbooks/AGENT_PENETRATION_RUNBOOK_v0_1.md
@@ -1,0 +1,42 @@
+# AGENT_PENETRATION_RUNBOOK_v0_1
+
+**Status:** Draft / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [SPEC-WIP]
+
+---
+
+## Zweck
+
+Agenten-Penetration ist eine Vorprüfung. Sie testet Widerstand gegen Fehlinterpretation, Überclaiming und falsche Übersetzung. Sie ersetzt keinen menschlichen Boden-Test.
+
+> Agentenlob ist keine Evidenz.
+
+---
+
+## Rollen
+
+1. **Naiver Agent** — prüft Grundverständnis.
+2. **Red-Team-Agent** — sucht Fehlinterpretationen und Überclaims.
+3. **Auditor-Agent** — prüft Ist-/Ziel-Trennung.
+4. **Skeptiker-Agent** — prüft Metaphorik und Claim-Hygiene.
+5. **Übersetzungs-Agent** — prüft Fremdfähigkeit in QM-/Projektmanagement-Sprache.
+6. **Falsifikations-Agent** — formuliert Revisionsbedingungen.
+
+---
+
+## Report-Felder
+
+- Ziel-Dokument
+- Agentenrolle
+- Prüffrage
+- Ergebnis
+- kritische Schwäche
+- Empfehlung
+- Blocking: ja/nein
+
+---
+
+## Gate
+
+Ein bestandener Agentenlauf erlaubt nur den nächsten Review-Schritt. Er beweist nicht externe Tragfähigkeit.

--- a/docs/runbooks/BODENTEST_PROTOCOL_v0_1.md
+++ b/docs/runbooks/BODENTEST_PROTOCOL_v0_1.md
@@ -1,0 +1,46 @@
+# BODENTEST_PROTOCOL_v0_1
+
+**Status:** Draft / Intake-Kandidat  
+**Datum:** 2026-07-04  
+**Claim-Status:** [SPEC-WIP]
+
+---
+
+## Zweck
+
+Der Boden-Test prüft Fremdfähigkeit: Kann ein externer Leser die A-Schicht nutzen, ohne dass der Gründer danebensteht und ohne die B-Schicht übernehmen zu müssen?
+
+---
+
+## Grundregeln
+
+1. Test nur mit A-Schicht-Material.
+2. Keine private Symbolwelt voraussetzen.
+3. Testperson darf verwerfen, umbauen oder nur teilweise nutzen.
+4. Ergebnis ist Übertragbarkeitsindikator, kein Wahrheitsbeweis.
+5. Agenten-Penetration ist Vorfilter, nicht Ersatz.
+
+---
+
+## Minimalsetup
+
+- 2/3 oder 3/5 externe Leser
+- vorzugsweise QM-, Governance- oder Projektmanagement-affin für ersten Lauf
+- keine Live-Erklärung durch den Gründer
+- standardisiertes Feedbackformular
+
+---
+
+## Prüffragen
+
+- Was ist der Zweck des Artefakts?
+- Welche Begriffe sind verständlich?
+- Welche Begriffe wirken vereinnahmend oder zu intern?
+- Kann das Artefakt partiell genutzt werden?
+- Welche Stelle müsste für fremde Nutzung vereinfacht werden?
+
+---
+
+## Erfolgskriterium
+
+Ein leichter Boden-Test ist bestanden, wenn eine Mehrheit den Zweck, die Grenzen und eine sinnvolle partielle Nutzung korrekt wiedergeben kann.

--- a/policies/claim_tags_v0_2.yaml
+++ b/policies/claim_tags_v0_2.yaml
@@ -1,0 +1,91 @@
+version: "0.2"
+status: "draft"
+claim_status: "[SPEC-WIP]"
+updated: "2026-07-04"
+purpose: >
+  Define an expanded claim-tag canon for epistemic hygiene, recovery intake,
+  anti-capture use, and future runtime event validation.
+
+anti_capture_principles:
+  partial_use_allowed: true
+  no_framework_adoption_required: true
+  rejection_without_exclusion: true
+  ladder_is_not_value_hierarchy: true
+  metaphor_is_not_evidence: true
+  void_is_not_failure: true
+
+global_rules:
+  - id: sot_not_truth_maker
+    rule: "Claim tags make epistemic status traceable; they do not make claims true."
+  - id: partial_use_allowed
+    rule: "Using individual tags or transitions does not require adoption of the full framework, vocabulary, or symbolic layer."
+  - id: rejection_without_exclusion
+    rule: "An artifact, tag, or claim may be rejected, adapted, or used locally without implying exclusion or personal rejection."
+  - id: ladder_not_value_hierarchy
+    rule: "The claim ladder is not a value hierarchy. Higher tags mean narrower status under documented assumptions, not higher truth for external users."
+  - id: metaphor_not_evidence
+    rule: "Metaphor, analogy, and inspiration can motivate inquiry but are never sufficient evidence for inference, model, spec, or canon status."
+  - id: void_not_failure
+    rule: "A claim may remain [VOID] indefinitely; this can mark a boundary, open question, or unresolved difference rather than failure."
+  - id: provenance_inversion_guard
+    rule: "Receipts, chat traces, and material pointers show provenance or influence; they are not automatic proof of the claim."
+  - id: intake_first
+    rule: "New claims and recovered chat solutions start as ROHSEDIMENT unless a stronger status is explicitly justified."
+
+tags:
+  ROHSEDIMENT:
+    description: "Raw incoming material, trace, intuition, or recovered fragment before review."
+    allowed_next: ["[METAPHER]", "[HYPOTHESE]", "[VOID]", "[CONTEXT]", "[ANNEX]"]
+  "[METAPHER]":
+    description: "Figurative, analogical, aesthetic, or Rosetta-language framing; not evidence by itself."
+    allowed_next: ["[HYPOTHESE]", "[VOID]", "[ROSETTA]"]
+  "[HYPOTHESE]":
+    description: "Testable or reviewable claim that needs evidence, falsification path, or scoped validation."
+    allowed_next: ["[INFERENZ]", "[MODEL]", "[VOID]", "[SPEC-WIP]"]
+  "[INFERENZ]":
+    description: "Reasoned inference from stated evidence or sources, with assumptions still visible."
+    allowed_next: ["[MODEL]", "[SPEC-WIP]", "[VOID]"]
+  "[MODEL]":
+    description: "Structured representation or explanatory model under documented assumptions."
+    allowed_next: ["[SPEC-WIP]", "[SPEC]", "[VOID]"]
+  "[FACT]":
+    description: "Externally sourced or directly verified factual claim with source or measurement pointer."
+    allowed_next: ["[SPEC-WIP]", "[SPEC]", "[VOID]"]
+  "[SPEC-WIP]":
+    description: "Draft specification not yet fully enforced, reviewed, or stabilized."
+    allowed_next: ["[SPEC]", "[VOID]", "[ANNEX]"]
+  "[SPEC]":
+    description: "Reviewed specification with clear scope and implementation expectations."
+    allowed_next: ["[CANON]", "[VOID]", "[SPEC-WIP]"]
+  "[CANON]":
+    description: "Accepted canon within this repository scope; still revisable through explicit review."
+    allowed_next: ["[VOID]", "[SPEC-WIP]"]
+  "[VOID]":
+    description: "Known boundary, unresolved gap, contradiction, or intentionally open question. Not a defect by default."
+    allowed_next: ["ROHSEDIMENT", "[HYPOTHESE]", "[SPEC-WIP]"]
+  "[ROSETTA]":
+    description: "Translation layer, metaphorical bridge, or symbol-to-operation map. It may explain but not prove."
+    allowed_next: ["[ANNEX]", "[HYPOTHESE]", "[VOID]"]
+  "[ANNEX]":
+    description: "Supplementary material that informs the framework without becoming A-core policy."
+    allowed_next: ["[SPEC-WIP]", "[ROSETTA]", "[VOID]"]
+  "[CONTEXT]":
+    description: "Contextual framing, background, or ethical/cultural note without direct claim force."
+    allowed_next: ["[MODEL]", "[ANNEX]", "[VOID]"]
+  "[BRIDGE-WIP]":
+    description: "Draft bridge to external disciplines or collaborators; no partnership or validation claim implied."
+    allowed_next: ["[CONTEXT]", "[MODEL]", "[VOID]"]
+  "[UI-LAB]":
+    description: "Prototype, visualization, or interaction experiment; not a source of truth by itself."
+    allowed_next: ["[ANNEX]", "[MODEL]", "[VOID]"]
+  SIMULATION_PROXY:
+    description: "Simulation or proxy result. It can inform models but does not directly establish real-world fact status."
+    allowed_next: ["[MODEL]", "[HYPOTHESE]", "[VOID]"]
+
+compatibility_notes:
+  current_claim_lint: "Existing tooling may only enforce a narrower tag set. This policy is a draft expansion and needs tool alignment before hard enforcement."
+  spelling_aliases:
+    "[FAKT]": "[FACT]"
+    "[HYP]": "[HYPOTHESE]"
+    "[MET]": "[METAPHER]"
+    "[MODELL]": "[MODEL]"

--- a/spec/runtime_eventlog_v0_1.json
+++ b/spec/runtime_eventlog_v0_1.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "runtime_eventlog.v0.1",
+  "status": "draft",
+  "claim_status": "[SPEC-WIP]",
+  "updated": "2026-07-04",
+  "purpose": "Define a draft runtime event vocabulary for claim, VOID, guard, evidence, and withdrawal state changes.",
+  "principles": [
+    "The eventlog records state changes; it does not make claims true.",
+    "Events should be append-only and tamper-evident within documented assumptions.",
+    "Public exports must be reduced and non-reconstructive unless explicitly reviewed."
+  ],
+  "event_types": {
+    "CLAIM_CREATED": {
+      "required_fields": ["event_id", "timestamp", "actor", "claim_id", "claim_text", "claim_tag"],
+      "visibility": "private_or_reduced"
+    },
+    "CLAIM_RETAGGED": {
+      "required_fields": ["event_id", "timestamp", "actor", "claim_id", "from_tag", "to_tag", "reason"],
+      "visibility": "private_or_reduced"
+    },
+    "VOID_OPENED": {
+      "required_fields": ["event_id", "timestamp", "actor", "void_id", "scope", "reason"],
+      "visibility": "public_reduced_allowed"
+    },
+    "VOID_CLOSED": {
+      "required_fields": ["event_id", "timestamp", "actor", "void_id", "evidence_ref", "closure_reason"],
+      "visibility": "public_reduced_allowed"
+    },
+    "GUARD_DRILL_RUN": {
+      "required_fields": ["event_id", "timestamp", "actor", "guard_id", "drill_id", "result", "receipt_ref"],
+      "visibility": "public_reduced_allowed"
+    },
+    "R_DOWN_APPLIED": {
+      "required_fields": ["event_id", "timestamp", "actor", "scope", "reason", "future_contact_policy"],
+      "visibility": "private_or_reduced"
+    },
+    "VERIFY_PASS": {
+      "required_fields": ["event_id", "timestamp", "actor", "scope", "commit_sha"],
+      "visibility": "public_reduced_allowed"
+    },
+    "VERIFY_PASS_UNSIGNED": {
+      "required_fields": ["event_id", "timestamp", "actor", "scope", "commit_sha", "reason"],
+      "visibility": "public_reduced_allowed"
+    },
+    "SIGNED_EVIDENCE_PASS": {
+      "required_fields": ["event_id", "timestamp", "actor", "scope", "commit_sha", "signature_ref"],
+      "visibility": "public_reduced_allowed"
+    },
+    "SIGNED_EVIDENCE_SKIPPED": {
+      "required_fields": ["event_id", "timestamp", "actor", "scope", "commit_sha", "reason"],
+      "visibility": "public_reduced_allowed"
+    },
+    "SIGNED_EVIDENCE_FAIL": {
+      "required_fields": ["event_id", "timestamp", "actor", "scope", "commit_sha", "failure_reason"],
+      "visibility": "public_reduced_allowed"
+    }
+  },
+  "hashing_notes": {
+    "canonicalization": "stable JSON serialization required before hashing",
+    "chain_field": "prev_hash",
+    "truth_boundary": "hashes support integrity checking, not truth claims"
+  }
+}


### PR DESCRIPTION
## Summary

Adds reviewable draft artifacts from the 2026-07-04 recovery checkpoint.

Files added:

- source-of-truth spine draft
- claim tags v0.2 policy draft
- claim ladder draft
- breadcrumb lint draft
- runtime eventlog draft spec
- runtime eventlog spine draft
- guard check contract draft
- agent review runbook draft
- bodentest protocol draft
- branch expected state draft
- rosetta intervals annex
- intake record for this recovery cycle

## Intent

All new material is draft/intake/spec-work-in-progress unless explicitly reviewed later.

## Review checklist

- Confirm target checks are not described as already live.
- Confirm new claim tags are compatible with current lint scopes.
- Confirm annex material stays explanatory only.
- Run repository checks before merge.
