### PR TITLE
chore: align dependabot npm directory with pnpm workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,11 @@ updates:
       - "security"
     open-pull-requests-limit: 5
 
+  # directory muss auf den pnpm-Workspace-Root zeigen (pnpm-lock.yaml liegt dort);
+  # mit "/ui-app" bumpte Dependabot nur ui-app/package.json, der Root-Lockfile
+  # blieb stehen und jeder npm-PR failte an pnpm install --frozen-lockfile.
   - package-ecosystem: "npm"
-    directory: "/ui-app"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Intent

Struktur-Fix aus dem Repo-Hygiene-Pass (#280, Follow-up zu #281): Alle npm-Dependabot-PRs (#245/#273/#274/#275) failen systematisch, weil Dependabot mit `directory: "/ui-app"` nur `ui-app/package.json` bumpte, während der pnpm-Lockfile im Repo-Root liegt und unangetastet blieb. Folge: `pnpm install --frozen-lockfile` bricht in CI ab — belegt im Job-Log von #275:

```
specifiers in the lockfile don't match specifiers in package.json:
- @types/node (lockfile: ^25.9.2, manifest: ^26.0.1)
```

Mit `directory: "/"` arbeitet Dependabot im pnpm-Workspace-Modus und pflegt Manifeste und Root-Lockfile gemeinsam.

## Scope

- `.github/dependabot.yml` — nur der `directory`-Eintrag des npm-Ecosystems (+ erklärender Kommentar). Keine Versionsbumps, kein Lockfile-Update, keine Workflow-Änderungen.
- Hinweis: Mit Workspace-Root-Scope schlägt Dependabot künftig auch Bumps für die Root-`devDependencies` (electron-builder, jest, turbo) vor — das ist die korrekte Abdeckung, aber eine sichtbare Verhaltensänderung.

FOKUS: Dependabot npm Workspace-Root

## Test Plan

- [x] YAML-Parse geprüft (`yaml.safe_load`), npm-`directory` = `/`
- [x] Diagnose belegt (Job-Log #275, ci-js-workspace `workspace`-Job)
- [ ] CI checks pass

## Risk

- Gering: reine Dependabot-Konfiguration, kein Einfluss auf Builds/Tests.
- Nach Merge: für #273/#274/#275 `·@·d·ependabot r·ecreate` kommentieren, damit sie mit Root-Lockfile neu erzeugt werden. #245 (eslint 10) und #267 (checkout v7) bleiben Major-Bumps mit bewusster manueller Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012sqjVcvPf41ensv4icr1JJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012sqjVcvPf41ensv4icr1JJ)_