### PR TITLE
fix(docs): address Codex review on #279 — settings permission + report correction

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,8 +14,7 @@
       "Bash(git push:*)",
       "Bash(git fetch:*)",
       "Bash(git pull:*)",
-      "Bash(git commit:*)",
-      "mcp__Claude_Code_Remote__send_later"
+      "Bash(git commit:*)"
     ]
   }
 }

--- a/docs/audit/2026-07-04_repo_hygiene_report.md
+++ b/docs/audit/2026-07-04_repo_hygiene_report.md
@@ -66,7 +66,7 @@ offenen npm-PRs.
 | # | Titel | Kategorie | Status | Empfehlung |
 |---|-------|-----------|--------|------------|
 | #278 | Follow-up: align recovery governance drafts after PR #277 | Documentation / Governance | **actionable now** — alle referenzierten Dateien existieren in main [FACT] | Als eigener kleiner Cleanup-PR abarbeiten (P2); gut gescopte Checkliste |
-| #240 | Overdue VOIDs: VOID-010, VOID-011 | Governance / Backlog | **needs human decision** — beide VOIDs stehen weiterhin auf `IN_PROGRESS` in `VOIDMAP.yml` [FACT], Target 2026-06-01 überschritten | Offen lassen; Owner entscheidet: Re-Dating oder Teilschließung mit Evidence |
+| #240 | Overdue VOIDs: VOID-010, VOID-011 | Governance / Backlog | **überholt** — [CORRECTION 2026-07-05, aus Codex-Review auf PR #279] Die ursprüngliche Fassung dieser Zeile übernahm das Target „2026-06-01" ungeprüft aus dem Issue-Text (Stand 2026-06-08). `VOIDMAP.yml` führte beide VOIDs bereits am Report-Datum mit `target_date: "2026-07-15"` und Status `IN_PROGRESS` [FACT] — am 2026-07-04 waren sie also **nicht** überfällig; das Re-Dating hatte bereits stattgefunden | Issue #240 als überholt schließen (mit Verweis auf das erfolgte Re-Dating); Human OK |
 | #226 | Repo Re-Entry Notes: Wochenend-Audit Nachlauf | Governance / Notizen | **stale but valuable** — Kernpunkte inzwischen erledigt: #214 ist nicht mehr offen [FACT]; #225 (eslint 10.4.1) ist nicht mehr offen und durch #245 ersetzt (Dependabot-Supersede, Einschätzung); voids_backlog-Drift in diesem Pass behoben; Grimm-2-Narrative weiterhin nur `_template.md` [FACT] | Schließen mit Verweis auf diesen Report (Human OK) oder bewusst als Marker offen lassen |
 
 Keine Issues geschlossen, keine neuen Issues erstellt.


### PR DESCRIPTION
## Intent

Kleiner Follow-up zu PR #279: behebt die beiden P2-Punkte aus dem Codex-Review, die erst nach dem Merge eintrafen.

1. **`.claude/settings.local.json`**: Die in `c5c005a` committete `mcp__Claude_Code_Remote__send_later`-Permission ist wieder entfernt. Der Review-Punkt ist berechtigt: session-lokale Remote-Tool-Freigaben gehören nicht in die repo-getrackte Config. (Hinweis: Die Datei selbst ist seit `e9b8b39` getrackt und enthält weitere session-lokale Bash-Permissions — ob sie komplett enttrackt/`.gitignore`t werden soll, ist eine separate Human Decision.)
2. **Hygiene-Report §2, Zeile zu Issue #240**: korrigiert mit `[CORRECTION 2026-07-05]`-Vermerk. [FACT] `VOIDMAP.yml` führte VOID-010/011 bereits am Report-Datum (fe0a4e6) mit `target_date: "2026-07-15"` — nicht überfällig. Das alte Target „2026-06-01" stammte ungeprüft aus dem Issue-Text vom 08.06. Neue Empfehlung: Issue #240 als überholt schließen (Human OK).

## Scope

2 Dateien, ±5 Zeilen: `.claude/settings.local.json` (Revert), `docs/audit/2026-07-04_repo_hygiene_report.md` (eine Tabellenzeile). Keine Code-, GOLD- oder Receipt-Änderungen.

FOKUS: Repo-Hygiene-Pass (Follow-up)

## Test Plan

- [x] JSON-Validität von `.claude/settings.local.json` geprüft
- [x] Beide Behauptungen gegen `VOIDMAP.yml` (aktuell und bei `fe0a4e6`) verifiziert
- [ ] CI checks pass

## Risk

Minimal: docs + Revert einer Permission-Zeile. Bekannt und unabhängig davon: der vorbestehende mypy/numpy-Fehler im `ci.yml`-Push-Run (Report §5, P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXdmZna2vqEKUrYq7RxbKp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXdmZna2vqEKUrYq7RxbKp)_