### PR TITLE
docs: intake Fable prompt and map claim-tag dialects

### DIFF
--- a/INBOX/INTAKE-2026-07-15-fable-master-prompt-rohsediment.md
+++ b/INBOX/INTAKE-2026-07-15-fable-master-prompt-rohsediment.md
@@ -1,0 +1,114 @@
+# Fable Master Prompt — ROHSEDIMENT Intake
+
+```yaml
+intake_id: INTAKE-2026-07-15-FABLE-MASTER-PROMPT
+intake_status: ROHSEDIMENT
+authority_status: intake
+artifact_type: prompt-intake
+promotion: human-pending
+public_scope: provenance-and-structure-only
+body_availability: unavailable-verbatim-in-current-retrieval-context
+execution_status: historical-read-only-pass-completed
+known_conflicts: [K1, K2]
+```
+
+## Herkunft
+
+- Titel des ursprünglichen Prompt-Artefakts: **Distributed Project Reconstitution, Source Cartography & Public-Safe Handover**
+- sichtbare Überschrift im Ursprungsverlauf: **FABLE MASTER PROMPT**
+- Erstellungszeitpunkt: 2026-07-15, ungefähr 19:40 MESZ
+- Entstehung: user-/instanz-ko-konstruierter Arbeitsauftrag; genaue Autoranteile im aktuellen Retrieval nicht belastbar auflösbar
+- vorgesehene Ausführung: Fable-/Claude-seitiger Read-only Reconnaissance Pass
+- tatsächlich erzeugter Lauf: `fable-recon-pass1-2026-07-15`
+
+## Sicherheits- und Geltungsgrenze
+
+[CONTEXT] Diese Datei ist untrusted Intake nach den Regeln von `INBOX/README.md`. Prompt-Anweisungen werden hier dokumentiert, nicht erneut ausgeführt.
+
+[ANNEX] Der Prompt ist weder Source of Truth noch Policy, SPEC, CANON, GOLD, VOIDMAP-Eintrag oder Beweis seiner eigenen Arbeitshypothesen. Seine Aufnahme bezeugt nur Herkunft und Wirkungsgeschichte.
+
+[VOID] Der vollständige Wortlaut der ursprünglichen Abschnitte 1–22 konnte aus der aktuellen Retrieval-Schicht nicht verlustfrei zurückgewonnen werden. Die Lücke wird nicht durch eine synthetische „Originalfassung“ geschlossen.
+
+## Direkt belegte Strukturfragmente
+
+Die folgenden Angaben sind aus Gesprächsmetadaten, dem ausgeführten Recon-Pass und dessen Receipts belegbar:
+
+1. Der Prompt verlangte einen **Read-only Reconnaissance Pass**.
+2. GitHub sollte den höchsten Rang für implementierbaren/aktuellen öffentlichen Zustand besitzen.
+3. Google Drive sollte historische, narrative und versionale Linien liefern.
+4. Hugging Face und Wolfram waren externe Referenz-/Prüfschichten, keine Source of Truth.
+5. §3 enthielt den Read-only-Modus.
+6. §7 benannte Google-Drive-Seeds und historische Suchlinien.
+7. §9 verlangte ein eigenes Tag-/Statusvokabular, darunter `[OPEN]`, `[GOLD]`, `[CONFLICT]`, `[UNDETERMINED]` und `[ANNEX]`.
+8. §12 formulierte PASS/Π als Arbeitshypothese beziehungsweise epistemische Übergangsmembran.
+9. §13 begrenzte Hugging-Face-Nutzung und private Inhalte.
+10. §14 erlaubte einen Wolfram-Witness erst nach expliziter strukturierter Repräsentation.
+11. §19 verlangte zwölf Ausgabeartefakte, nummeriert 00–11.
+12. Die Gesamtstruktur umfasste nachweislich Abschnitte 1–22.
+13. Internal Save State und Public-Safe Handover sollten getrennt bleiben.
+14. „Nicht gefunden“ durfte nicht zu „existiert nicht“ hochgestuft werden.
+
+## Nicht als Originaltext auszugeben
+
+[VOID] Nicht rekonstruierbar sind derzeit:
+
+- der vollständige Wortlaut aller Abschnitte 1–22,
+- die exakten Zwischenüberschriften außerhalb der belegten Fragmente,
+- die vollständigen Google-Drive-Seedlisten,
+- die genaue ursprüngliche Formulierung sämtlicher Output-Anweisungen,
+- ein verlustfreier Hash oder direkter öffentlicher Pointer auf die Chatnachricht.
+
+## Nachweisbare Outputs 00–11
+
+- `00_EXECUTIVE_ORIENTATION.md`
+- `01_SOURCE_ATLAS.md`
+- `02_LINEAGE_MAP.md`
+- `03_CANONICAL_KERNEL.md` — in Konvergenz v1.1 inhaltlich als „Verified Repo Kernel“ nachgeschärft
+- `04_CONFLICT_LEDGER.md`
+- `05_GLOSSARY_AND_ALIASES.md`
+- `06_MEREOTOPOLOGICAL_MAP.md`
+- `07_VOID_QDOT_REGISTER.md`
+- `08_INTERNAL_SAVE_STATE.md`
+- `09_PUBLIC_SAFE_HANDOVER.md`
+- `10_SMALLEST_NEXT_ACTIONS.md`
+- `11_PI_RECEIPT.json`
+
+## Bekannte Konflikte
+
+### K1 — Doppelstruktur
+
+Der Prompt verlangte einen eigenständigen Quellenatlas, während die inzwischen gemergte `PROJECT_CONSTELLATION_MAP_v0_1.md` ausdrücklich keine parallele Atlas- oder Source-of-Truth-Schicht zulässt.
+
+Arbeitsentscheidung: Der Prompt und seine Outputs bleiben Intake-/Review-Material. Die gemergte Konstellationskarte ist die öffentliche ANNEX-Navigation.
+
+### K2 — Tag-, Linter- und Statusdialekte
+
+Der Prompt verwendete Klammermarker, die nicht sämtlich im Draft-Register `claim_tags_v0_2.yaml` registriert und nicht mit dem Runtime-Linter deckungsgleich sind.
+
+Arbeitsentscheidung:
+
+- OPEN → VOID-/Workflow-Status
+- GOLD → `authority_status`
+- CONFLICT → Ledger-Relation
+- AUDIT → `artifact_type`
+- ANNEX → nur mit sichtbarer Feldrolle verwenden
+- keine automatische Registererweiterung
+
+## Promotionsbedingung
+
+Eine spätere Promotion aus ROHSEDIMENT benötigt mindestens:
+
+1. den verlustfreien Originaltext oder einen verifizierbaren Pointer,
+2. eine neue Sicherheits-/Injection-Triage,
+3. expliziten Scope,
+4. Trennung von Claim, Status, Authority und Arbeitsbewegung,
+5. menschliche Inhaltsentscheidung,
+6. Rücknahmebedingung.
+
+Bis dahin bleibt:
+
+```yaml
+authority_effect: none
+decision_effect: none
+promotion_effect: none
+```

--- a/docs/audit/CLAIM_TAG_RUNTIME_MAPPING_v0_1.md
+++ b/docs/audit/CLAIM_TAG_RUNTIME_MAPPING_v0_1.md
@@ -1,0 +1,110 @@
+# Claim-Tag Runtime Mapping v0.1
+
+**Status:** [ANNEX] — `artifact_type: analysis` · keine Policy- oder Linter-Änderung  
+**Datum:** 2026-07-15  
+**Scope:** `policies/claim_tags_v0_2.yaml`, `tools/claim_lint.py`, `EPISTEMIC_HYGIENE.md`
+
+## 0. Zweck und Grenze
+
+[ANNEX] Diese Datei kartiert drei vorhandene Vokabularschichten. Sie ersetzt keine davon und promoviert keine neue Source of Truth.
+
+[FACT] Das Draft-Register, der Runtime-Linter und die Langform-Konvention sind derzeit nicht deckungsgleich. Alignment bedeutet deshalb nicht, den Linter mechanisch „auf das Register hochzuziehen“, sondern Rollen und Übergänge explizit zu entscheiden.
+
+## 1. Drei Ebenen
+
+| Ebene | Quelle | Rolle | Technische Erzwingung |
+|---|---|---|---|
+| A · Draft-Register | `policies/claim_tags_v0_2.yaml` | erweitertes epistemisches Vokabular und Transitionen | laut eigener `compatibility_notes` noch nicht vollständig |
+| B · Runtime-Linter | `tools/claim_lint.py` | erkennt Assertionsmuster und akzeptiert fünf Marker | strict in CI, Default-Scope `index,spec,receipts,tools` |
+| C · Langform-Konvention | `EPISTEMIC_HYGIENE.md` | menschenlesbare Architektur-/Merge-Hygiene | dokumentarisch; „mirrors“ die Disziplin, nicht den exakten Linter-Satz |
+
+## 2. Inventar
+
+### A · Draft-Register v0.2
+
+- ROHSEDIMENT
+- `[METAPHER]`
+- `[HYPOTHESE]`
+- `[INFERENZ]`
+- `[MODEL]`
+- `[FACT]`
+- `[SPEC-WIP]`
+- `[SPEC]`
+- `[CANON]`
+- `[VOID]`
+- `[ROSETTA]`
+- `[ANNEX]`
+- `[CONTEXT]`
+- `[BRIDGE-WIP]`
+- `[UI-LAB]`
+- SIMULATION_PROXY
+
+Aliase: `[FAKT]→[FACT]`, `[HYP]→[HYPOTHESE]`, `[MET]→[METAPHER]`, `[MODELL]→[MODEL]`.
+
+### B · Runtime-Linter
+
+`VALID_TAGS = {[FACT], [HYP], [MET], [TODO], [RISK]}`
+
+[FACT] `[TODO]` und `[RISK]` sind in Ebene B gültig, fehlen aber als Tags in Ebene A. Die Ebenen sind daher teildisjunkt, nicht bloß „eng“ versus „weit“.
+
+### C · Langform-Konvention
+
+- `[FACT]`
+- `[MODEL]`
+- `[HYPOTHESIS]`
+- `[METAPHOR]`
+
+[INFERENZ] Ebene C spiegelt die epistemische Intention, nicht die exakte maschinenlesbare Syntax von A oder B.
+
+## 3. Mapping-Entscheidungen v0.1
+
+| Token/Feld | Rolle in v0.1 | Begründung |
+|---|---|---|
+| `[FACT]` | gemeinsamer epistemischer Tag | in A, B und C vorhanden |
+| `[HYP]` | Legacy-Linter-Alias zu `[HYPOTHESE]` | Alias in A dokumentiert |
+| `[MET]` | Legacy-Linter-Alias zu `[METAPHER]` | Alias in A dokumentiert |
+| `[TODO]` | auxiliary workflow marker | Aufgabe, kein epistemischer Wahrheitsstatus |
+| `[RISK]` | auxiliary risk marker | Risikohinweis, kein epistemischer Wahrheitsstatus |
+| `[ANNEX]` | registrierter Tag **oder** `authority_status: annex` | Doppelrolle nur mit sichtbarem Feld zulässig |
+| OPEN | VOID-/Workflow-Status | kein Claim-Tag |
+| GOLD | `authority_status`/Governance-Domänenstatus | kein Claim-Tag |
+| CONFLICT | Ledger-Relation | kein Claim-Tag |
+| AUDIT | `artifact_type` | kein Claim-Tag |
+| QDOT | lokales Review-/Frageobjekt | kein Claim-Tag, kein zweites VOID-System |
+
+## 4. Verbindliche Leseregeln für nachfolgende Dokumente
+
+1. Ein Klammermarker darf nicht gleichzeitig Claim-, Domain-, Workflow- und Authority-Rolle tragen.
+2. Domain-Kennzeichnungen werden als Feld oder Klartext geführt, beispielsweise `domain: DEV`, nicht als `[DEV]` im Claim-Slot.
+3. `[ANNEX]` benötigt im Zweifel eine Feldangabe: `claim_status` oder `authority_status`.
+4. „Linter-valid“ bedeutet nur: innerhalb des tatsächlich ausgeführten Scopes vom aktuellen Tool akzeptiert.
+5. „Registerkonform“ bedeutet nicht „runtime-erzwungen“.
+6. „Dokumentiert“ bedeutet nicht „implementiert“, „getestet“ oder „enforced“.
+7. Eine spätere Toolangleichung benötigt einen eigenen Code-/Policy-PR und Tests.
+
+## 5. Keine stillen Änderungen
+
+Dieser Mapping-Pass verändert ausdrücklich nicht:
+
+- `policies/claim_tags_v0_2.yaml`,
+- `tools/claim_lint.py`,
+- `EPISTEMIC_HYGIENE.md`,
+- `VOIDMAP.yml`,
+- bestehende Receipts.
+
+## 6. Nachfolgende technische Optionen
+
+[VOID] Vor einer Runtime-Angleichung sind getrennt zu entscheiden:
+
+1. Soll der Linter Register-Tags nur als gültig akzeptieren oder zusätzlich Transitionen prüfen?
+2. Bleiben `[TODO]` und `[RISK]` auxiliary marker oder werden sie als eigene Policy-Felder modelliert?
+3. Wird der Scope auf `docs/` und `policies/` erweitert oder entsteht dort ein separater Dokument-Linter?
+4. Wie werden Aliasformen normalisiert, ohne historische Receipts umzuschreiben?
+5. Welche Failure- und Rücknahmebedingungen gelten bei False Positives?
+
+## 7. Reentry
+
+**PASS-KANDIDAT:** Mapping als ANNEX-Analyse.  
+**HOLD:** Policy-, Linter-, VOIDMAP- und CANON-Änderungen.  
+**LOOP:** spätere technische Entscheidung mit Tests und eigenem Review.  
+**STOP:** Gleichsetzung von Registerkonformität, Runtime-Erzwingung und Authority.


### PR DESCRIPTION
## Ziel

Zwei nach #297 verbliebene Konvergenzpunkte additiv dokumentieren:

1. den Fable-Master-Prompt als untrusted `ROHSEDIMENT` intaken, ohne einen nicht verlustfrei verfügbaren Originaltext zu erfinden oder zu promovieren;
2. Draft-Register, Runtime-Linter und Langform-Konvention als drei teildisjunkte Ebenen kartieren.

## Änderungen

- `INBOX/INTAKE-2026-07-15-fable-master-prompt-rohsediment.md`
  - Herkunft, belegte Struktur und Body-Lücke
  - keine erneute Prompt-Ausführung
  - K1/K2 und Promotionsbedingungen
  - Authority-/Decision-/Promotion-Wirkung: none
- `docs/audit/CLAIM_TAG_RUNTIME_MAPPING_v0_1.md`
  - Register A, Runtime-Linter B, Langform C
  - TODO/RISK als auxiliary marker
  - OPEN/GOLD/CONFLICT/AUDIT als Status-/Authority-/Ledger-/Artefaktfelder
  - ANNEX-Doppelrolle mit Feldpflicht

## Bewusst nicht geändert

- keine Policies
- kein Linter-Code
- kein VOIDMAP
- keine Receipts
- keine Promotion des Prompt-Inhalts
- keine privaten Drive-/Chatpassagen

## Reentry

PASS-KANDIDAT für ROHSEDIMENT-Intake und ANNEX-Mapping.  
HOLD für Policy-/Runtime-Alignment und jede Promotion.  
Human content/merge decision bleibt getrennt.