### PR TITLE
feat(ui): add canonical tesser3TAKT Kenogram HUD v0.2

### DIFF
--- a/docs/spec/tesser3takt_hud_v0_1.md
+++ b/docs/spec/tesser3takt_hud_v0_1.md
@@ -1,0 +1,64 @@
+# tesser3TAKT Kenogram HUD v0.1
+
+Status: SPEC-WIP. Authority: ANNEX. Artifact: UI-LAB.
+
+## Purpose
+
+The route `/tesser3takt` is a read-only projection of the current tesser3TAKT / Grimm-Apparat working grammar. It visualizes possible relations and unresolved fringes. It does not promote claims, diagnose users, or select a personal telos.
+
+## Core rule
+
+The HUD may locate an unbound relation without presenting the visualization itself as its resolution.
+
+- projection is not ontology
+- visibility is not truth
+- salience is not priority
+- a shared trace does not imply ownership of its source process
+
+## Main layers
+
+1. Landau panel: local regime display only.
+2. Caduceus vortex: two counter-rotating channels around the orthogonal mast.
+3. Wheeler slices: discrete views of a continuous process.
+4. Orange and blue portals: handedness and antisymmetric occupancy.
+5. Four 7x9 fields: local addressability.
+6. Knight path: non-local but rule-bound traversal.
+7. zN depth: stored transformation between frames.
+8. Kenogram fringes: unresolved operational positions.
+
+## Kenogram states
+
+- UNOBSERVED: not yet inspected.
+- UNBOUND: anchors exist but a connecting operator is missing.
+- CONFLICT: competing operators remain unresolved.
+- WITHHELD: the relation is intentionally not shared.
+- FORBIDDEN: a guard blocks the coupling.
+
+A fringe may remain unresolved.
+
+## Portal gate
+
+Orange and blue are complementary display directions. The determinant proxy is a formal collision indicator only. A zero result is not a moral judgement.
+
+## Boundary rule
+
+The last half of a knight transition in one quadrant and the first half in the next quadrant are stored as one transition. The boundary is inside the move, not at the end of it.
+
+## Consent and persistence
+
+The prototype stores no interaction telemetry. Any later persistence requires explicit consent, separate permission for points, edges, and trajectories, revocation, visible provenance, and no hidden reconstruction of the person.
+
+## Acceptance criteria
+
+- mobile-first route `/tesser3takt`
+- no autoplay
+- no third-party visualization dependency
+- observer mode changes the projection, not the source data
+- unresolved kenograms remain visible
+- portal collision is reversible
+- claim boundaries are visible
+- build, lint, and typecheck pass before promotion
+
+## Hold
+
+No VOIDMAP edit, no new canonical VOID identifier, no telemetry, no policy promotion, and no equation of the visual grammar with human interiority.

--- a/docs/spec/tesser3takt_hud_v0_2.md
+++ b/docs/spec/tesser3takt_hud_v0_2.md
@@ -1,0 +1,305 @@
+# tesser3TAKT Kenogram HUD v0.2
+
+**Status:** [SPEC-WIP]
+**Authority:** ANNEX
+**Artifact:** UI-LAB
+**Route:** `/tesser3takt`
+
+## 0. Purpose
+
+The HUD is a read-only projection of the current tesser3TAKT / Grimm-Apparat working grammar. It makes relations, transformations, receipts, and unresolved fringes visible without turning the visualization into an ontology, diagnosis, personal telos, or oracle.
+
+## 1. Hard separation: regime vs. guard
+
+This is the principal v0.2 correction.
+
+### Regime state
+
+Derived only from model-display variables:
+
+- `control` — dimensionless Landau control parameter;
+- `orderParameter` — local display value `sqrt(abs(control))` for `control < 0`;
+- `torsion` — Loosen/Tighten display parameter;
+- `state` — `SYMMETRIC | CRITICAL | BROKEN | LOOSENED | OVERWOUND`.
+
+Regime state changes the projection. It does not decide consent, truth, safety, or authority.
+
+### Guard state
+
+Derived only from explicit governance events:
+
+- `consentFailed`;
+- `focusSwitchPending`;
+- `forbiddenCouplingAttempted`;
+- `claimPromotionRequested`;
+- `receiptPending`;
+- `loopRequested`.
+
+Guard output remains:
+
+- `PASS`;
+- `HOLD`;
+- `LOOP`;
+- `STOP`.
+
+A slider must never produce `STOP` merely because a visual field is highly twisted, cold, hot, critical, or symmetrical.
+
+## 2. Canonical transport and HUD view
+
+`TesserTickFrame` v0.2 is the canonical transport contract defined in `ui-app/lib/tesser3takt-frame.ts`. Its required fields are:
+
+```text
+frameId
+collisionSemantics
+leftStateId
+rightStateId
+collisionProxy
+kenograms
+boundaryTransitions
+provenance
+```
+
+The route-specific `TesserHudFrame` is a view model. It wraps the canonical object in `transport` and adds local display state such as observer mode, regime controls, z-layer, guard display, verification witnesses, and disabled semantic-assist configuration. Those view fields do not redefine the wire contract.
+
+Both objects are serializable JSON. They contain no user identity, hidden interaction trace, inferred biography, or telemetry.
+
+## 3. 7×9 and residual channel
+
+Each local field contains `7 × 9 = 63` addressable cells.
+
+The HUD exposes an additional unoccupied residual marker `X`:
+
+```text
+63 + X
+```
+
+`X` is not a sixty-fourth ordinary cell. It marks the unresolved or orthogonal channel that must not be silently filled by the renderer.
+
+## 4. Knight graph witness
+
+A standard knight graph on a 9-by-7 rectangular board has the following computed witness values:
+
+```text
+vertices: 63
+edges: 164
+connected: true
+bipartite: true
+diameter: 6
+```
+
+These values are verification witnesses for the formal graph only. They do not prove the narrative or physical layers.
+
+## 5. Boundary half-step invariant
+
+A quadrant-crossing move is one logical pair with exactly one `EXIT` and one `ENTRY` record. Both records share a `pairId` and carry:
+
+```text
+pairId
+half
+stepIndex
+stateId
+quadrant
+coordinateSpace = GLOBAL_REENTRY_LATTICE
+latticePosition
+transformedFrom (ENTRY only)
+provenance
+```
+
+The `ENTRY.transformedFrom` value must equal the paired `EXIT.stateId`, `EXIT` must precede `ENTRY`, and the two global lattice coordinates must form a legal knight move. The renderer derives its two visual marks from these canonical records; it does not maintain a second boundary identity.
+
+## 6. S₄ permutation witness
+
+The adjacent-transposition Cayley graph of `S₄` has:
+
+```text
+vertices: 24
+edges: 36
+regular degree: 3
+connected: true
+bipartite: true
+diameter: 6
+```
+
+This supplies the reversible ordering space for local permutation operations. It is not identical to the 7×9 knight graph; both remain separate generator families.
+
+## 7. Landau panel
+
+The display potential is:
+
+```text
+V(phi) = 1/2 control phi^2 + 1/4 quartic phi^4
+```
+
+For `control = -0.34` and `quartic = 1`, the local minima occur at approximately:
+
+```text
+phi = +/- 0.583095
+Vmin = -0.0289
+```
+
+The panel is a regime grammar only. It must be labeled as a model display and must never be described as measuring a person's psychological truth, moral state, coherence, love, or health.
+
+## 8. Hermes / Caduceus / Wheeler / zN
+
+- The orthogonal Hermes mast is an axis role.
+- The two Caduceus channels are counter-rotating phase carriers.
+- Wheeler slices are discrete projections of a continuous process.
+- zN depth stores transformation between slices.
+
+Required transport receipt:
+
+```text
+sliceId
+sourceFrameId
+targetFrameId
+phaseBefore
+phaseAfter
+handedness
+provenance
+transformId
+```
+
+Depth is not inferred from screen distance alone.
+
+## 9. Seven Lyra channels
+
+The HUD carries exactly seven independent channels:
+
+```text
+C D E F G A B
+```
+
+The channels may map to sound, color, context, or another declared scale. A mapping requires a visible adapter and provenance. The seven channels must not be collapsed into six decorative fibers.
+
+## 10. Portal antisymmetry
+
+Orange and blue represent reversible complementary handedness directions.
+
+The current collision proxy is intentionally narrow:
+
+```text
+leftStateId === rightStateId -> collisionProxy = true -> determinantProxy = 0
+otherwise                    -> collisionProxy = false -> determinantProxy = 1
+```
+
+`collisionProxy` is derived by the canonical frame helper and validated against the two state IDs. The HUD cannot inject a manual collision boolean. A duplicate-row Slater determinant is zero; this witness supports only the formal collision metaphor and does not classify persons, moral positions, identities, or biological states.
+
+Open question `Kη-04`: should collision use exact equality or equality up to an explicitly declared symmetry group?
+
+## 11. Kenogram fringes
+
+A fringe is not a generic error.
+
+Allowed states:
+
+- `UNOBSERVED` — not yet inspected;
+- `UNBOUND` — anchors exist, connecting operator missing;
+- `CONFLICT` — multiple operators compete;
+- `WITHHELD` — relation intentionally not shared;
+- `FORBIDDEN` — guard blocks the coupling.
+
+Each fringe carries:
+
+```text
+id
+status
+layer
+anchors
+missingOperator or competingOperators
+provenance
+resolutionGate
+allowPersistentVoid
+```
+
+A fringe may remain unresolved indefinitely.
+
+## 12. Optional semantic assistance
+
+The optional Hugging Face adapter is disabled by default:
+
+```text
+provider: hugging-face
+modelRef: intfloat/multilingual-e5-small
+enabled: false
+role: candidate-neighbor-ranking
+persistence: none
+canResolveKenograms: false
+canPromoteClaims: false
+```
+
+The adapter may later rank semantically similar existing nodes or receipts. It may not generate authority, close a VOID, infer a person, or write back without explicit review.
+
+The model reference is an implementation candidate, not a dependency of the current route.
+
+## 13. Knowledge-graph export
+
+A future graph export must be flat and many-to-many. It may include cycles and cross-domain edges.
+
+Every node and edge must preserve:
+
+```text
+claimLayer
+provenance
+projectionRole
+authorityStatus
+```
+
+Graph centrality, visual position, or hub degree must not be interpreted as ontological origin, truth, importance, or personal telos.
+
+## 14. Sierpiński and Assembly
+
+The Sierpiński dimension witness is:
+
+```text
+log(3) / log(2) ~= 1.5849625007
+```
+
+Assembly depth may record minimal joining steps, reuse, and provenance. It must not be used as a proxy for:
+
+- truth;
+- moral value;
+- human worth;
+- Qualia depth;
+- Nordstern proximity.
+
+## 15. Consent and persistence
+
+Current route:
+
+```text
+autoplay: false
+telemetry: false
+persistence: false
+claimUpgrade: false
+```
+
+Any later persistence requires separate explicit consent for:
+
+- points;
+- edges;
+- trajectories;
+- semantic-neighbor suggestions;
+- exports.
+
+Consent must be revocable. No hidden reconstruction of the person is permitted.
+
+## 16. Acceptance criteria
+
+- mobile-first route `/tesser3takt`;
+- seven visible Lyra channels;
+- regime and guard shown separately;
+- sliders affect regime only;
+- consent failure produces `STOP`;
+- claim-promotion request produces `HOLD`;
+- portal collision remains reversible and does not automatically alter the guard;
+- boundary halves share one transition ID;
+- `63 + X` remains visible;
+- backend frame is visible and serializable;
+- unresolved kenograms remain visible;
+- optional semantic assistance is disabled;
+- no third-party runtime visualization dependency;
+- build, lint, typecheck, overlap audit, and counterfixtures pass before promotion.
+
+## 17. Hold
+
+No VOIDMAP edit. No new canonical VOID identifier. No telemetry. No policy promotion. No automatic graph writeback. No equation of Landau, Slater, Pauli, Wheeler, Majorana, Sierpiński, Assembly, Kenogrammatics, or the HUD with human interiority.

--- a/ui-app/README.md
+++ b/ui-app/README.md
@@ -5,6 +5,7 @@ Web-App für die Visualisierung der EntaENGELment-Konzepte (Guard System, VOIDMA
 ## Features
 
 - **Metatron HUD** - Fokus & Aufmerksamkeit Monitor (G4)
+- **tesser3TAKT HUD** - 7×9-Quadranten, Caduceus/Vortex, Portal-Antisymmetrie und Kenogramm-Fransen **[UI-LAB]**
 - **VOIDMAP Explorer** - Durchsuchen aller VOIDs mit Filter
 - **Guard Dashboard** - G0-G6 Status-Überwachung
 - **Nichtraum View** - Visualisierung des geschützten Bereichs (G2)
@@ -16,6 +17,7 @@ Web-App für die Visualisierung der EntaENGELment-Konzepte (Guard System, VOIDMA
 |-------|-------------|
 | `/` | Dashboard |
 | `/metatron` | Focus/Attention HUD (G4) |
+| `/tesser3takt` | Read-only tesser3TAKT / Kenogram HUD **[UI-LAB]** |
 | `/voidmap` | VOID Explorer |
 | `/guards` | Guard Status (G0-G6) |
 | `/fractalsense` | Fractal Visualization 🌀 **[NEU v1.1]** |
@@ -26,6 +28,18 @@ Web-App für die Visualisierung der EntaENGELment-Konzepte (Guard System, VOIDMA
 - **FractalSense Integration**: 7 φ-basierte Colormaps, 3 Fractal-Typen, interaktives Canvas
 - TypeScript-Port von Python `color_generator.py`
 - Route: `/fractalsense`
+
+## UI-LAB: tesser3TAKT HUD
+
+Der neue Prototyp hält folgende Grenzen sichtbar:
+
+- Projektion ist kein Ontologie-Claim.
+- Kenogramm-Fransen dürfen offen bleiben.
+- Orange/Blau ist eine Händigkeit-/Antisymmetrie-Lesart, keine moralische Polarität.
+- Kein Autoplay und keine Telemetrie.
+- Kein Claim-Upgrade ohne Human Commit.
+
+Arbeits-Spec: `docs/spec/tesser3takt_hud_v0_2.md`. Der HUD-View-State in `lib/tesser3takt-hud.ts` umschließt den kanonischen, runtime-validierten Transport aus `lib/tesser3takt-frame.ts`; die minimale Wire-Fixture liegt unter `fixtures/tesser3takt-minimal-frame.json`.
 
 ## Tech Stack
 
@@ -66,6 +80,7 @@ ui-app/
 ├── app/                     # Next.js App Router Pages
 │   ├── page.tsx             # Dashboard
 │   ├── metatron/page.tsx    # Metatron HUD
+│   ├── tesser3takt/page.tsx # tesser3TAKT / Kenogram HUD
 │   ├── voidmap/page.tsx     # VOIDMAP Explorer
 │   ├── guards/page.tsx      # Guard Dashboard
 │   └── nichtraum/page.tsx   # Nichtraum View
@@ -76,6 +91,8 @@ ui-app/
 │   ├── guards/              # Guard Status Cards
 │   └── nichtraum/           # Nichtraum Zones
 ├── lib/                     # Utilities & Data
+│   ├── tesser3takt-hud.ts   # Typed HUD model and fixtures
+│   ├── tesser3takt-frame.ts # Canonical transport + runtime validation
 │   ├── voidmap-parser.ts    # VOIDMAP Daten
 │   ├── guard-definitions.ts # G0-G6 Definitionen
 │   └── mock-data.ts         # Simulierte Daten
@@ -90,6 +107,7 @@ npm run dev      # Development mit Hot Reload
 npm run build    # Production Build
 npm run start    # Production Server
 npm run lint     # ESLint
+npm run test     # Node tests for frame and HUD invariants
 ```
 
 ## Datenquellen
@@ -99,6 +117,7 @@ Im MVP werden die Daten statisch eingebunden:
 - **VOIDMAP**: Aus `VOIDMAP.yml` geparsed (statisch in `lib/voidmap-parser.ts`)
 - **Guards**: Aus `CLAUDE.md` extrahiert (statisch in `lib/guard-definitions.ts`)
 - **Metatron**: Mock-Daten für Simulation (in `lib/mock-data.ts`)
+- **tesser3TAKT**: Typed UI-LAB state in `lib/tesser3takt-hud.ts`
 
 ## Geplante Features (Phase 2+)
 

--- a/ui-app/app/tesser3takt/page.tsx
+++ b/ui-app/app/tesser3takt/page.tsx
@@ -1,0 +1,5 @@
+import { Tesser3TaktHudV2 } from '@/components/tesser3takt/Tesser3TaktHudV2';
+
+export default function Tesser3TaktHudPage() {
+  return <Tesser3TaktHudV2 />;
+}

--- a/ui-app/components/layout/Navigation.tsx
+++ b/ui-app/components/layout/Navigation.tsx
@@ -7,6 +7,7 @@ import { NavItem } from '@/types';
 const NAV_ITEMS: NavItem[] = [
   { id: 'home', label: 'Home', icon: '🏠', href: '/' },
   { id: 'metatron', label: 'Fokus', icon: '🎯', href: '/metatron' },
+  { id: 'tesser3takt', label: 'tesser3TAKT', icon: '⌬', href: '/tesser3takt' },
   { id: 'voidmap', label: 'VOIDs', icon: '☐', href: '/voidmap' },
   { id: 'guards', label: 'Guards', icon: '🛡️', href: '/guards' },
   { id: 'fractalsense', label: 'Fraktal', icon: '🌀', href: '/fractalsense' },
@@ -35,7 +36,7 @@ export function Navigation() {
               href={item.href}
               className={`
                 flex flex-col items-center justify-center
-                min-w-[64px] min-h-[56px] p-2
+                min-w-[56px] min-h-[56px] p-2
                 touch-manipulation
                 transition-colors duration-150
                 ${isActive
@@ -45,7 +46,7 @@ export function Navigation() {
               `}
             >
               <span className="text-xl mb-0.5">{item.icon}</span>
-              <span className="text-[10px] font-medium">{item.label}</span>
+              <span className="text-[9px] font-medium">{item.label}</span>
             </Link>
           );
         })}
@@ -69,7 +70,7 @@ export function Navigation() {
         </div>
 
         {/* Navigation Links */}
-        <nav className="flex-1 p-4 space-y-1">
+        <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
           {NAV_ITEMS.map((item) => {
             const isActive = pathname === item.href;
             return (

--- a/ui-app/components/tesser3takt/Tesser3TaktHudV2.tsx
+++ b/ui-app/components/tesser3takt/Tesser3TaktHudV2.tsx
@@ -1,0 +1,602 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  buildTesserHudFrame,
+  KENO_FRINGES,
+  KNIGHT_TRAJECTORY,
+  landauPotential,
+  LYRA_CHANNELS,
+  PORTAL_DISTINCT_RIGHT_STATE_ID,
+  PORTAL_LEFT_STATE_ID,
+  type KenoStatus,
+  type ObserverMode,
+} from '@/lib/tesser3takt-hud';
+
+const QUADRANT_ORIGINS = [
+  { x: 40, y: 78 },
+  { x: 326, y: 78 },
+  { x: 40, y: 308 },
+  { x: 326, y: 308 },
+] as const;
+
+const CELL_W = 24;
+const CELL_H = 22;
+const COLS = 9;
+const ROWS = 7;
+
+const FIBER_COLORS = [
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#06b6d4',
+  '#3b82f6',
+  '#a855f7',
+] as const;
+
+const STATUS_STYLES: Record<KenoStatus, string> = {
+  UNOBSERVED: 'border-zinc-600 text-zinc-300 bg-zinc-800/60',
+  UNBOUND: 'border-amber-500/50 text-amber-300 bg-amber-500/10',
+  CONFLICT: 'border-fuchsia-500/50 text-fuchsia-300 bg-fuchsia-500/10',
+  WITHHELD: 'border-sky-500/50 text-sky-300 bg-sky-500/10',
+  FORBIDDEN: 'border-red-500/50 text-red-300 bg-red-500/10',
+};
+
+const GUARD_STYLES = {
+  PASS: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-300',
+  HOLD: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  LOOP: 'border-sky-500/40 bg-sky-500/10 text-sky-300',
+  STOP: 'border-red-500/40 bg-red-500/10 text-red-300',
+} as const;
+
+const REGIME_STYLES = {
+  SYMMETRIC: 'border-zinc-600 bg-zinc-800/60 text-zinc-300',
+  CRITICAL: 'border-amber-500/40 bg-amber-500/10 text-amber-300',
+  BROKEN: 'border-violet-500/40 bg-violet-500/10 text-violet-300',
+  LOOSENED: 'border-sky-500/40 bg-sky-500/10 text-sky-300',
+  OVERWOUND: 'border-rose-500/40 bg-rose-500/10 text-rose-300',
+} as const;
+
+function cellCenter(quadrant: number, column: number, row: number) {
+  const origin = QUADRANT_ORIGINS[quadrant];
+  return {
+    x: origin.x + (column + 0.5) * CELL_W,
+    y: origin.y + (row + 0.5) * CELL_H,
+  };
+}
+
+function fiberPath(index: number, torsion: number) {
+  const points: string[] = [];
+  const amplitude = 42 * (1 - torsion) + 6;
+  const turns = 1.1 + 4.6 * torsion;
+  const spread = (index - 3) * (11 * (1 - torsion) + 2);
+
+  for (let i = 0; i <= 90; i += 1) {
+    const t = i / 90;
+    const x = 118 + 404 * t;
+    const envelope = Math.sin(Math.PI * t);
+    const y =
+      270 +
+      spread +
+      amplitude * envelope * Math.sin(2 * Math.PI * turns * t + index * 0.62);
+    points.push(`${i === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`);
+  }
+
+  return points.join(' ');
+}
+
+function landauPath(control: number) {
+  const points: string[] = [];
+  for (let i = 0; i <= 100; i += 1) {
+    const phi = -1.8 + (3.6 * i) / 100;
+    const potential = landauPotential(phi, control);
+    const x = 20 + (220 * i) / 100;
+    const y = 116 - Math.min(96, potential * 28 + 20);
+    points.push(`${i === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`);
+  }
+  return points.join(' ');
+}
+
+export function Tesser3TaktHudV2() {
+  const [control, setControl] = useState(-0.34);
+  const [torsion, setTorsion] = useState(0.48);
+  const [zLayer, setZLayer] = useState(4);
+  const [observerMode, setObserverMode] = useState<ObserverMode>('OUTER');
+  const [selectedFringe, setSelectedFringe] = useState('Kη-01');
+  const [rightStateId, setRightStateId] = useState(PORTAL_DISTINCT_RIGHT_STATE_ID);
+  const [claimPromotionRequested, setClaimPromotionRequested] = useState(false);
+  const [consentFailed, setConsentFailed] = useState(false);
+
+  const frame = buildTesserHudFrame({
+    observerMode,
+    control,
+    torsion,
+    zLayer,
+    leftStateId: PORTAL_LEFT_STATE_ID,
+    rightStateId,
+    guardInputs: {
+      claimPromotionRequested,
+      consentFailed,
+    },
+  });
+  const portalCollision = frame.transport.collisionProxy;
+
+  const selected =
+    KENO_FRINGES.find((fringe) => fringe.id === selectedFringe) ?? KENO_FRINGES[0];
+
+  const trajectory = useMemo(
+    () => {
+      const boundaryByStep = new Map(
+        frame.transport.boundaryTransitions.map((transition) => [
+          transition.stepIndex,
+          transition,
+        ]),
+      );
+
+      return KNIGHT_TRAJECTORY.map((step, stepIndex) => ({
+        ...step,
+        ...cellCenter(step.quadrant, step.column, step.row),
+        boundaryTransition: boundaryByStep.get(stepIndex),
+      }));
+    },
+    [frame.transport.boundaryTransitions],
+  );
+
+  return (
+    <div className="space-y-6 md:space-y-8">
+      <header className="pt-2 md:pt-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-3xl">⌬</span>
+          <div>
+            <h1 className="text-2xl font-bold text-zinc-100 md:text-3xl">
+              tesser3TAKT · Kenogram HUD v0.2
+            </h1>
+            <p className="mt-1 text-sm text-zinc-500 md:text-base">
+              SPEC-WIP · projection-only · regime ≠ guard · no oracle
+            </p>
+          </div>
+          <div className="ml-auto flex flex-wrap gap-2">
+            <span
+              className={`rounded-full border px-3 py-1 text-xs font-bold ${REGIME_STYLES[frame.regime.state]}`}
+            >
+              {frame.regime.state}
+            </span>
+            <span
+              className={`rounded-full border px-3 py-1 text-xs font-bold ${GUARD_STYLES[frame.guardState]}`}
+            >
+              {frame.guardState}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/35 p-3">
+          <div className="text-xs text-zinc-500">Knight graph</div>
+          <div className="mt-1 text-xl font-semibold text-zinc-100">63 / 164</div>
+          <div className="text-xs text-zinc-500">vertices / edges · d=6</div>
+        </div>
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/35 p-3">
+          <div className="text-xs text-zinc-500">S₄ adjacent swaps</div>
+          <div className="mt-1 text-xl font-semibold text-zinc-100">24 / 36</div>
+          <div className="text-xs text-zinc-500">3-regular · d=6</div>
+        </div>
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/35 p-3">
+          <div className="text-xs text-zinc-500">Lyra</div>
+          <div className="mt-1 text-xl font-semibold text-zinc-100">7</div>
+          <div className="text-xs text-zinc-500">independent channels</div>
+        </div>
+        <div className="rounded-xl border border-zinc-800 bg-zinc-900/35 p-3">
+          <div className="text-xs text-zinc-500">Address space</div>
+          <div className="mt-1 text-xl font-semibold text-zinc-100">63 + X</div>
+          <div className="text-xs text-zinc-500">residual channel unoccupied</div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[1.65fr_.85fr]">
+        <div className="overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 md:p-5">
+          <svg
+            viewBox="0 0 760 560"
+            className="h-auto w-full"
+            role="img"
+            aria-label="tesser3TAKT HUD mit vier 7-mal-9-Feldern, Rösselsprung, sieben Lyra-Fasern, Hermes-Mast, Caduceus und Orange-Blau-Portalen"
+          >
+            <defs>
+              <radialGradient id="hud-core-v2" cx="50%" cy="50%" r="52%">
+                <stop offset="0%" stopColor="#f8fafc" stopOpacity="0.52" />
+                <stop offset="28%" stopColor="#f59e0b" stopOpacity="0.2" />
+                <stop offset="100%" stopColor="#09090b" stopOpacity="0" />
+              </radialGradient>
+              <linearGradient id="orange-portal-v2" x1="0" x2="1">
+                <stop offset="0%" stopColor="#f59e0b" />
+                <stop offset="100%" stopColor="#fb7185" />
+              </linearGradient>
+              <linearGradient id="blue-portal-v2" x1="0" x2="1">
+                <stop offset="0%" stopColor="#22d3ee" />
+                <stop offset="100%" stopColor="#3b82f6" />
+              </linearGradient>
+            </defs>
+
+            <rect x="2" y="2" width="756" height="556" rx="24" fill="#050507" stroke="#27272a" />
+            <ellipse
+              cx="380"
+              cy="278"
+              rx="198"
+              ry="220"
+              fill="url(#hud-core-v2)"
+              opacity={observerMode === 'INNER' ? 0.92 : 0.46}
+            />
+
+            {QUADRANT_ORIGINS.map((origin, quadrant) => (
+              <g key={quadrant} opacity={observerMode === 'INNER' ? 0.36 : 0.78}>
+                <rect
+                  x={origin.x}
+                  y={origin.y}
+                  width={COLS * CELL_W}
+                  height={ROWS * CELL_H}
+                  rx="10"
+                  fill="#09090b"
+                  stroke="#3f3f46"
+                />
+                {Array.from({ length: ROWS + 1 }, (_, row) => (
+                  <line
+                    key={`r-${quadrant}-${row}`}
+                    x1={origin.x}
+                    y1={origin.y + row * CELL_H}
+                    x2={origin.x + COLS * CELL_W}
+                    y2={origin.y + row * CELL_H}
+                    stroke="#27272a"
+                    strokeWidth="0.8"
+                  />
+                ))}
+                {Array.from({ length: COLS + 1 }, (_, column) => (
+                  <line
+                    key={`c-${quadrant}-${column}`}
+                    x1={origin.x + column * CELL_W}
+                    y1={origin.y}
+                    x2={origin.x + column * CELL_W}
+                    y2={origin.y + ROWS * CELL_H}
+                    stroke="#27272a"
+                    strokeWidth="0.8"
+                  />
+                ))}
+                <text x={origin.x + 8} y={origin.y - 8} fill="#71717a" fontSize="11">
+                  Q{quadrant + 1} · 7×9
+                </text>
+              </g>
+            ))}
+
+            <polyline
+              points={trajectory.map((step) => `${step.x},${step.y}`).join(' ')}
+              fill="none"
+              stroke="#fbbf24"
+              strokeWidth="3"
+              strokeLinejoin="round"
+              opacity="0.82"
+            />
+
+            {trajectory.map((step) => (
+              <g key={step.id}>
+                <circle
+                  cx={step.x}
+                  cy={step.y}
+                  r={step.boundaryTransition ? 6 : 4}
+                  fill={step.boundaryTransition ? '#f4f4f5' : '#f59e0b'}
+                  stroke={step.boundaryTransition ? '#f59e0b' : '#09090b'}
+                  strokeWidth="2"
+                />
+                {step.boundaryTransition && (
+                  <text x={step.x + 8} y={step.y - 8} fill="#fbbf24" fontSize="9">
+                    {step.boundaryTransition.half === 'EXIT' ? '½→' : '→½'}
+                  </text>
+                )}
+              </g>
+            ))}
+
+            {FIBER_COLORS.map((color, index) => (
+              <path
+                key={color}
+                d={fiberPath(index, torsion)}
+                fill="none"
+                stroke={color}
+                strokeWidth={2.1 + torsion * 2.3}
+                opacity={0.4 + torsion * 0.38}
+                strokeLinecap="round"
+              />
+            ))}
+
+            <line x1="380" y1="500" x2="380" y2="52" stroke="#f8fafc" strokeWidth="3" opacity="0.82" />
+            <text x="390" y="64" fill="#e4e4e7" fontSize="12">
+              z · orthogonaler Hermes-Mast
+            </text>
+
+            <path
+              d={`M380 486 C${328 - zLayer * 2} 432 ${432 + zLayer * 2} 378 380 326 C${328 - zLayer * 2} 274 ${432 + zLayer * 2} 220 380 166 C${328 - zLayer * 2} 126 ${432 + zLayer * 2} 94 380 68`}
+              fill="none"
+              stroke="#22d3ee"
+              strokeWidth="5"
+              strokeLinecap="round"
+            />
+            <path
+              d={`M380 486 C${432 + zLayer * 2} 432 ${328 - zLayer * 2} 378 380 326 C${432 + zLayer * 2} 274 ${328 - zLayer * 2} 220 380 166 C${432 + zLayer * 2} 126 ${328 - zLayer * 2} 94 380 68`}
+              fill="none"
+              stroke="#f59e0b"
+              strokeWidth="5"
+              strokeLinecap="round"
+            />
+
+            <g transform="translate(85 255)">
+              <circle r="48" fill="#030712" stroke="url(#orange-portal-v2)" strokeWidth="5" />
+              <circle r="28" fill="none" stroke="#f59e0b" strokeWidth="2" opacity="0.5" />
+              <text x="0" y="4" fill="#fdba74" textAnchor="middle" fontSize="13">ORANGE</text>
+              <text x="0" y="65" fill="#a1a1aa" textAnchor="middle" fontSize="10">+ Händigkeit</text>
+            </g>
+
+            <g transform="translate(675 255)">
+              <circle r="48" fill="#030712" stroke="url(#blue-portal-v2)" strokeWidth="5" />
+              <circle r="28" fill="none" stroke="#38bdf8" strokeWidth="2" opacity="0.5" />
+              <text x="0" y="4" fill="#7dd3fc" textAnchor="middle" fontSize="13">BLUE</text>
+              <text x="0" y="65" fill="#a1a1aa" textAnchor="middle" fontSize="10">− Händigkeit</text>
+            </g>
+
+            <circle
+              cx="380"
+              cy="278"
+              r="18"
+              fill="#09090b"
+              stroke={portalCollision ? '#ef4444' : '#f8fafc'}
+              strokeWidth="3"
+            />
+            <text
+              x="380"
+              y="282"
+              fill={portalCollision ? '#fca5a5' : '#f8fafc'}
+              textAnchor="middle"
+              fontSize="11"
+            >
+              {portalCollision ? '0' : 'X'}
+            </text>
+            <text x="380" y="310" fill="#71717a" textAnchor="middle" fontSize="10">
+              63 + X · unoccupied residual channel
+            </text>
+
+            {LYRA_CHANNELS.map((channel, index) => {
+              const y = 510 - index * 13;
+              return (
+                <g key={channel.id}>
+                  <line x1="300" y1={y} x2="460" y2={y} stroke={FIBER_COLORS[index]} strokeWidth="1.4" opacity="0.72" />
+                  <text x="286" y={y + 3} fill="#a1a1aa" textAnchor="end" fontSize="9">
+                    {index + 1} · {channel.note}
+                  </text>
+                </g>
+              );
+            })}
+
+            {observerMode === 'INVERSE' && (
+              <g>
+                <rect x="250" y="20" width="260" height="32" rx="12" fill="#18181b" stroke="#a78bfa" strokeDasharray="6 4" />
+                <text x="380" y="40" fill="#c4b5fd" textAnchor="middle" fontSize="12">
+                  719° frozen frame · &gt;~&lt; · Rücken in 2D
+                </text>
+              </g>
+            )}
+          </svg>
+        </div>
+
+        <aside className="space-y-4">
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/35 p-4">
+            <h2 className="font-semibold text-zinc-100">Regime · keine Guard-Ableitung</h2>
+            <label className="mt-4 block text-xs text-zinc-400">
+              Landau control · {control.toFixed(2)}
+              <input
+                type="range"
+                min="-1"
+                max="1"
+                step="0.02"
+                value={control}
+                onChange={(event) => setControl(Number(event.target.value))}
+                className="mt-2 w-full"
+              />
+            </label>
+            <svg viewBox="0 0 260 130" className="mt-2 w-full rounded-xl border border-zinc-800 bg-zinc-950/70">
+              <line x1="20" y1="116" x2="242" y2="116" stroke="#52525b" />
+              <line x1="130" y1="12" x2="130" y2="122" stroke="#52525b" />
+              <path d={landauPath(control)} fill="none" stroke="#f59e0b" strokeWidth="3" />
+              <circle cx={130 + frame.regime.orderParameter * 52} cy={112} r="4" fill="#22d3ee" />
+            </svg>
+
+            <label className="mt-4 block text-xs text-zinc-400">
+              Loosen ↔ Tighten · {torsion.toFixed(2)}
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={torsion}
+                onChange={(event) => setTorsion(Number(event.target.value))}
+                className="mt-2 w-full"
+              />
+            </label>
+
+            <label className="mt-4 block text-xs text-zinc-400">
+              zN depth · {zLayer}
+              <input
+                type="range"
+                min="1"
+                max="9"
+                step="1"
+                value={zLayer}
+                onChange={(event) => setZLayer(Number(event.target.value))}
+                className="mt-2 w-full"
+              />
+            </label>
+
+            <div className="mt-4 grid grid-cols-3 gap-2">
+              {(['OUTER', 'INNER', 'INVERSE'] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setObserverMode(mode)}
+                  className={`rounded-lg border px-2 py-2 text-[11px] font-medium ${
+                    observerMode === mode
+                      ? 'border-emerald-500/50 bg-emerald-500/10 text-emerald-300'
+                      : 'border-zinc-700 bg-zinc-950/40 text-zinc-500'
+                  }`}
+                >
+                  {mode}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/35 p-4">
+            <h2 className="font-semibold text-zinc-100">Portal-Antisymmetrie</h2>
+            <p className="mt-2 text-xs leading-relaxed text-zinc-500">
+              Der Nullfall ist ein formaler Kollisionshinweis. Er verändert nicht automatisch den Guard.
+            </p>
+            <button
+              type="button"
+              onClick={() =>
+                setRightStateId((value) =>
+                  value === PORTAL_LEFT_STATE_ID
+                    ? PORTAL_DISTINCT_RIGHT_STATE_ID
+                    : PORTAL_LEFT_STATE_ID,
+                )
+              }
+              className={`mt-3 w-full rounded-xl border px-3 py-3 text-sm font-medium ${
+                portalCollision
+                  ? 'border-red-500/50 bg-red-500/10 text-red-300'
+                  : 'border-sky-500/50 bg-sky-500/10 text-sky-300'
+              }`}
+            >
+              {portalCollision ? 'Det Ψ = 0 · Kollision lösen' : 'Det Ψ ≠ 0 · Kollision simulieren'}
+            </button>
+            <p className="mt-2 break-all text-[10px] text-zinc-600">
+              {frame.portal.leftStateId} ↔ {frame.portal.rightStateId}
+            </p>
+          </div>
+
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/35 p-4">
+            <h2 className="font-semibold text-zinc-100">Guard-Ereignisse</h2>
+            <label className="mt-3 flex items-center gap-3 text-xs text-zinc-400">
+              <input
+                type="checkbox"
+                checked={claimPromotionRequested}
+                onChange={(event) => setClaimPromotionRequested(event.target.checked)}
+              />
+              Claim-Promotion angefordert → HOLD
+            </label>
+            <label className="mt-3 flex items-center gap-3 text-xs text-zinc-400">
+              <input
+                type="checkbox"
+                checked={consentFailed}
+                onChange={(event) => setConsentFailed(event.target.checked)}
+              />
+              Consent-Fail → STOP
+            </label>
+          </div>
+        </aside>
+      </section>
+
+      <section className="grid gap-4 xl:grid-cols-[1.25fr_.75fr]">
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/25 p-4 md:p-5">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h2 className="font-semibold text-zinc-100">Kenogramm-Fransen</h2>
+              <p className="mt-1 text-xs text-zinc-500">Lokalisieren, ohne durch Sichtbarkeit bereits zu schließen.</p>
+            </div>
+            <span className="rounded-full border border-zinc-700 px-3 py-1 text-xs text-zinc-400">
+              {KENO_FRINGES.length} offen
+            </span>
+          </div>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {KENO_FRINGES.map((fringe) => (
+              <button
+                key={fringe.id}
+                type="button"
+                onClick={() => setSelectedFringe(fringe.id)}
+                className={`rounded-xl border p-3 text-left transition ${STATUS_STYLES[fringe.status]} ${
+                  selectedFringe === fringe.id ? 'ring-2 ring-emerald-400/60' : ''
+                }`}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-bold">{fringe.id}</span>
+                  <span className="text-[10px] opacity-70">{fringe.status}</span>
+                </div>
+                <div className="mt-2 text-sm font-medium">{fringe.label}</div>
+                <div className="mt-1 text-[10px] opacity-70">{fringe.layer}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/35 p-4 md:p-5">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="font-semibold text-zinc-100">{selected.id}</h2>
+            <span className={`rounded-full border px-2 py-1 text-[10px] ${STATUS_STYLES[selected.status]}`}>
+              {selected.status}
+            </span>
+          </div>
+          <p className="mt-3 text-sm font-medium text-zinc-300">{selected.label}</p>
+          <dl className="mt-4 space-y-3 text-xs">
+            <div>
+              <dt className="text-zinc-600">Fehlender Operator</dt>
+              <dd className="mt-1 text-zinc-300">{selected.missingOperator ?? 'mehrere konkurrierende Operatoren'}</dd>
+            </div>
+            <div>
+              <dt className="text-zinc-600">Anker</dt>
+              <dd className="mt-1 flex flex-wrap gap-1">
+                {selected.anchors.map((anchor) => (
+                  <span key={anchor} className="rounded bg-zinc-950/70 px-2 py-1 text-zinc-400">{anchor}</span>
+                ))}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-zinc-600">Provenienz</dt>
+              <dd className="mt-1 space-y-1 text-zinc-400">
+                {selected.provenance.map((reference, index) => (
+                  <div key={`${reference.source}:${reference.locator}:${index}`}>
+                    {reference.source} · {reference.locator}
+                  </div>
+                ))}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-zinc-600">Resolution Gate</dt>
+              <dd className="mt-1 text-zinc-300">
+                human={String(selected.resolutionGate.needsHumanCommit)} · counterfixture={String(selected.resolutionGate.needsCounterfixture)} · claim-audit={String(selected.resolutionGate.needsClaimAudit)} · consent={String(selected.resolutionGate.needsConsent)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-zinc-600">Persistenter VOID</dt>
+              <dd className="mt-1 text-emerald-300">zulässig</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/20 p-4 md:p-6">
+          <h2 className="font-semibold text-zinc-100">HUD view + canonical transport</h2>
+          <pre className="mt-4 max-h-96 overflow-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-[11px] leading-relaxed text-zinc-400">
+            {JSON.stringify(frame, null, 2)}
+          </pre>
+        </div>
+
+        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/20 p-4 md:p-6">
+          <h2 className="font-semibold text-zinc-100">Optional semantic assist</h2>
+          <p className="mt-3 text-sm leading-relaxed text-zinc-500">
+            {frame.semanticAssist.modelRef} bleibt deaktiviert. Seine einzige erlaubte Rolle ist das Ranking möglicher Nachbarknoten; Kenogramme schließen und Claims promoten darf es nicht.
+          </p>
+          <div className="mt-4 grid gap-2 text-xs sm:grid-cols-2">
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 text-zinc-400">enabled: false</div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 text-zinc-400">persistence: none</div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 text-zinc-400">resolve kenograms: false</div>
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950/60 p-3 text-zinc-400">promote claims: false</div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/ui-app/lib/tesser3takt-hud.ts
+++ b/ui-app/lib/tesser3takt-hud.ts
@@ -1,0 +1,638 @@
+import {
+  validateTesserTickFrame,
+  withDerivedCollisionProxy,
+  type BoundaryTransition,
+  type ProvenanceRef,
+  type TesserTickFrame as CanonicalTesserTickFrame,
+} from './tesser3takt-frame.ts';
+
+export type ClaimLayer =
+  | 'FACT'
+  | 'FORMAL'
+  | 'MODEL'
+  | 'METAPHOR'
+  | 'POETRY'
+  | 'GUARD';
+
+export type KenoStatus =
+  | 'UNOBSERVED'
+  | 'UNBOUND'
+  | 'CONFLICT'
+  | 'WITHHELD'
+  | 'FORBIDDEN';
+
+export type GuardState = 'PASS' | 'HOLD' | 'LOOP' | 'STOP';
+
+export type RegimeState =
+  | 'SYMMETRIC'
+  | 'CRITICAL'
+  | 'BROKEN'
+  | 'LOOSENED'
+  | 'OVERWOUND';
+
+export type ObserverMode = 'OUTER' | 'INNER' | 'INVERSE';
+
+export interface HudAnchor {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  layer: ClaimLayer;
+}
+
+export interface ResolutionGate {
+  needsHumanCommit: boolean;
+  needsCounterfixture: boolean;
+  needsClaimAudit: boolean;
+  needsConsent: boolean;
+}
+
+export interface KenoFringe {
+  id: `Kη-${string}`;
+  label: string;
+  status: KenoStatus;
+  layer: ClaimLayer;
+  anchors: string[];
+  missingOperator?: string;
+  competingOperators?: string[];
+  provenance: readonly ProvenanceRef[];
+  resolutionGate: ResolutionGate;
+  allowPersistentVoid: true;
+}
+
+export interface KnightStep {
+  id: string;
+  quadrant: 0 | 1 | 2 | 3;
+  column: number;
+  row: number;
+}
+
+export interface GuardInputs {
+  consentFailed?: boolean;
+  focusSwitchPending?: boolean;
+  forbiddenCouplingAttempted?: boolean;
+  claimPromotionRequested?: boolean;
+  receiptPending?: boolean;
+  loopRequested?: boolean;
+}
+
+export interface SemanticAssistConfig {
+  enabled: false;
+  provider: 'hugging-face';
+  modelRef: string;
+  role: 'candidate-neighbor-ranking';
+  canResolveKenograms: false;
+  canPromoteClaims: false;
+  persistence: 'none';
+}
+
+export interface VerificationWitnesses {
+  knightGraph: {
+    vertices: 63;
+    edges: 164;
+    connected: true;
+    bipartite: true;
+    diameter: 6;
+  };
+  s4AdjacentSwapGraph: {
+    vertices: 24;
+    edges: 36;
+    regularDegree: 3;
+    connected: true;
+    bipartite: true;
+    diameter: 6;
+  };
+  sierpinskiDimension: number;
+  slaterDuplicateRowsDeterminant: 0;
+}
+
+export interface TesserHudFrame {
+  schemaVersion: '0.2';
+  authorityStatus: 'annex';
+  artifactType: 'ui-lab';
+  projectionOnly: true;
+  transport: CanonicalTesserTickFrame;
+  observerMode: ObserverMode;
+  regime: {
+    control: number;
+    orderParameter: number;
+    torsion: number;
+    state: RegimeState;
+  };
+  zLayer: number;
+  guardState: GuardState;
+  portal: {
+    left: 'ORANGE';
+    right: 'BLUE';
+    leftStateId: string;
+    rightStateId: string;
+    handednessPreserved: true;
+    determinantProxy: 0 | 1;
+  };
+  quadrants: {
+    count: 4;
+    rows: 7;
+    columns: 9;
+    addressableCells: 63;
+    residualChannel: 'X';
+    boundaryRule: 'ONE_TRANSITION_TWO_PROJECTIONS';
+  };
+  lyraChannels: 7;
+  kenograms: readonly KenoFringe[];
+  semanticAssist: SemanticAssistConfig;
+  verification: VerificationWitnesses;
+  constraints: {
+    autoplay: false;
+    telemetry: false;
+    claimUpgrade: false;
+    persistentVoidAllowed: true;
+    humanCommitRequiredForPromotion: true;
+  };
+}
+
+export const LYRA_CHANNELS = [
+  { id: 'L1', note: 'C' },
+  { id: 'L2', note: 'D' },
+  { id: 'L3', note: 'E' },
+  { id: 'L4', note: 'F' },
+  { id: 'L5', note: 'G' },
+  { id: 'L6', note: 'A' },
+  { id: 'L7', note: 'B' },
+] as const;
+
+export const LYRA_NOTES = LYRA_CHANNELS.map((channel) => channel.note);
+
+function provenanceRef(reference: string): ProvenanceRef {
+  const separator = reference.indexOf(':');
+  const namespace = separator === -1 ? 'repo' : reference.slice(0, separator);
+  const locator = separator === -1 ? reference : reference.slice(separator + 1);
+
+  const source =
+    namespace === 'repo'
+      ? 'fleksible/entaENGELment-'
+      : namespace === 'drive'
+        ? 'Google Drive annex'
+        : namespace === 'wolfram'
+          ? 'Wolfram Language calculation'
+          : 'conversation transport';
+
+  return {
+    kind:
+      namespace === 'wolfram'
+        ? 'calculation'
+        : namespace === 'chat'
+          ? 'transport'
+          : 'annex',
+    source,
+    revision: 'unverified',
+    digest: null,
+    digestStatus: 'UNVERIFIED',
+    locator,
+    claimLayer: namespace === 'repo' ? 'SPEC' : 'MODEL',
+    authorityStatus:
+      namespace === 'wolfram'
+        ? 'derived'
+        : namespace === 'repo'
+          ? 'repo-local'
+          : 'external-unverified',
+  };
+}
+
+function provenanceRefs(...references: string[]): readonly ProvenanceRef[] {
+  return references.map(provenanceRef);
+}
+
+export const PORTAL_LEFT_STATE_ID = 'S4:1234';
+export const PORTAL_DISTINCT_RIGHT_STATE_ID = 'S4:2143';
+
+const BOUNDARY_PROVENANCE = provenanceRef(
+  'repo:docs/spec/tesser3takt_hud_v0_2.md#5-boundary-half-step-invariant',
+);
+
+export const HUD_BOUNDARY_TRANSITIONS: readonly BoundaryTransition[] = [
+  {
+    pairId: 'B-Q0-Q1',
+    half: 'EXIT',
+    stepIndex: 4,
+    stateId: 'hud:N04',
+    quadrant: 'alpha',
+    coordinateSpace: 'GLOBAL_REENTRY_LATTICE',
+    latticePosition: [8, 5],
+    provenance: BOUNDARY_PROVENANCE,
+  },
+  {
+    pairId: 'B-Q0-Q1',
+    half: 'ENTRY',
+    stepIndex: 5,
+    stateId: 'hud:N05',
+    quadrant: 'beta',
+    coordinateSpace: 'GLOBAL_REENTRY_LATTICE',
+    latticePosition: [9, 7],
+    transformedFrom: 'hud:N04',
+    provenance: BOUNDARY_PROVENANCE,
+  },
+  {
+    pairId: 'B-Q1-Q3',
+    half: 'EXIT',
+    stepIndex: 9,
+    stateId: 'hud:N09',
+    quadrant: 'beta',
+    coordinateSpace: 'GLOBAL_REENTRY_LATTICE',
+    latticePosition: [17, 7],
+    provenance: BOUNDARY_PROVENANCE,
+  },
+  {
+    pairId: 'B-Q1-Q3',
+    half: 'ENTRY',
+    stepIndex: 10,
+    stateId: 'hud:N10',
+    quadrant: 'delta',
+    coordinateSpace: 'GLOBAL_REENTRY_LATTICE',
+    latticePosition: [19, 8],
+    transformedFrom: 'hud:N09',
+    provenance: BOUNDARY_PROVENANCE,
+  },
+  {
+    pairId: 'B-Q3-Q2',
+    half: 'EXIT',
+    stepIndex: 14,
+    stateId: 'hud:N14',
+    quadrant: 'delta',
+    coordinateSpace: 'GLOBAL_REENTRY_LATTICE',
+    latticePosition: [19, 14],
+    provenance: BOUNDARY_PROVENANCE,
+  },
+  {
+    pairId: 'B-Q3-Q2',
+    half: 'ENTRY',
+    stepIndex: 15,
+    stateId: 'hud:N15',
+    quadrant: 'gamma',
+    coordinateSpace: 'GLOBAL_REENTRY_LATTICE',
+    latticePosition: [18, 16],
+    transformedFrom: 'hud:N14',
+    provenance: BOUNDARY_PROVENANCE,
+  },
+];
+
+const HUD_FRAME_PROVENANCE = provenanceRefs(
+  'repo:docs/spec/tesser3takt_hud_v0_2.md',
+  'drive:Zwischenzeitliches_Ganzes_tesser3TAKT_entaENGELment_SaveState_v1_2.docx',
+  'wolfram:knight-graph-7x9-and-s4-adjacent-transpositions',
+);
+
+export const KNIGHT_TRAJECTORY: KnightStep[] = [
+  { id: 'N00', quadrant: 0, column: 0, row: 5 },
+  { id: 'N01', quadrant: 0, column: 2, row: 4 },
+  { id: 'N02', quadrant: 0, column: 4, row: 5 },
+  { id: 'N03', quadrant: 0, column: 6, row: 4 },
+  { id: 'N04', quadrant: 0, column: 8, row: 5 },
+  { id: 'N05', quadrant: 1, column: 0, row: 1 },
+  { id: 'N06', quadrant: 1, column: 2, row: 0 },
+  { id: 'N07', quadrant: 1, column: 4, row: 1 },
+  { id: 'N08', quadrant: 1, column: 6, row: 0 },
+  { id: 'N09', quadrant: 1, column: 8, row: 1 },
+  { id: 'N10', quadrant: 3, column: 7, row: 5 },
+  { id: 'N11', quadrant: 3, column: 5, row: 6 },
+  { id: 'N12', quadrant: 3, column: 3, row: 5 },
+  { id: 'N13', quadrant: 3, column: 1, row: 6 },
+  { id: 'N14', quadrant: 3, column: 0, row: 4 },
+  { id: 'N15', quadrant: 2, column: 8, row: 1 },
+  { id: 'N16', quadrant: 2, column: 6, row: 2 },
+  { id: 'N17', quadrant: 2, column: 4, row: 1 },
+  { id: 'N18', quadrant: 2, column: 2, row: 2 },
+  { id: 'N19', quadrant: 2, column: 0, row: 1 },
+];
+
+export const KENO_FRINGES: KenoFringe[] = [
+  {
+    id: 'Kη-01',
+    label: 'Landau-Übersetzung',
+    status: 'UNBOUND',
+    layer: 'MODEL',
+    anchors: ['landau-control', 'hud-regime'],
+    missingOperator: 'dimensionless-regime-calibration',
+    provenance: provenanceRefs('drive:ANNEX_F', 'wolfram:quartic-witness'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-02',
+    label: 'Vortex–Bifröst-Projektion',
+    status: 'UNOBSERVED',
+    layer: 'MODEL',
+    anchors: ['vortex-inner', 'wheeler-outer'],
+    missingOperator: 'continuous-to-sliced-projection',
+    provenance: provenanceRefs('chat:caduceus-bifrost'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-03',
+    label: 'Wheeler-Transport',
+    status: 'UNBOUND',
+    layer: 'FORMAL',
+    anchors: ['phase', 'provenance', 'holonomy'],
+    missingOperator: 'slice-transport-receipt',
+    provenance: provenanceRefs('chat:wheeler-slices'),
+    resolutionGate: {
+      needsHumanCommit: false,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-04',
+    label: 'Portal-Antisymmetrie',
+    status: 'CONFLICT',
+    layer: 'FORMAL',
+    anchors: ['orange-portal', 'blue-portal', 'slater'],
+    competingOperators: ['exact-state-equality', 'equivalence-up-to-symmetry'],
+    provenance: provenanceRefs('wolfram:duplicate-row-determinant-zero'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-05',
+    label: 'Majorana/Fermi-Inversion',
+    status: 'UNOBSERVED',
+    layer: 'METAPHOR',
+    anchors: ['majorana-void', 'fermi-outside'],
+    missingOperator: 'perspective-invariant-map',
+    provenance: provenanceRefs('chat:inverse-pov'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-06',
+    label: 'Curie–ADR-Extremachse',
+    status: 'UNBOUND',
+    layer: 'MODEL',
+    anchors: ['curie', 'adiabatic-demagnetization'],
+    missingOperator: 'dimensionless-extreme-axis',
+    provenance: provenanceRefs('chat:curie-adr-axis'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-07',
+    label: '7×9-Grenzsprung',
+    status: 'UNBOUND',
+    layer: 'FORMAL',
+    anchors: ['knight-path', 'quadrant-boundary'],
+    missingOperator: 'shared-boundary-transition-id',
+    provenance: provenanceRefs('wolfram:knight-graph-7x9', 'drive:ANNEX_F'),
+    resolutionGate: {
+      needsHumanCommit: false,
+      needsCounterfixture: true,
+      needsClaimAudit: false,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-08',
+    label: 'zN-Tiefe',
+    status: 'UNOBSERVED',
+    layer: 'MODEL',
+    anchors: ['zn-stack', 'stored-transform'],
+    missingOperator: 'depth-composition-law',
+    provenance: provenanceRefs('chat:zn-depth'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-09',
+    label: 'Nicht-Raum / Not-at-ion',
+    status: 'UNBOUND',
+    layer: 'METAPHOR',
+    anchors: ['latex-ast', 'chemical-notation', 'assembly-ledger'],
+    missingOperator: 'typed-notation-to-assembly-bridge',
+    provenance: provenanceRefs('chat:not-at-ion'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-10',
+    label: 'Consent-Telemetrie',
+    status: 'WITHHELD',
+    layer: 'GUARD',
+    anchors: ['crank', 'slice', 'breadcrumb'],
+    missingOperator: 'explicit-granular-consent',
+    provenance: provenanceRefs('repo:G0-consent-boundary'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: true,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-11',
+    label: 'Claim-Migration',
+    status: 'FORBIDDEN',
+    layer: 'GUARD',
+    anchors: ['poetry', 'model', 'claim-registry'],
+    missingOperator: 'human-reviewed-promotion-receipt',
+    provenance: provenanceRefs('repo:claim-tag-runtime-mapping'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+  {
+    id: 'Kη-12',
+    label: 'Kenogrammstatus',
+    status: 'CONFLICT',
+    layer: 'FORMAL',
+    anchors: ['unobserved', 'unbound', 'conflict', 'withheld', 'forbidden'],
+    competingOperators: ['workflow-status', 'epistemic-status', 'authority-status'],
+    provenance: provenanceRefs('repo:voidmap', 'repo:claim-tag-runtime-mapping'),
+    resolutionGate: {
+      needsHumanCommit: true,
+      needsCounterfixture: true,
+      needsClaimAudit: true,
+      needsConsent: false,
+    },
+    allowPersistentVoid: true,
+  },
+];
+
+export const SEMANTIC_ASSIST: SemanticAssistConfig = {
+  enabled: false,
+  provider: 'hugging-face',
+  modelRef: 'intfloat/multilingual-e5-small',
+  role: 'candidate-neighbor-ranking',
+  canResolveKenograms: false,
+  canPromoteClaims: false,
+  persistence: 'none',
+};
+
+export const VERIFICATION_WITNESSES: VerificationWitnesses = {
+  knightGraph: {
+    vertices: 63,
+    edges: 164,
+    connected: true,
+    bipartite: true,
+    diameter: 6,
+  },
+  s4AdjacentSwapGraph: {
+    vertices: 24,
+    edges: 36,
+    regularDegree: 3,
+    connected: true,
+    bipartite: true,
+    diameter: 6,
+  },
+  sierpinskiDimension: 1.584962500721156,
+  slaterDuplicateRowsDeterminant: 0,
+};
+
+export function landauPotential(
+  phi: number,
+  control: number,
+  quartic = 1,
+): number {
+  return 0.5 * control * phi * phi + 0.25 * quartic * phi ** 4;
+}
+
+export function deriveOrderParameter(control: number, quartic = 1): number {
+  if (control >= 0 || quartic <= 0) return 0;
+  return Math.sqrt(Math.abs(control) / quartic);
+}
+
+export function deriveRegimeState(
+  control: number,
+  torsion: number,
+): RegimeState {
+  if (torsion > 0.88) return 'OVERWOUND';
+  if (torsion < 0.12) return 'LOOSENED';
+  if (Math.abs(control) < 0.08) return 'CRITICAL';
+  return control < 0 ? 'BROKEN' : 'SYMMETRIC';
+}
+
+export function deriveGuardState(inputs: GuardInputs = {}): GuardState {
+  if (
+    inputs.consentFailed ||
+    inputs.focusSwitchPending ||
+    inputs.forbiddenCouplingAttempted
+  ) {
+    return 'STOP';
+  }
+
+  if (inputs.claimPromotionRequested || inputs.receiptPending) {
+    return 'HOLD';
+  }
+
+  if (inputs.loopRequested) return 'LOOP';
+  return 'PASS';
+}
+
+export function buildTesserHudFrame(input: {
+  observerMode: ObserverMode;
+  control: number;
+  torsion: number;
+  zLayer: number;
+  leftStateId: string;
+  rightStateId: string;
+  guardInputs?: GuardInputs;
+}): TesserHudFrame {
+  const transport = withDerivedCollisionProxy({
+    frameId: 'tesser3takt-hud-v0.2',
+    collisionSemantics: 'EXACT_STATE_ID' as const,
+    leftStateId: input.leftStateId,
+    rightStateId: input.rightStateId,
+    kenograms: KENO_FRINGES.map((fringe) => fringe.id),
+    boundaryTransitions: HUD_BOUNDARY_TRANSITIONS,
+    provenance: HUD_FRAME_PROVENANCE,
+  });
+  const validation = validateTesserTickFrame(transport);
+  if (!validation.valid) {
+    throw new Error(`Invalid tesser3TAKT transport: ${validation.errors.join('; ')}`);
+  }
+
+  return {
+    schemaVersion: '0.2',
+    authorityStatus: 'annex',
+    artifactType: 'ui-lab',
+    projectionOnly: true,
+    transport,
+    observerMode: input.observerMode,
+    regime: {
+      control: input.control,
+      orderParameter: deriveOrderParameter(input.control),
+      torsion: input.torsion,
+      state: deriveRegimeState(input.control, input.torsion),
+    },
+    zLayer: input.zLayer,
+    guardState: deriveGuardState(input.guardInputs),
+    portal: {
+      left: 'ORANGE',
+      right: 'BLUE',
+      leftStateId: transport.leftStateId,
+      rightStateId: transport.rightStateId,
+      handednessPreserved: true,
+      determinantProxy: transport.collisionProxy ? 0 : 1,
+    },
+    quadrants: {
+      count: 4,
+      rows: 7,
+      columns: 9,
+      addressableCells: 63,
+      residualChannel: 'X',
+      boundaryRule: 'ONE_TRANSITION_TWO_PROJECTIONS',
+    },
+    lyraChannels: 7,
+    kenograms: KENO_FRINGES,
+    semanticAssist: SEMANTIC_ASSIST,
+    verification: VERIFICATION_WITNESSES,
+    constraints: {
+      autoplay: false,
+      telemetry: false,
+      claimUpgrade: false,
+      persistentVoidAllowed: true,
+      humanCommitRequiredForPromotion: true,
+    },
+  };
+}

--- a/ui-app/test/tesser3takt-hud.test.mjs
+++ b/ui-app/test/tesser3takt-hud.test.mjs
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildTesserHudFrame,
+  HUD_BOUNDARY_TRANSITIONS,
+  KENO_FRINGES,
+  PORTAL_DISTINCT_RIGHT_STATE_ID,
+  PORTAL_LEFT_STATE_ID,
+} from '../lib/tesser3takt-hud.ts';
+import {
+  validateBoundaryPairs,
+  validateTesserTickFrame,
+} from '../lib/tesser3takt-frame.ts';
+
+function buildFrame(overrides = {}) {
+  return buildTesserHudFrame({
+    observerMode: 'OUTER',
+    control: -0.34,
+    torsion: 0.48,
+    zLayer: 4,
+    leftStateId: PORTAL_LEFT_STATE_ID,
+    rightStateId: PORTAL_DISTINCT_RIGHT_STATE_ID,
+    ...overrides,
+  });
+}
+
+test('portal determinant is derived from exact canonical state ids', () => {
+  const distinct = buildFrame();
+  assert.equal(distinct.transport.collisionProxy, false);
+  assert.equal(distinct.portal.determinantProxy, 1);
+
+  const collision = buildFrame({ rightStateId: PORTAL_LEFT_STATE_ID });
+  assert.equal(collision.transport.collisionProxy, true);
+  assert.equal(collision.portal.determinantProxy, 0);
+
+  for (const frame of [distinct, collision]) {
+    assert.deepEqual(validateTesserTickFrame(frame.transport), {
+      valid: true,
+      errors: [],
+      frame: frame.transport,
+    });
+  }
+});
+
+test('HUD boundary markers are canonical paired transitions', () => {
+  assert.equal(HUD_BOUNDARY_TRANSITIONS.length, 6);
+  assert.equal(
+    new Set(HUD_BOUNDARY_TRANSITIONS.map((transition) => transition.pairId)).size,
+    3,
+  );
+  assert.deepEqual(validateBoundaryPairs(HUD_BOUNDARY_TRANSITIONS), {
+    valid: true,
+    errors: [],
+  });
+
+  for (const pairId of new Set(
+    HUD_BOUNDARY_TRANSITIONS.map((transition) => transition.pairId),
+  )) {
+    const pair = HUD_BOUNDARY_TRANSITIONS.filter(
+      (transition) => transition.pairId === pairId,
+    );
+    assert.deepEqual(
+      pair.map((transition) => transition.half).sort(),
+      ['ENTRY', 'EXIT'],
+    );
+  }
+});
+
+test('display regime cannot produce a governance guard transition', () => {
+  const loosened = buildFrame({ control: 1, torsion: 0 });
+  const overwound = buildFrame({ control: -1, torsion: 1 });
+  assert.equal(loosened.guardState, 'PASS');
+  assert.equal(overwound.guardState, 'PASS');
+  assert.notEqual(loosened.regime.state, overwound.regime.state);
+
+  const held = buildFrame({
+    control: 1,
+    torsion: 0,
+    guardInputs: { claimPromotionRequested: true },
+  });
+  assert.equal(held.guardState, 'HOLD');
+});
+
+test('fringe and transport provenance remain structured and explicitly unverified', () => {
+  const references = [
+    ...KENO_FRINGES.flatMap((fringe) => fringe.provenance),
+    ...buildFrame().transport.provenance,
+    ...HUD_BOUNDARY_TRANSITIONS.map((transition) => transition.provenance),
+  ];
+
+  assert.ok(references.length > 0);
+  for (const reference of references) {
+    assert.equal(typeof reference, 'object');
+    assert.equal(reference.digestStatus, 'UNVERIFIED');
+    assert.equal(reference.digest, null);
+    assert.ok(reference.source.length > 0);
+    assert.ok(reference.locator.length > 0);
+  }
+});

--- a/ui-app/tsconfig.json
+++ b/ui-app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@enta/tsconfig/nextjs.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary

Adds the projection-only tesser3TAKT / Kenogram HUD at `/tesser3takt`, now rebased on current `main` and bound to the canonical frame contract from #312.

### Boundary hardening

- wraps the canonical `TesserTickFrame` as `transport` instead of defining a competing wire shape
- derives `collisionProxy` from exact left/right state IDs; the UI cannot inject a collision boolean
- renders boundary marks from six validated canonical records (three EXIT/ENTRY pairs) in `GLOBAL_REENTRY_LATTICE`
- uses structured provenance with explicit `UNVERIFIED` / `digest: null` semantics
- keeps display regime and governance guard inputs independent
- removes the duplicate incompatible fixture

## Verification

- 12/12 UI frame and HUD invariant tests
- TypeScript typecheck
- ESLint
- optimized Next.js production build
- `pnpm audit --audit-level=high`: no known vulnerabilities
- exact witnesses independently checked: 7×9 knight graph = 63 vertices / 164 edges / connected / bipartite / diameter 6; adjacent-transposition `S4` graph = 24 / 36 / degree 3 / connected / bipartite / diameter 6; duplicate-row determinant = 0

## Smallest review focus

1. Confirm the three declared global re-entry coordinate pairs are the intended cross-quadrant embeddings.
2. Confirm `EXACT_STATE_ID` remains the intended portal collision semantics (symmetry-equivalence remains explicitly open as `Kη-04`).
3. Treat all external provenance as unverified until a digest/revision witness is supplied.