### PR TITLE
Validate tesser3takt frame contract

### DIFF
--- a/docs/tesser3takt/README.md
+++ b/docs/tesser3takt/README.md
@@ -102,3 +102,12 @@ Optionally add a future VOIDMAP proposal in a separate explicit GOLD-change step
 Optionally create a later PATH_INTEGRAL_ASSEMBLY_NOTE only after the local cluster is stable.
 
 Optionally link this README from docs/masterindex.md only after explicit approval.
+
+
+## Frame Contract v0.2
+
+The UI frame contract is represented by `ui-app/lib/tesser3takt-frame.ts` and the minimal serializable fixture `ui-app/fixtures/tesser3takt-minimal-frame.json`. The v0.2 contract keeps kenograms as UI-local `kenograms`, derives `collisionProxy` from `leftStateId`, `rightStateId`, and `collisionSemantics: EXACT_STATE_ID`, and makes `boundaryTransitions` first-class frame data.
+
+Each boundary pair must contain exactly one ordered `EXIT` and one `ENTRY`, use unique half IDs per pair, link the entry to the exit via `transformedFrom`, and validate the knight move in the explicitly shared `GLOBAL_REENTRY_LATTICE` coordinate space rather than subtracting unrelated quadrant-local coordinates. Every boundary transition and frame-level witness carries a typed `ProvenanceRef` with source, revision, optional `digest`, explicit `digestStatus`, locator, claim layer, and authority status. An unverified pointer uses `digest: null` plus `digestStatus: UNVERIFIED`; it never uses a hash-looking placeholder.
+
+JSON and transport inputs must enter through `validateTesserTickFrame`. The runtime validator checks the complete serialized shape, requires every transition to name `GLOBAL_REENTRY_LATTICE`, verifies the EXIT/ENTRY pair invariant, rejects a supplied `collisionProxy` that disagrees with the state IDs, and enforces the `digest`/`digestStatus` relation. TypeScript annotations alone are not an input boundary.

--- a/ui-app/README.md
+++ b/ui-app/README.md
@@ -29,7 +29,7 @@ Web-App für die Visualisierung der EntaENGELment-Konzepte (Guard System, VOIDMA
 
 ## Tech Stack
 
-- Next.js 14 (App Router)
+- Next.js 16 (App Router)
 - TypeScript
 - Tailwind CSS
 - React Query (vorbereitet)

--- a/ui-app/fixtures/tesser3takt-minimal-frame.json
+++ b/ui-app/fixtures/tesser3takt-minimal-frame.json
@@ -1,0 +1,61 @@
+{
+  "frameId": "tesser3takt-minimal-v0.2",
+  "collisionSemantics": "EXACT_STATE_ID",
+  "leftStateId": "S4:1234",
+  "rightStateId": "S4:1234",
+  "collisionProxy": true,
+  "kenograms": ["kg-fringe-01", "kg-fringe-02"],
+  "boundaryTransitions": [
+    {
+      "pairId": "bt-001",
+      "half": "EXIT",
+      "stepIndex": 2,
+      "stateId": "S4:1234",
+      "quadrant": "alpha",
+      "coordinateSpace": "GLOBAL_REENTRY_LATTICE",
+      "latticePosition": [1, 1],
+      "provenance": {
+        "kind": "fixture",
+        "source": "ui-app/fixtures/tesser3takt-minimal-frame.json",
+        "revision": "v0.2",
+        "digest": null,
+        "digestStatus": "UNVERIFIED",
+        "locator": "$.boundaryTransitions[0]",
+        "claimLayer": "FIXTURE",
+        "authorityStatus": "repo-local"
+      }
+    },
+    {
+      "pairId": "bt-001",
+      "half": "ENTRY",
+      "stepIndex": 3,
+      "stateId": "S4:2143",
+      "quadrant": "beta",
+      "coordinateSpace": "GLOBAL_REENTRY_LATTICE",
+      "latticePosition": [2, 3],
+      "transformedFrom": "S4:1234",
+      "provenance": {
+        "kind": "fixture",
+        "source": "ui-app/fixtures/tesser3takt-minimal-frame.json",
+        "revision": "v0.2",
+        "digest": null,
+        "digestStatus": "UNVERIFIED",
+        "locator": "$.boundaryTransitions[1]",
+        "claimLayer": "FIXTURE",
+        "authorityStatus": "repo-local"
+      }
+    }
+  ],
+  "provenance": [
+    {
+      "kind": "annex",
+      "source": "docs/tesser3takt/TESSER3TAKT_ASSEMBLY_NAVI_v0_1.md",
+      "revision": "v0.1",
+      "digest": null,
+      "digestStatus": "UNVERIFIED",
+      "locator": "docs/tesser3takt/TESSER3TAKT_ASSEMBLY_NAVI_v0_1.md#boundary-roles",
+      "claimLayer": "MODEL",
+      "authorityStatus": "repo-local"
+    }
+  ]
+}

--- a/ui-app/lib/tesser3takt-frame.ts
+++ b/ui-app/lib/tesser3takt-frame.ts
@@ -1,0 +1,339 @@
+export type CollisionSemantics = 'EXACT_STATE_ID';
+export type BoundaryHalf = 'EXIT' | 'ENTRY';
+export type Quadrant = 'alpha' | 'beta' | 'gamma' | 'delta';
+export type BoundaryCoordinateSpace = 'GLOBAL_REENTRY_LATTICE';
+export type DigestStatus = 'VERIFIED' | 'UNVERIFIED';
+
+export interface ProvenanceRef {
+  kind: 'annex' | 'fixture' | 'calculation' | 'transport';
+  source: string;
+  revision: string;
+  digest: string | null;
+  digestStatus: DigestStatus;
+  locator: string;
+  claimLayer: 'MODEL' | 'SPEC' | 'FIXTURE' | 'RECEIPT';
+  authorityStatus: 'repo-local' | 'external-unverified' | 'derived';
+}
+
+export interface BoundaryTransition {
+  pairId: string;
+  half: BoundaryHalf;
+  stepIndex: number;
+  stateId: string;
+  quadrant: Quadrant;
+  coordinateSpace: BoundaryCoordinateSpace;
+  latticePosition: readonly [number, number];
+  transformedFrom?: string;
+  provenance: ProvenanceRef;
+}
+
+export interface TesserTickFrame {
+  frameId: string;
+  collisionSemantics: CollisionSemantics;
+  leftStateId: string;
+  rightStateId: string;
+  collisionProxy: boolean;
+  kenograms: readonly string[];
+  boundaryTransitions: readonly BoundaryTransition[];
+  provenance: readonly ProvenanceRef[];
+}
+
+export interface BoundaryPairValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface TesserTickFrameValidationResult extends BoundaryPairValidationResult {
+  frame?: TesserTickFrame;
+}
+
+const PROVENANCE_KINDS = new Set<ProvenanceRef['kind']>([
+  'annex',
+  'fixture',
+  'calculation',
+  'transport',
+]);
+const DIGEST_STATUSES = new Set<DigestStatus>(['VERIFIED', 'UNVERIFIED']);
+const CLAIM_LAYERS = new Set<ProvenanceRef['claimLayer']>([
+  'MODEL',
+  'SPEC',
+  'FIXTURE',
+  'RECEIPT',
+]);
+const AUTHORITY_STATUSES = new Set<ProvenanceRef['authorityStatus']>([
+  'repo-local',
+  'external-unverified',
+  'derived',
+]);
+const BOUNDARY_HALVES = new Set<BoundaryHalf>(['EXIT', 'ENTRY']);
+const QUADRANTS = new Set<Quadrant>(['alpha', 'beta', 'gamma', 'delta']);
+
+const KNIGHT_DELTAS = new Set([
+  '1:2',
+  '2:1',
+  '1:-2',
+  '2:-1',
+  '-1:2',
+  '-2:1',
+  '-1:-2',
+  '-2:-1',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateNonEmptyString(
+  record: Record<string, unknown>,
+  field: string,
+  path: string,
+  errors: string[],
+): void {
+  const value = record[field];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    errors.push(`${path}.${field}: expected a non-empty string`);
+  }
+}
+
+function validateProvenanceRef(
+  value: unknown,
+  path: string,
+  errors: string[],
+): value is ProvenanceRef {
+  const errorCount = errors.length;
+  if (!isRecord(value)) {
+    errors.push(`${path}: expected a provenance object`);
+    return false;
+  }
+
+  if (!PROVENANCE_KINDS.has(value.kind as ProvenanceRef['kind'])) {
+    errors.push(`${path}.kind: unsupported provenance kind`);
+  }
+  for (const field of ['source', 'revision', 'locator']) {
+    validateNonEmptyString(value, field, path, errors);
+  }
+  if (!DIGEST_STATUSES.has(value.digestStatus as DigestStatus)) {
+    errors.push(`${path}.digestStatus: expected VERIFIED or UNVERIFIED`);
+  } else if (value.digestStatus === 'VERIFIED') {
+    if (typeof value.digest !== 'string' || value.digest.trim().length === 0) {
+      errors.push(`${path}.digest: VERIFIED provenance requires a non-empty digest`);
+    }
+  } else if (value.digest !== null) {
+    errors.push(`${path}.digest: UNVERIFIED provenance requires digest: null`);
+  }
+  if (!CLAIM_LAYERS.has(value.claimLayer as ProvenanceRef['claimLayer'])) {
+    errors.push(`${path}.claimLayer: unsupported claim layer`);
+  }
+  if (!AUTHORITY_STATUSES.has(value.authorityStatus as ProvenanceRef['authorityStatus'])) {
+    errors.push(`${path}.authorityStatus: unsupported authority status`);
+  }
+
+  return errors.length === errorCount;
+}
+
+function validateBoundaryTransition(
+  value: unknown,
+  path: string,
+  errors: string[],
+): value is BoundaryTransition {
+  const errorCount = errors.length;
+  if (!isRecord(value)) {
+    errors.push(`${path}: expected a boundary transition object`);
+    return false;
+  }
+
+  for (const field of ['pairId', 'stateId']) {
+    validateNonEmptyString(value, field, path, errors);
+  }
+  if (!BOUNDARY_HALVES.has(value.half as BoundaryHalf)) {
+    errors.push(`${path}.half: expected EXIT or ENTRY`);
+  }
+  if (!Number.isInteger(value.stepIndex) || (value.stepIndex as number) < 0) {
+    errors.push(`${path}.stepIndex: expected a non-negative integer`);
+  }
+  if (!QUADRANTS.has(value.quadrant as Quadrant)) {
+    errors.push(`${path}.quadrant: unsupported quadrant`);
+  }
+  if (value.coordinateSpace !== 'GLOBAL_REENTRY_LATTICE') {
+    errors.push(`${path}.coordinateSpace: expected GLOBAL_REENTRY_LATTICE`);
+  }
+  if (
+    !Array.isArray(value.latticePosition) ||
+    value.latticePosition.length !== 2 ||
+    !value.latticePosition.every(Number.isInteger)
+  ) {
+    errors.push(`${path}.latticePosition: expected two integer global coordinates`);
+  }
+  if (
+    value.transformedFrom !== undefined &&
+    (typeof value.transformedFrom !== 'string' || value.transformedFrom.trim().length === 0)
+  ) {
+    errors.push(`${path}.transformedFrom: expected a non-empty state id when present`);
+  }
+  validateProvenanceRef(value.provenance, `${path}.provenance`, errors);
+
+  return errors.length === errorCount;
+}
+
+export function isSlaterCollision(
+  leftStateId: string,
+  rightStateId: string,
+  semantics: CollisionSemantics = 'EXACT_STATE_ID',
+): boolean {
+  if (semantics !== 'EXACT_STATE_ID') {
+    return false;
+  }
+
+  return leftStateId === rightStateId;
+}
+
+export function withDerivedCollisionProxy<T extends Omit<TesserTickFrame, 'collisionProxy'>>(
+  frame: T,
+): T & Pick<TesserTickFrame, 'collisionProxy'> {
+  return {
+    ...frame,
+    collisionProxy: isSlaterCollision(
+      frame.leftStateId,
+      frame.rightStateId,
+      frame.collisionSemantics,
+    ),
+  };
+}
+
+export function validateBoundaryPairs(
+  transitions: readonly BoundaryTransition[],
+): BoundaryPairValidationResult {
+  const errors: string[] = [];
+  const pairs = new Map<string, BoundaryTransition[]>();
+
+  transitions.forEach((transition) => {
+    if (!pairs.has(transition.pairId)) {
+      pairs.set(transition.pairId, []);
+    }
+    pairs.get(transition.pairId)?.push(transition);
+  });
+
+  pairs.forEach((pairTransitions, pairId) => {
+    const exits = pairTransitions.filter((transition) => transition.half === 'EXIT');
+    const entries = pairTransitions.filter((transition) => transition.half === 'ENTRY');
+
+    if (exits.length !== 1 || entries.length !== 1) {
+      errors.push(`${pairId}: expected exactly one EXIT and one ENTRY`);
+      return;
+    }
+
+    const [exit] = exits;
+    const [entry] = entries;
+
+    if (exit.stepIndex >= entry.stepIndex) {
+      errors.push(`${pairId}: EXIT must precede ENTRY`);
+    }
+
+    if (entry.transformedFrom !== exit.stateId) {
+      errors.push(`${pairId}: ENTRY transformedFrom must match EXIT stateId`);
+    }
+
+    if (exit.coordinateSpace !== entry.coordinateSpace) {
+      errors.push(`${pairId}: EXIT and ENTRY must use the same coordinate space`);
+    }
+    if (exit.coordinateSpace !== 'GLOBAL_REENTRY_LATTICE') {
+      errors.push(`${pairId}: EXIT must use GLOBAL_REENTRY_LATTICE`);
+    }
+    if (entry.coordinateSpace !== 'GLOBAL_REENTRY_LATTICE') {
+      errors.push(`${pairId}: ENTRY must use GLOBAL_REENTRY_LATTICE`);
+    }
+    if (
+      exit.coordinateSpace !== entry.coordinateSpace ||
+      exit.coordinateSpace !== 'GLOBAL_REENTRY_LATTICE' ||
+      entry.coordinateSpace !== 'GLOBAL_REENTRY_LATTICE'
+    ) {
+      return;
+    }
+
+    const [exitX, exitY] = exit.latticePosition;
+    const [entryX, entryY] = entry.latticePosition;
+    const delta = `${entryX - exitX}:${entryY - exitY}`;
+    if (!KNIGHT_DELTAS.has(delta)) {
+      errors.push(`${pairId}: EXIT→ENTRY move is not knight-legal in the global lattice`);
+    }
+  });
+
+  const uniqueKeys = new Set<string>();
+  transitions.forEach((transition) => {
+    const key = `${transition.pairId}:${transition.half}`;
+    if (uniqueKeys.has(key)) {
+      errors.push(`${transition.pairId}: duplicate ${transition.half} half`);
+    }
+    uniqueKeys.add(key);
+  });
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function validateTesserTickFrame(input: unknown): TesserTickFrameValidationResult {
+  const errors: string[] = [];
+  if (!isRecord(input)) {
+    return { valid: false, errors: ['$: expected a frame object'] };
+  }
+
+  for (const field of ['frameId', 'leftStateId', 'rightStateId']) {
+    validateNonEmptyString(input, field, '$', errors);
+  }
+  if (input.collisionSemantics !== 'EXACT_STATE_ID') {
+    errors.push('$.collisionSemantics: expected EXACT_STATE_ID');
+  }
+  if (typeof input.collisionProxy !== 'boolean') {
+    errors.push('$.collisionProxy: expected a boolean');
+  } else if (
+    typeof input.leftStateId === 'string' &&
+    typeof input.rightStateId === 'string' &&
+    input.collisionSemantics === 'EXACT_STATE_ID' &&
+    input.collisionProxy !==
+      isSlaterCollision(input.leftStateId, input.rightStateId, input.collisionSemantics)
+  ) {
+    errors.push('$.collisionProxy: value does not match the derived collision state');
+  }
+
+  if (!Array.isArray(input.kenograms)) {
+    errors.push('$.kenograms: expected an array');
+  } else {
+    input.kenograms.forEach((kenogram, index) => {
+      if (typeof kenogram !== 'string' || kenogram.trim().length === 0) {
+        errors.push(`$.kenograms[${index}]: expected a non-empty string`);
+      }
+    });
+  }
+
+  const transitions: BoundaryTransition[] = [];
+  if (!Array.isArray(input.boundaryTransitions)) {
+    errors.push('$.boundaryTransitions: expected an array');
+  } else {
+    input.boundaryTransitions.forEach((transition, index) => {
+      if (
+        validateBoundaryTransition(
+          transition,
+          `$.boundaryTransitions[${index}]`,
+          errors,
+        )
+      ) {
+        transitions.push(transition);
+      }
+    });
+    if (transitions.length === input.boundaryTransitions.length) {
+      errors.push(...validateBoundaryPairs(transitions).errors);
+    }
+  }
+
+  if (!Array.isArray(input.provenance)) {
+    errors.push('$.provenance: expected an array');
+  } else {
+    input.provenance.forEach((provenance, index) => {
+      validateProvenanceRef(provenance, `$.provenance[${index}]`, errors);
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+  return { valid: true, errors, frame: input as unknown as TesserTickFrame };
+}

--- a/ui-app/package.json
+++ b/ui-app/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test test/*.test.mjs"
   },
   "dependencies": {
     "next": "16.2.10",

--- a/ui-app/test/tesser3takt-frame.test.mjs
+++ b/ui-app/test/tesser3takt-frame.test.mjs
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+  isSlaterCollision,
+  validateBoundaryPairs,
+  validateTesserTickFrame,
+  withDerivedCollisionProxy,
+} from '../lib/tesser3takt-frame.ts';
+
+const fixture = JSON.parse(
+  readFileSync(new URL('../fixtures/tesser3takt-minimal-frame.json', import.meta.url), 'utf8'),
+);
+
+const exit = fixture.boundaryTransitions[0];
+const entry = fixture.boundaryTransitions[1];
+
+test('collision proxy uses exact state-id equality in production code', () => {
+  assert.equal(isSlaterCollision('S4:1234', 'S4:1234'), true);
+  assert.equal(isSlaterCollision('S4:1234', 'S4:2143'), false);
+
+  const frame = withDerivedCollisionProxy({
+    ...fixture,
+    leftStateId: 'S4:1234',
+    rightStateId: 'S4:2143',
+  });
+  assert.equal(frame.collisionProxy, false);
+});
+
+test('valid boundary pair uses one global coordinate space and a knight move', () => {
+  assert.deepEqual(validateBoundaryPairs([exit, entry]), { valid: true, errors: [] });
+});
+
+test('the serialized fixture passes full runtime validation', () => {
+  const result = validateTesserTickFrame(fixture);
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.frame, fixture);
+});
+
+test('boundary validation rejects orphan, duplicate, id mismatch, coordinate mismatch, and non-knight transforms', () => {
+  assert.match(
+    validateBoundaryPairs([exit]).errors.join('\n'),
+    /expected exactly one EXIT and one ENTRY/,
+  );
+  assert.match(
+    validateBoundaryPairs([exit, { ...exit }]).errors.join('\n'),
+    /duplicate EXIT/,
+  );
+  assert.match(
+    validateBoundaryPairs([exit, { ...entry, transformedFrom: 'S4:9999' }]).errors.join('\n'),
+    /transformedFrom must match/,
+  );
+  assert.match(
+    validateBoundaryPairs([
+      exit,
+      { ...entry, coordinateSpace: 'OTHER_LOCAL_SPACE' },
+    ]).errors.join('\n'),
+    /same coordinate space/,
+  );
+  assert.match(
+    validateBoundaryPairs([
+      { ...exit, coordinateSpace: 'OTHER_LOCAL_SPACE' },
+      { ...entry, coordinateSpace: 'OTHER_LOCAL_SPACE' },
+    ]).errors.join('\n'),
+    /must use GLOBAL_REENTRY_LATTICE/,
+  );
+  assert.match(
+    validateBoundaryPairs([exit, { ...entry, latticePosition: [2, 2] }]).errors.join('\n'),
+    /not knight-legal in the global lattice/,
+  );
+});
+
+test('unverified provenance uses null digest rather than a hash-looking placeholder', () => {
+  for (const transition of fixture.boundaryTransitions) {
+    assert.equal(transition.provenance.digest, null);
+    assert.equal(transition.provenance.digestStatus, 'UNVERIFIED');
+  }
+  for (const provenance of fixture.provenance) {
+    assert.equal(provenance.digest, null);
+    assert.equal(provenance.digestStatus, 'UNVERIFIED');
+  }
+});
+
+test('runtime validation rejects a supplied collision value that contradicts state ids', () => {
+  const result = validateTesserTickFrame({
+    ...fixture,
+    rightStateId: 'S4:2143',
+    collisionProxy: true,
+  });
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join('\n'), /does not match the derived collision state/);
+});
+
+test('runtime validation enforces digest and digest-status consistency', () => {
+  const verifiedWithoutDigest = {
+    ...fixture.provenance[0],
+    digestStatus: 'VERIFIED',
+    digest: null,
+  };
+  const unverifiedWithDigest = {
+    ...fixture.provenance[0],
+    digestStatus: 'UNVERIFIED',
+    digest: 'sha256:not-a-witness',
+  };
+
+  assert.match(
+    validateTesserTickFrame({ ...fixture, provenance: [verifiedWithoutDigest] }).errors.join(
+      '\n',
+    ),
+    /VERIFIED provenance requires a non-empty digest/,
+  );
+  assert.match(
+    validateTesserTickFrame({ ...fixture, provenance: [unverifiedWithDigest] }).errors.join(
+      '\n',
+    ),
+    /UNVERIFIED provenance requires digest: null/,
+  );
+});
+
+test('runtime validation rejects malformed JSON without throwing', () => {
+  const result = validateTesserTickFrame({
+    ...fixture,
+    boundaryTransitions: [
+      {
+        ...exit,
+        stepIndex: '2',
+        latticePosition: [1],
+        coordinateSpace: 'OTHER_LOCAL_SPACE',
+      },
+      entry,
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.match(result.errors.join('\n'), /stepIndex/);
+  assert.match(result.errors.join('\n'), /latticePosition/);
+  assert.match(result.errors.join('\n'), /GLOBAL_REENTRY_LATTICE/);
+});


### PR DESCRIPTION
### Motivation

Define one UI-local, serializable tesser3TAKT frame contract without promoting ANNEX material or turning model relations into identity claims.

### Changes

- add typed frame, boundary-transition, and provenance contracts
- derive collision only from exact state-id equality
- add `validateTesserTickFrame(unknown)` as the JSON/transport boundary
- require exactly one ordered EXIT/ENTRY pair, canonical `GLOBAL_REENTRY_LATTICE` coordinates, a knight-legal move, and matching `transformedFrom`
- enforce `collisionProxy` consistency and the `digest`/`digestStatus` relation
- add the minimal fixture, runtime counterexamples, and contract documentation

### Verification

- `pnpm --filter entaengelment-ui test` — 8/8 passing
- `pnpm turbo run typecheck lint build` — all tasks passing
- `pnpm audit --audit-level=high` — no known vulnerabilities

Rebased onto the audited dependency baseline from #317.