### PR TITLE
docs(grimm2): add guarded mereotopology intake

### DIFF
--- a/docs/audit/2026-07-22_grimm_mereotopology_intake_validation.md
+++ b/docs/audit/2026-07-22_grimm_mereotopology_intake_validation.md
@@ -1,0 +1,60 @@
+# Grimm-IR Mereotopology Intake Validation
+
+**Date:** 2026-07-22  
+**Status:** `[ANNEX]` `[FACT]`  
+**Scope:** read-only fixture and documentation validation
+
+## Outcome
+
+PASS for ANNEX intake. Runtime promotion remains HOLD.
+
+The bundle adds no UI surface and therefore makes no claim that an actual Grimm-IR view has rendered successfully on a phone. It establishes the content and accessibility contract that such a surface must satisfy.
+
+## Commands
+
+```text
+python tools/validate_grimm_mereotopology_fixtures.py
+PASS: 6 Grimm-IR mereotopology fixtures satisfy the intake invariants
+
+python -m unittest discover -s tests/unit -p 'test_grimm_mereotopology_fixtures.py' -v
+Ran 7 tests in 0.001s
+OK
+
+python -m py_compile tools/validate_grimm_mereotopology_fixtures.py tests/unit/test_grimm_mereotopology_fixtures.py
+PASS (exit 0)
+```
+
+## Validation matrix
+
+| Gate | Result | Evidence / limit |
+|---|---|---|
+| six qualitative relations | PASS | exactly one fixture each for `DC`, `EC`, `PO`, `TPP`, `NTPP`, and `EQ` |
+| collision semantics | PASS | `PROJECTED`, `OVER`, `UNDER`, and `TOUCH` fixtures are non-colliding; only the explicit equal-State-ID frame witness is true |
+| production boundary | PASS | Grimm-IR may reference `transitionPairId` but cannot replace frame validation |
+| plain language | PASS | every fixture has a short German reading, guard, and reentry question |
+| reader reversibility | PASS | every fixture exposes `ACCEPT`, `REVISE`, `REJECT`, and `SILENCE` |
+| colorless reading | PASS at contract level | relation label, line pattern, arrow, and static fallback remain; color is never required for meaning |
+| reduced motion | PASS at contract level | motion is never required for meaning; all fixtures specify a static fallback |
+| protected provenance | PASS | protected origin has no source pointer and explicitly forbids public reconstruction |
+| 320 CSS-pixel content order | PASS at contract level | minimum width and deterministic narrow reading order are validated |
+| actual 320 CSS-pixel Grimm rendering | HOLD | no Grimm-IR runtime surface exists in this change; screenshot and interaction inspection are required before runtime promotion |
+
+## Counterexample check
+
+The test suite mutates the projected `DC` fixture to request `collisionProxy: true`. The validator rejects it because screen-space projection is not `EXACT_STATE_ID` evidence.
+
+## Repository boundary
+
+This change is limited to:
+
+- `docs/narratives/grimm2/`;
+- a local pointer in `docs/tesser3takt/README.md`;
+- a read-only validator under `tools/`;
+- unit tests under `tests/unit/`;
+- this audit note.
+
+It does not modify `docs/masterindex.md`, `VOIDMAP.yml`, `index/`, `policies/`, `data/receipts/`, UI runtime code, persistence, telemetry, or guard state.
+
+## Promotion condition
+
+Before any runtime promotion, implement the smallest read-only Grimm edge view and inspect it at 320 CSS pixels with color removed and reduced motion enabled. The visual result must preserve relation, endpoints, direction, guard, reentry question, provenance visibility, and all four reader actions.

--- a/docs/audit/2026-07-22_grimm_mereotopology_intake_validation.md
+++ b/docs/audit/2026-07-22_grimm_mereotopology_intake_validation.md
@@ -22,6 +22,12 @@ OK
 
 python -m py_compile tools/validate_grimm_mereotopology_fixtures.py tests/unit/test_grimm_mereotopology_fixtures.py
 PASS (exit 0)
+
+ruff check tools/validate_grimm_mereotopology_fixtures.py tests/unit/test_grimm_mereotopology_fixtures.py
+All checks passed!
+
+black --check tools/validate_grimm_mereotopology_fixtures.py tests/unit/test_grimm_mereotopology_fixtures.py
+2 files would be left unchanged.
 ```
 
 ## Validation matrix

--- a/docs/audit/2026-07-22_grimm_mereotopology_intake_validation.md
+++ b/docs/audit/2026-07-22_grimm_mereotopology_intake_validation.md
@@ -5,12 +5,13 @@
 **Status:** `[ANNEX]` `[FACT]`  
 **Scope:** read-only fixture and documentation validation  
 **Input snapshot:** PR #319 head `23b72e8`, reconciled with `main@586fc7a`
+**Validated code tree:** `f9e56c3`
 
 ## Outcome
 
-The hardened ANNEX intake candidate passes the targeted local validator, negative mutation suite, bytecode compilation, Ruff, and Black checks listed below.
+The committed ANNEX intake code tree `f9e56c3` passes the targeted local validator, negative mutation suite, bytecode compilation, Ruff, Black, full core verifier, governance verifier, and all seven GitHub pull-request workflows.
 
-PR merge and runtime promotion remain HOLD until the candidate is committed, GitHub CI completes on that exact remote head, and a human confirms the content-level protected-origin boundary. No Grimm-IR runtime surface exists in this change, so no phone rendering or interaction claim is made.
+PR merge remains HOLD until a human confirms the content-level protected-origin boundary and re-reviews the remaining open threads. Runtime promotion remains HOLD. No Grimm-IR runtime surface exists in this change, so no phone rendering or interaction claim is made.
 
 ## Commands
 
@@ -42,9 +43,13 @@ make verify-governance
 14 workflow(s) meet the posture contract
 22 VOIDs in sync between VOIDMAP.yml and UI mirror
 Governance membrane checked
+
+GitHub workflows on f9e56c3
+CI Pipeline, Policy Lint, Metatron Guard, Smoke Tests, Tests,
+DeepJump CI, and Python Quality: success
 ```
 
-`make verify-js` was attempted with a frozen lockfile and a writable temporary pnpm/XDG store. Installation stopped at pnpm's `ERR_PNPM_IGNORED_BUILDS` for `electron-winstaller@5.4.0` and `unrs-resolver@1.12.2`. The same failure reproduces on an unmodified detached `main@586fc7a` worktree, so it is recorded as a pre-existing JS-workspace/environment HOLD rather than a PASS or a regression caused by this Python/docs patch. GitHub workflow results on the committed head remain the remote integration receipt.
+`make verify-js` was attempted with a frozen lockfile and a writable temporary pnpm/XDG store. Installation stopped at pnpm's `ERR_PNPM_IGNORED_BUILDS` for `electron-winstaller@5.4.0` and `unrs-resolver@1.12.2`. The same failure reproduces on an unmodified detached `main@586fc7a` worktree, so it is recorded as a pre-existing JS-workspace/environment HOLD rather than a PASS or a regression caused by this Python/docs patch. The seven successful GitHub workflows on `f9e56c3` are the remote integration receipt for the validated code tree.
 
 ## Validation matrix
 

--- a/docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md
+++ b/docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md
@@ -1,0 +1,163 @@
+# Grimm-IR Mereotopology Intake v0.1
+
+**Status:** `[ANNEX]` `[SPEC-WIP]` `[ROSETTA]`  
+**Date:** 2026-07-22  
+**Scope:** local intake note; no canon promotion
+
+## 1. Purpose
+
+This note records the useful remainder of the Grimm Narrativ 2.0 discussion as a guarded, testable edge grammar. It is a sidecar between Grimm-IR and the tesser3TAKT Frame Contract v0.2, not a replacement for either contract.
+
+The central distinction is:
+
+> A projected crossing is not automatically a contact, an overlap, an identity, or a collision.
+
+Layout may stretch, rotate, reorder, or flatten a scene. The relation, endpoints, direction, guard, reentry question, and provenance must survive those transformations.
+
+## 2. Non-goals
+
+This intake does not:
+
+- assert identity between mythology, private experience, biology, chemistry, mathematics, or physics;
+- derive `collisionProxy` from color, proximity, narrative equivalence, or a screen-space crossing;
+- reconstruct protected personal material;
+- change `TesserTickFrame`, `BoundaryTransition`, or their validation rules;
+- update `docs/masterindex.md`, `VOIDMAP.yml`, policies, receipts, or runtime code;
+- create a parallel source of truth for tesser3TAKT.
+
+## 3. Minimal Grimm-IR shape
+
+The following is an intake vocabulary, not yet a runtime TypeScript contract.
+
+```ts
+type GrimmIRRole =
+  | 'SOURCE'
+  | 'MOTIF'
+  | 'OPERATOR'
+  | 'BOUNDARY'
+  | 'REENTRY'
+  | 'READER';
+
+type MereoRelation = 'DC' | 'EC' | 'PO' | 'TPP' | 'NTPP' | 'EQ';
+type EdgeDirection = 'NONE' | 'FORWARD' | 'REVERSE' | 'BIDIRECTIONAL';
+type CrossingStatus =
+  | 'PROJECTED'
+  | 'OVER'
+  | 'UNDER'
+  | 'TOUCH'
+  | 'EXACT_STATE_ID';
+
+interface GrimmSourceRef {
+  sourceForm: string;
+  sourcePointer: string | null;
+  authorityStatus: 'repo-local' | 'external-unverified' | 'derived';
+  sourceVisibility: 'public-safe' | 'protected-origin';
+}
+
+interface GrimmIRNode {
+  nodeId: string;
+  role: GrimmIRRole;
+  label: string;
+  claimLayer: string;
+  provenance: GrimmSourceRef;
+}
+
+interface GrimmIREdge {
+  edgeId: string;
+  sourceNodeId: string;
+  targetNodeId: string;
+  relation: MereoRelation;
+  direction: EdgeDirection;
+  crossing: CrossingStatus;
+  guard: string;
+  reentryQuestion: string;
+  transitionPairId?: string;
+}
+```
+
+`GrimmSourceRef` is deliberately separate from the frame-level `ProvenanceRef`. In particular, `protected-origin` describes disclosure handling; it is not a new frame authority status.
+
+## 4. Mereotopological edge grammar
+
+| Code | Reading | Required distinction |
+|---|---|---|
+| `DC` | disconnected | no contact and no shared interior |
+| `EC` | externally connected | boundary contact without shared interior |
+| `PO` | partial overlap | shared interior while both retain a remainder |
+| `TPP` | tangential proper part | contained and touching the container boundary |
+| `NTPP` | non-tangential proper part | contained without touching the container boundary |
+| `EQ` | equal region/state description | narrative equality alone is not a collision witness |
+
+Crossing status is orthogonal to the relation:
+
+- `PROJECTED`, `OVER`, `UNDER`, and `TOUCH` are view or scene facts. They never set `collisionProxy`.
+- `EXACT_STATE_ID` is permitted only when the frame provides equal left/right state IDs under `collisionSemantics: EXACT_STATE_ID`.
+- A Grimm-IR edge with `relation: EQ` but without the exact frame witness remains non-colliding.
+
+An optional `transitionPairId` may point to `BoundaryTransition.pairId`. The frame owns pair validation, ordering, transformed-state checks, lattice checks, provenance checks, and collision semantics. Grimm-IR cannot overwrite them.
+
+## 5. Orthogonal visual channels
+
+Meaning must remain recoverable when color and motion are removed.
+
+| Channel | Carries | Must not carry alone |
+|---|---|---|
+| line pattern | mereotopological relation | truth or authority |
+| text label | explicit relation code and plain-language reading | decorative mood |
+| arrow | direction | relation class |
+| color | claim/translation layer | identity, collision, or validity |
+| opacity | provenance availability/depth | certainty |
+| crossing marker | projection/over/under/touch/exact-witness status | contact by appearance |
+
+Every edge therefore has a relation label, line pattern, direction marker, static fallback, guard, and reentry question. Color and animation may enrich the view but are not required to read it.
+
+## 6. Reader membrane
+
+The reader remains an active boundary, not a passive target. Each offered relation supports four reversible actions:
+
+- `ACCEPT` — keep the proposed edge for the current reading;
+- `REVISE` — change its relation, wording, or provenance link;
+- `REJECT` — remove the proposed edge from the current reading;
+- `SILENCE` — leave the edge uncommitted without forcing a decision.
+
+These actions do not diagnose the reader, infer private states, or promote a claim. At narrow width the reading order is fixed as title, relation, endpoints, guard, and reentry question.
+
+## 7. Protected origins
+
+Protected personal material may contribute only a non-reconstructable structural note. The public form records that a boundary, detour, or translation pressure existed; it does not store identifying events, names, quotations, or a reverse path to the origin.
+
+For `sourceVisibility: protected-origin`, `publicReconstructionAllowed` must be `false` in fixtures and later implementations.
+
+## 8. Limited motif roles
+
+| Motif | Limited role | Guard / non-claim |
+|---|---|---|
+| Förster Hörst | listener and translator at the forest boundary | no authority over another person's inner state |
+| Wood Wide Web | distributed-connection motif | no proof of intention, consciousness, or shared qualia |
+| spore / mycelium | packet and substrate image | not a biological identity claim for software messages |
+| gap junction | selective biological seam | not equivalent to a graph edge, mycorrhiza, or narrative link |
+| toroidal garland | phase-sequence image | no quantum-spin assertion |
+| absorber inertia | reversible scene memory | no physical continuum between Slater and Pauli |
+| cone → lens → jet → Wheeler envelope | scene grammar for direction, wrapping, load, and reentry | Bernoulli and Coandă remain marked metaphors unless independently modelled |
+| autopoiesis / qualia | relational description of self-maintaining interpretation | no transfer, measurement, or equivalence of experience |
+
+Each motif remains subject to its source form, limited role, guard, and reentry question.
+
+## 9. Fixtures and promotion gate
+
+The companion fixture bundle contains exactly six qualitative counterexamples, one for each relation. The read-only validator checks:
+
+1. complete relation coverage;
+2. collision isolation to an exact frame witness;
+3. non-reconstructability of protected origins;
+4. plain-language guards and reentry questions;
+5. colorless and static fallbacks;
+6. the four reader actions and a 320 CSS-pixel content contract.
+
+If a proposed edge type changes neither validation, reader rollback, nor provenance clarity, it is decoration and is not promoted.
+
+Runtime promotion remains blocked until the fixtures pass and an actual Grimm-IR surface has been inspected at 320 CSS pixels with color removed and reduced motion enabled. This ANNEX introduces no such surface.
+
+## 10. Reentry question
+
+Which single relation or reader action would a future implementation make measurably clearer, without converting metaphor into evidence or screen-space overlap into collision?

--- a/docs/narratives/grimm2/fixtures/mereotopology_edge_fixtures_v0_1.json
+++ b/docs/narratives/grimm2/fixtures/mereotopology_edge_fixtures_v0_1.json
@@ -1,0 +1,262 @@
+{
+  "schemaVersion": "0.1",
+  "status": "[ANNEX]",
+  "claimLayer": "[SPEC-WIP]",
+  "purpose": "Qualitative counterexamples for Grimm-IR edge relations and the tesser3TAKT collision boundary.",
+  "invariants": {
+    "relationSet": ["DC", "EC", "PO", "TPP", "NTPP", "EQ"],
+    "collisionSource": "EXACT_STATE_ID",
+    "colorCarriesMeaning": false,
+    "motionCarriesMeaning": false,
+    "readerActions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+    "minimumViewportCssPx": 320
+  },
+  "fixtures": [
+    {
+      "id": "horizon-projection-no-contact",
+      "title": "Horizontprojektion ohne Kontakt",
+      "relation": "DC",
+      "crossing": "PROJECTED",
+      "direction": "NONE",
+      "sourceNodeId": "line-observer-a",
+      "targetNodeId": "line-observer-b",
+      "plainLanguage": "Die Kanten liegen nur in der Projektion übereinander; ihre Bereiche bleiben getrennt.",
+      "guard": "Bildschirmnähe oder perspektivisches Kreuzen erzeugt weder Kontakt noch Identität.",
+      "reentryQuestion": "Bleiben die Bereiche bei einem Perspektivwechsel weiterhin getrennt?",
+      "claimLayer": "[MODEL]",
+      "provenance": {
+        "sourceForm": "conversation-derived edge distinction",
+        "sourcePointer": "docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md#4-mereotopological-edge-grammar",
+        "authorityStatus": "derived",
+        "sourceVisibility": "public-safe",
+        "publicReconstructionAllowed": true
+      },
+      "visualEncoding": {
+        "color": "claim-layer-neutral",
+        "linePattern": "long-gap",
+        "relationLabel": "DC — getrennt",
+        "arrow": "none",
+        "staticFallback": "Two labelled lines cross in projection with a small bridge break at the crossing.",
+        "requiresColorForMeaning": false,
+        "requiresMotionForMeaning": false
+      },
+      "reader": {
+        "actions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+        "orderAtNarrowWidth": ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+      },
+      "frameBridge": {
+        "transitionPairId": null,
+        "collisionSemantics": null,
+        "leftStateId": null,
+        "rightStateId": null,
+        "expectedCollisionProxy": false,
+        "disposition": "NO_FRAME_EFFECT"
+      }
+    },
+    {
+      "id": "shared-boundary-no-interior",
+      "title": "Gemeinsame Grenze ohne gemeinsamen Innenraum",
+      "relation": "EC",
+      "crossing": "TOUCH",
+      "direction": "BIDIRECTIONAL",
+      "sourceNodeId": "reader-membrane",
+      "targetNodeId": "offered-scene",
+      "plainLanguage": "Die beiden Bereiche berühren dieselbe Grenze, teilen aber keinen Innenraum.",
+      "guard": "Berührung erlaubt Austauschfragen, aber keine Verschmelzung der Bereiche.",
+      "reentryQuestion": "Ist nur die Grenze gemeinsam oder auch ein Teil des Innenraums?",
+      "claimLayer": "[MODEL]",
+      "provenance": {
+        "sourceForm": "conversation-derived boundary motif",
+        "sourcePointer": "docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md#6-reader-membrane",
+        "authorityStatus": "derived",
+        "sourceVisibility": "public-safe",
+        "publicReconstructionAllowed": true
+      },
+      "visualEncoding": {
+        "color": "claim-layer-neutral",
+        "linePattern": "paired-dot",
+        "relationLabel": "EC — Randberührung",
+        "arrow": "double-ended",
+        "staticFallback": "Two labelled regions meet at one marked boundary point without an overlap fill.",
+        "requiresColorForMeaning": false,
+        "requiresMotionForMeaning": false
+      },
+      "reader": {
+        "actions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+        "orderAtNarrowWidth": ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+      },
+      "frameBridge": {
+        "transitionPairId": null,
+        "collisionSemantics": null,
+        "leftStateId": null,
+        "rightStateId": null,
+        "expectedCollisionProxy": false,
+        "disposition": "NO_FRAME_EFFECT"
+      }
+    },
+    {
+      "id": "partial-overlap-with-remainders",
+      "title": "Teilüberlappung mit Resten",
+      "relation": "PO",
+      "crossing": "OVER",
+      "direction": "FORWARD",
+      "sourceNodeId": "mythic-vocabulary",
+      "targetNodeId": "technical-vocabulary",
+      "plainLanguage": "Die Bereiche überlappen teilweise und behalten getrennte Reste.",
+      "guard": "Eine gemeinsame Übersetzungszone beweist keine Gleichheit der Vokabulare.",
+      "reentryQuestion": "Welche Anteile bleiben auf beiden Seiten außerhalb der Überlappung?",
+      "claimLayer": "[ROSETTA]",
+      "provenance": {
+        "sourceForm": "conversation-derived translation zone",
+        "sourcePointer": "docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md#5-orthogonal-visual-channels",
+        "authorityStatus": "derived",
+        "sourceVisibility": "public-safe",
+        "publicReconstructionAllowed": true
+      },
+      "visualEncoding": {
+        "color": "translation-layer",
+        "linePattern": "dash-dot",
+        "relationLabel": "PO — Teilüberlappung",
+        "arrow": "forward",
+        "staticFallback": "Two labelled regions share a hatched lens while each retains an unhatched remainder.",
+        "requiresColorForMeaning": false,
+        "requiresMotionForMeaning": false
+      },
+      "reader": {
+        "actions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+        "orderAtNarrowWidth": ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+      },
+      "frameBridge": {
+        "transitionPairId": null,
+        "collisionSemantics": null,
+        "leftStateId": null,
+        "rightStateId": null,
+        "expectedCollisionProxy": false,
+        "disposition": "NO_FRAME_EFFECT"
+      }
+    },
+    {
+      "id": "reader-scene-tangential-containment",
+      "title": "Rücknehmbare Szene an der Reader-Membran",
+      "relation": "TPP",
+      "crossing": "OVER",
+      "direction": "FORWARD",
+      "sourceNodeId": "offered-scene",
+      "targetNodeId": "reader-membrane",
+      "plainLanguage": "Die angebotene Szene liegt tangential innerhalb der Reader-Membran und bleibt rücknehmbar.",
+      "guard": "Die Membran begrenzt die Szene; sie diagnostiziert oder verpflichtet die lesende Person nicht.",
+      "reentryQuestion": "Kann die Szene revidiert oder abgelehnt werden, ohne die Membran zu verändern?",
+      "claimLayer": "[SPEC-WIP]",
+      "provenance": {
+        "sourceForm": "conversation-derived reader action model",
+        "sourcePointer": "docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md#6-reader-membrane",
+        "authorityStatus": "derived",
+        "sourceVisibility": "public-safe",
+        "publicReconstructionAllowed": true
+      },
+      "visualEncoding": {
+        "color": "reader-boundary",
+        "linePattern": "solid-with-tangent-mark",
+        "relationLabel": "TPP — innen mit Randkontakt",
+        "arrow": "forward",
+        "staticFallback": "A labelled scene sits inside a labelled membrane and touches it at one marked tangent.",
+        "requiresColorForMeaning": false,
+        "requiresMotionForMeaning": false
+      },
+      "reader": {
+        "actions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+        "orderAtNarrowWidth": ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+      },
+      "frameBridge": {
+        "transitionPairId": null,
+        "collisionSemantics": null,
+        "leftStateId": null,
+        "rightStateId": null,
+        "expectedCollisionProxy": false,
+        "disposition": "NO_FRAME_EFFECT"
+      }
+    },
+    {
+      "id": "protected-origin-inside-privacy-envelope",
+      "title": "Geschützte Herkunft in der Privacy-Hülle",
+      "relation": "NTPP",
+      "crossing": "UNDER",
+      "direction": "REVERSE",
+      "sourceNodeId": "protected-origin-note",
+      "targetNodeId": "privacy-envelope",
+      "plainLanguage": "Der Herkunftshinweis liegt geschützt innerhalb der Privacy-Hülle und wird öffentlich nicht rekonstruiert.",
+      "guard": "Nur die nicht rückrechenbare Struktur darf den öffentlichen Rand erreichen.",
+      "reentryQuestion": "Lässt sich aus der öffentlichen Form noch eine Person oder ein Ereignis rekonstruieren?",
+      "claimLayer": "[CONTEXT]",
+      "provenance": {
+        "sourceForm": "protected personal origin reduced to a structural note",
+        "sourcePointer": null,
+        "authorityStatus": "derived",
+        "sourceVisibility": "protected-origin",
+        "publicReconstructionAllowed": false
+      },
+      "visualEncoding": {
+        "color": "protected-context",
+        "linePattern": "double-boundary",
+        "relationLabel": "NTPP — geschützt innen",
+        "arrow": "reverse-to-envelope",
+        "staticFallback": "An anonymous structural note is fully enclosed by a double-lined privacy boundary with no trace-back path.",
+        "requiresColorForMeaning": false,
+        "requiresMotionForMeaning": false
+      },
+      "reader": {
+        "actions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+        "orderAtNarrowWidth": ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+      },
+      "frameBridge": {
+        "transitionPairId": null,
+        "collisionSemantics": null,
+        "leftStateId": null,
+        "rightStateId": null,
+        "expectedCollisionProxy": false,
+        "disposition": "NO_FRAME_EFFECT"
+      }
+    },
+    {
+      "id": "exact-state-id-frame-witness",
+      "title": "Exakter State-ID-Witness des Frames",
+      "relation": "EQ",
+      "crossing": "EXACT_STATE_ID",
+      "direction": "BIDIRECTIONAL",
+      "sourceNodeId": "left-frame-state",
+      "targetNodeId": "right-frame-state",
+      "plainLanguage": "Nur der Frame bestätigt auf beiden Seiten exakt dieselbe State-ID; deshalb ist der Kollisionsproxy wahr.",
+      "guard": "Narrative Gleichheit, ähnliche Farbe oder sichtbare Überlagerung reichen dafür nicht aus.",
+      "reentryQuestion": "Sind Semantik und beide State-IDs im Frame weiterhin exakt gleich?",
+      "claimLayer": "[SPEC]",
+      "provenance": {
+        "sourceForm": "tesser3TAKT Frame Contract v0.2 counterexample",
+        "sourcePointer": "ui-app/lib/tesser3takt-frame.ts",
+        "authorityStatus": "repo-local",
+        "sourceVisibility": "public-safe",
+        "publicReconstructionAllowed": true
+      },
+      "visualEncoding": {
+        "color": "frame-witness",
+        "linePattern": "double-solid",
+        "relationLabel": "EQ + EXACT_STATE_ID — Frame-Witness",
+        "arrow": "double-ended",
+        "staticFallback": "Both labelled endpoints print the same full State-ID beside an explicit EXACT_STATE_ID badge.",
+        "requiresColorForMeaning": false,
+        "requiresMotionForMeaning": false
+      },
+      "reader": {
+        "actions": ["ACCEPT", "REVISE", "REJECT", "SILENCE"],
+        "orderAtNarrowWidth": ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+      },
+      "frameBridge": {
+        "transitionPairId": "bt-fixture-exact-001",
+        "collisionSemantics": "EXACT_STATE_ID",
+        "leftStateId": "S4:1234",
+        "rightStateId": "S4:1234",
+        "expectedCollisionProxy": true,
+        "disposition": "FRAME_WITNESS_REQUIRED"
+      }
+    }
+  ]
+}

--- a/docs/tesser3takt/README.md
+++ b/docs/tesser3takt/README.md
@@ -112,3 +112,6 @@ Each boundary pair must contain exactly one ordered `EXIT` and one `ENTRY`, use 
 
 JSON and transport inputs must enter through `validateTesserTickFrame`. The runtime validator checks the complete serialized shape, requires every transition to name `GLOBAL_REENTRY_LATTICE`, verifies the EXIT/ENTRY pair invariant, rejects a supplied `collisionProxy` that disagrees with the state IDs, and enforces the `digest`/`digestStatus` relation. TypeScript annotations alone are not an input boundary.
 
+## Related Intake
+
+`docs/narratives/grimm2/GRIMM_IR_MEREOTOPOLOGY_INTAKE_v0_1.md` is an optional Grimm-IR crosswalk for projected crossings, mereotopological relations, reader actions, and protected provenance. It is not a dependency of Frame Contract v0.2 and cannot alter frame validation or collision semantics.

--- a/tests/unit/test_grimm_mereotopology_fixtures.py
+++ b/tests/unit/test_grimm_mereotopology_fixtures.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from tools.validate_grimm_mereotopology_fixtures import (  # noqa: E402
+    READER_ACTIONS,
+    RELATIONS,
+    load_bundle,
+    validate_bundle,
+)
+
+
+class GrimmMereotopologyFixtureTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.bundle = load_bundle()
+
+    def test_bundle_satisfies_all_intake_invariants(self) -> None:
+        self.assertEqual(validate_bundle(self.bundle), [])
+
+    def test_six_fixtures_cover_each_relation_exactly_once(self) -> None:
+        relations = [fixture["relation"] for fixture in self.bundle["fixtures"]]
+        self.assertEqual(len(relations), 6)
+        self.assertEqual(set(relations), RELATIONS)
+        self.assertEqual(len(relations), len(set(relations)))
+
+    def test_non_exact_crossings_never_create_collision(self) -> None:
+        for fixture in self.bundle["fixtures"]:
+            if fixture["crossing"] == "EXACT_STATE_ID":
+                continue
+            with self.subTest(fixture=fixture["id"]):
+                self.assertFalse(fixture["frameBridge"]["expectedCollisionProxy"])
+                self.assertEqual(fixture["frameBridge"]["disposition"], "NO_FRAME_EFFECT")
+
+    def test_exact_collision_has_frame_owned_witness(self) -> None:
+        exact = [
+            fixture
+            for fixture in self.bundle["fixtures"]
+            if fixture["crossing"] == "EXACT_STATE_ID"
+        ]
+        self.assertEqual(len(exact), 1)
+        bridge = exact[0]["frameBridge"]
+        self.assertEqual(exact[0]["relation"], "EQ")
+        self.assertEqual(bridge["collisionSemantics"], "EXACT_STATE_ID")
+        self.assertEqual(bridge["leftStateId"], bridge["rightStateId"])
+        self.assertTrue(bridge["expectedCollisionProxy"])
+
+    def test_reader_colorless_motionless_and_narrow_width_contracts(self) -> None:
+        self.assertGreaterEqual(self.bundle["invariants"]["minimumViewportCssPx"], 320)
+        for fixture in self.bundle["fixtures"]:
+            with self.subTest(fixture=fixture["id"]):
+                self.assertEqual(set(fixture["reader"]["actions"]), READER_ACTIONS)
+                self.assertFalse(fixture["visualEncoding"]["requiresColorForMeaning"])
+                self.assertFalse(fixture["visualEncoding"]["requiresMotionForMeaning"])
+                self.assertTrue(fixture["visualEncoding"]["relationLabel"])
+                self.assertTrue(fixture["visualEncoding"]["linePattern"])
+                self.assertTrue(fixture["visualEncoding"]["staticFallback"])
+
+    def test_validator_rejects_collision_from_projected_crossing(self) -> None:
+        malformed = copy.deepcopy(self.bundle)
+        projected = next(
+            fixture for fixture in malformed["fixtures"] if fixture["crossing"] == "PROJECTED"
+        )
+        projected["frameBridge"]["expectedCollisionProxy"] = True
+        errors = validate_bundle(malformed)
+        self.assertTrue(any("only EXACT_STATE_ID" in error for error in errors))
+
+    def test_protected_origin_is_not_publicly_reconstructable(self) -> None:
+        protected = next(
+            fixture
+            for fixture in self.bundle["fixtures"]
+            if fixture["provenance"]["sourceVisibility"] == "protected-origin"
+        )
+        self.assertIsNone(protected["provenance"]["sourcePointer"])
+        self.assertFalse(protected["provenance"]["publicReconstructionAllowed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_grimm_mereotopology_fixtures.py
+++ b/tests/unit/test_grimm_mereotopology_fixtures.py
@@ -5,7 +5,6 @@ import sys
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
@@ -37,9 +36,7 @@ class GrimmMereotopologyFixtureTests(unittest.TestCase):
                 continue
             with self.subTest(fixture=fixture["id"]):
                 self.assertFalse(fixture["frameBridge"]["expectedCollisionProxy"])
-                self.assertEqual(
-                    fixture["frameBridge"]["disposition"], "NO_FRAME_EFFECT"
-                )
+                self.assertEqual(fixture["frameBridge"]["disposition"], "NO_FRAME_EFFECT")
 
     def test_exact_collision_has_frame_owned_witness(self) -> None:
         exact = [
@@ -68,9 +65,7 @@ class GrimmMereotopologyFixtureTests(unittest.TestCase):
     def test_validator_rejects_collision_from_projected_crossing(self) -> None:
         malformed = copy.deepcopy(self.bundle)
         projected = next(
-            fixture
-            for fixture in malformed["fixtures"]
-            if fixture["crossing"] == "PROJECTED"
+            fixture for fixture in malformed["fixtures"] if fixture["crossing"] == "PROJECTED"
         )
         projected["frameBridge"]["expectedCollisionProxy"] = True
         errors = validate_bundle(malformed)

--- a/tests/unit/test_grimm_mereotopology_fixtures.py
+++ b/tests/unit/test_grimm_mereotopology_fixtures.py
@@ -37,7 +37,9 @@ class GrimmMereotopologyFixtureTests(unittest.TestCase):
                 continue
             with self.subTest(fixture=fixture["id"]):
                 self.assertFalse(fixture["frameBridge"]["expectedCollisionProxy"])
-                self.assertEqual(fixture["frameBridge"]["disposition"], "NO_FRAME_EFFECT")
+                self.assertEqual(
+                    fixture["frameBridge"]["disposition"], "NO_FRAME_EFFECT"
+                )
 
     def test_exact_collision_has_frame_owned_witness(self) -> None:
         exact = [
@@ -66,7 +68,9 @@ class GrimmMereotopologyFixtureTests(unittest.TestCase):
     def test_validator_rejects_collision_from_projected_crossing(self) -> None:
         malformed = copy.deepcopy(self.bundle)
         projected = next(
-            fixture for fixture in malformed["fixtures"] if fixture["crossing"] == "PROJECTED"
+            fixture
+            for fixture in malformed["fixtures"]
+            if fixture["crossing"] == "PROJECTED"
         )
         projected["frameBridge"]["expectedCollisionProxy"] = True
         errors = validate_bundle(malformed)

--- a/tools/validate_grimm_mereotopology_fixtures.py
+++ b/tools/validate_grimm_mereotopology_fixtures.py
@@ -61,7 +61,9 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
     if invariants.get("motionCarriesMeaning") is not False:
         errors.append("bundle: motionCarriesMeaning must be false")
     if set(invariants.get("readerActions", [])) != READER_ACTIONS:
-        errors.append("bundle: readerActions must contain ACCEPT, REVISE, REJECT, and SILENCE")
+        errors.append(
+            "bundle: readerActions must contain ACCEPT, REVISE, REJECT, and SILENCE"
+        )
     viewport = invariants.get("minimumViewportCssPx")
     if not isinstance(viewport, int) or isinstance(viewport, bool) or viewport < 320:
         errors.append("bundle: minimumViewportCssPx must be an integer of at least 320")
@@ -124,7 +126,9 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
             for field in ("sourceForm", "authorityStatus", "sourceVisibility"):
                 value = provenance.get(field)
                 if not isinstance(value, str) or not value.strip():
-                    errors.append(f"{prefix}: provenance.{field} must be a non-empty string")
+                    errors.append(
+                        f"{prefix}: provenance.{field} must be a non-empty string"
+                    )
             if provenance.get("sourceVisibility") == "protected-origin":
                 if provenance.get("publicReconstructionAllowed") is not False:
                     errors.append(
@@ -138,7 +142,9 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
             for field in ("linePattern", "relationLabel", "arrow", "staticFallback"):
                 value = visual.get(field)
                 if not isinstance(value, str) or not value.strip():
-                    errors.append(f"{prefix}: visualEncoding.{field} must be a non-empty string")
+                    errors.append(
+                        f"{prefix}: visualEncoding.{field} must be a non-empty string"
+                    )
             if visual.get("requiresColorForMeaning") is not False:
                 errors.append(f"{prefix}: color may not be required for meaning")
             if visual.get("requiresMotionForMeaning") is not False:
@@ -164,30 +170,44 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
 
         if crossing != "EXACT_STATE_ID":
             if expected_collision is not False:
-                errors.append(f"{prefix}: only EXACT_STATE_ID may produce collisionProxy=true")
+                errors.append(
+                    f"{prefix}: only EXACT_STATE_ID may produce collisionProxy=true"
+                )
             if frame_bridge.get("disposition") != "NO_FRAME_EFFECT":
-                errors.append(f"{prefix}: non-exact crossings must have NO_FRAME_EFFECT")
+                errors.append(
+                    f"{prefix}: non-exact crossings must have NO_FRAME_EFFECT"
+                )
         else:
             exact_witness_count += 1
             if relation != "EQ":
                 errors.append(f"{prefix}: EXACT_STATE_ID requires relation EQ")
             if frame_bridge.get("collisionSemantics") != "EXACT_STATE_ID":
-                errors.append(f"{prefix}: exact witness requires EXACT_STATE_ID semantics")
+                errors.append(
+                    f"{prefix}: exact witness requires EXACT_STATE_ID semantics"
+                )
             left = frame_bridge.get("leftStateId")
             right = frame_bridge.get("rightStateId")
             if not isinstance(left, str) or not left or left != right:
-                errors.append(f"{prefix}: exact witness requires equal non-empty state IDs")
+                errors.append(
+                    f"{prefix}: exact witness requires equal non-empty state IDs"
+                )
             pair_id = frame_bridge.get("transitionPairId")
             if not isinstance(pair_id, str) or not pair_id.strip():
                 errors.append(f"{prefix}: exact witness requires transitionPairId")
             if expected_collision is not True:
-                errors.append(f"{prefix}: valid exact witness must expect collisionProxy=true")
+                errors.append(
+                    f"{prefix}: valid exact witness must expect collisionProxy=true"
+                )
             if frame_bridge.get("disposition") != "FRAME_WITNESS_REQUIRED":
-                errors.append(f"{prefix}: exact crossing must have FRAME_WITNESS_REQUIRED")
+                errors.append(
+                    f"{prefix}: exact crossing must have FRAME_WITNESS_REQUIRED"
+                )
 
     if observed_relations != RELATIONS:
         missing = ", ".join(sorted(RELATIONS - observed_relations)) or "none"
-        errors.append(f"bundle: fixture relation coverage incomplete; missing {missing}")
+        errors.append(
+            f"bundle: fixture relation coverage incomplete; missing {missing}"
+        )
     if exact_witness_count != 1:
         errors.append("bundle: expected exactly one EXACT_STATE_ID frame witness")
 

--- a/tools/validate_grimm_mereotopology_fixtures.py
+++ b/tools/validate_grimm_mereotopology_fixtures.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Read-only validation for the Grimm-IR mereotopology intake fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+RELATIONS = {"DC", "EC", "PO", "TPP", "NTPP", "EQ"}
+CROSSINGS = {"PROJECTED", "OVER", "UNDER", "TOUCH", "EXACT_STATE_ID"}
+DIRECTIONS = {"NONE", "FORWARD", "REVERSE", "BIDIRECTIONAL"}
+READER_ACTIONS = {"ACCEPT", "REVISE", "REJECT", "SILENCE"}
+NARROW_ORDER = ["title", "relation", "endpoints", "guard", "reentryQuestion"]
+
+
+def _root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+DEFAULT_FIXTURE = (
+    _root()
+    / "docs"
+    / "narratives"
+    / "grimm2"
+    / "fixtures"
+    / "mereotopology_edge_fixtures_v0_1.json"
+)
+
+
+def load_bundle(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError("fixture root must be a JSON object")
+    return loaded
+
+
+def validate_bundle(bundle: dict[str, Any]) -> list[str]:
+    """Return all validation errors without mutating the supplied bundle."""
+
+    errors: list[str] = []
+    invariants = bundle.get("invariants")
+    fixtures = bundle.get("fixtures")
+
+    if bundle.get("schemaVersion") != "0.1":
+        errors.append("bundle: schemaVersion must be 0.1")
+    if not isinstance(invariants, dict):
+        return [*errors, "bundle: invariants must be an object"]
+    if not isinstance(fixtures, list):
+        return [*errors, "bundle: fixtures must be an array"]
+
+    if set(invariants.get("relationSet", [])) != RELATIONS:
+        errors.append("bundle: relationSet must contain DC, EC, PO, TPP, NTPP, and EQ")
+    if invariants.get("collisionSource") != "EXACT_STATE_ID":
+        errors.append("bundle: collisionSource must be EXACT_STATE_ID")
+    if invariants.get("colorCarriesMeaning") is not False:
+        errors.append("bundle: colorCarriesMeaning must be false")
+    if invariants.get("motionCarriesMeaning") is not False:
+        errors.append("bundle: motionCarriesMeaning must be false")
+    if set(invariants.get("readerActions", [])) != READER_ACTIONS:
+        errors.append("bundle: readerActions must contain ACCEPT, REVISE, REJECT, and SILENCE")
+    viewport = invariants.get("minimumViewportCssPx")
+    if not isinstance(viewport, int) or isinstance(viewport, bool) or viewport < 320:
+        errors.append("bundle: minimumViewportCssPx must be an integer of at least 320")
+
+    if len(fixtures) != 6:
+        errors.append("bundle: expected exactly six qualitative fixtures")
+
+    ids: set[str] = set()
+    observed_relations: set[str] = set()
+    exact_witness_count = 0
+
+    for index, fixture in enumerate(fixtures):
+        prefix = f"fixtures[{index}]"
+        if not isinstance(fixture, dict):
+            errors.append(f"{prefix}: fixture must be an object")
+            continue
+
+        fixture_id = fixture.get("id")
+        if not isinstance(fixture_id, str) or not fixture_id.strip():
+            errors.append(f"{prefix}: id must be a non-empty string")
+            fixture_id = prefix
+        elif fixture_id in ids:
+            errors.append(f"{fixture_id}: duplicate fixture id")
+        ids.add(fixture_id)
+        prefix = fixture_id
+
+        for field in (
+            "title",
+            "sourceNodeId",
+            "targetNodeId",
+            "plainLanguage",
+            "guard",
+            "reentryQuestion",
+            "claimLayer",
+        ):
+            value = fixture.get(field)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{prefix}: {field} must be a non-empty string")
+
+        plain_language = fixture.get("plainLanguage")
+        if isinstance(plain_language, str) and len(plain_language) > 180:
+            errors.append(f"{prefix}: plainLanguage must be at most 180 characters")
+
+        relation = fixture.get("relation")
+        crossing = fixture.get("crossing")
+        direction = fixture.get("direction")
+        if relation not in RELATIONS:
+            errors.append(f"{prefix}: unsupported relation {relation!r}")
+        else:
+            observed_relations.add(relation)
+        if crossing not in CROSSINGS:
+            errors.append(f"{prefix}: unsupported crossing {crossing!r}")
+        if direction not in DIRECTIONS:
+            errors.append(f"{prefix}: unsupported direction {direction!r}")
+
+        provenance = fixture.get("provenance")
+        if not isinstance(provenance, dict):
+            errors.append(f"{prefix}: provenance must be an object")
+        else:
+            for field in ("sourceForm", "authorityStatus", "sourceVisibility"):
+                value = provenance.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    errors.append(f"{prefix}: provenance.{field} must be a non-empty string")
+            if provenance.get("sourceVisibility") == "protected-origin":
+                if provenance.get("publicReconstructionAllowed") is not False:
+                    errors.append(
+                        f"{prefix}: protected-origin must set publicReconstructionAllowed to false"
+                    )
+
+        visual = fixture.get("visualEncoding")
+        if not isinstance(visual, dict):
+            errors.append(f"{prefix}: visualEncoding must be an object")
+        else:
+            for field in ("linePattern", "relationLabel", "arrow", "staticFallback"):
+                value = visual.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    errors.append(f"{prefix}: visualEncoding.{field} must be a non-empty string")
+            if visual.get("requiresColorForMeaning") is not False:
+                errors.append(f"{prefix}: color may not be required for meaning")
+            if visual.get("requiresMotionForMeaning") is not False:
+                errors.append(f"{prefix}: motion may not be required for meaning")
+
+        reader = fixture.get("reader")
+        if not isinstance(reader, dict):
+            errors.append(f"{prefix}: reader must be an object")
+        else:
+            if set(reader.get("actions", [])) != READER_ACTIONS:
+                errors.append(f"{prefix}: reader actions are incomplete")
+            if reader.get("orderAtNarrowWidth") != NARROW_ORDER:
+                errors.append(f"{prefix}: narrow-width reading order is unstable")
+
+        frame_bridge = fixture.get("frameBridge")
+        if not isinstance(frame_bridge, dict):
+            errors.append(f"{prefix}: frameBridge must be an object")
+            continue
+
+        expected_collision = frame_bridge.get("expectedCollisionProxy")
+        if not isinstance(expected_collision, bool):
+            errors.append(f"{prefix}: expectedCollisionProxy must be boolean")
+
+        if crossing != "EXACT_STATE_ID":
+            if expected_collision is not False:
+                errors.append(f"{prefix}: only EXACT_STATE_ID may produce collisionProxy=true")
+            if frame_bridge.get("disposition") != "NO_FRAME_EFFECT":
+                errors.append(f"{prefix}: non-exact crossings must have NO_FRAME_EFFECT")
+        else:
+            exact_witness_count += 1
+            if relation != "EQ":
+                errors.append(f"{prefix}: EXACT_STATE_ID requires relation EQ")
+            if frame_bridge.get("collisionSemantics") != "EXACT_STATE_ID":
+                errors.append(f"{prefix}: exact witness requires EXACT_STATE_ID semantics")
+            left = frame_bridge.get("leftStateId")
+            right = frame_bridge.get("rightStateId")
+            if not isinstance(left, str) or not left or left != right:
+                errors.append(f"{prefix}: exact witness requires equal non-empty state IDs")
+            pair_id = frame_bridge.get("transitionPairId")
+            if not isinstance(pair_id, str) or not pair_id.strip():
+                errors.append(f"{prefix}: exact witness requires transitionPairId")
+            if expected_collision is not True:
+                errors.append(f"{prefix}: valid exact witness must expect collisionProxy=true")
+            if frame_bridge.get("disposition") != "FRAME_WITNESS_REQUIRED":
+                errors.append(f"{prefix}: exact crossing must have FRAME_WITNESS_REQUIRED")
+
+    if observed_relations != RELATIONS:
+        missing = ", ".join(sorted(RELATIONS - observed_relations)) or "none"
+        errors.append(f"bundle: fixture relation coverage incomplete; missing {missing}")
+    if exact_witness_count != 1:
+        errors.append("bundle: expected exactly one EXACT_STATE_ID frame witness")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=DEFAULT_FIXTURE)
+    args = parser.parse_args()
+
+    try:
+        bundle = load_bundle(args.path)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    errors = validate_bundle(bundle)
+    if errors:
+        print(f"FAIL: {len(errors)} validation error(s)")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("PASS: 6 Grimm-IR mereotopology fixtures satisfy the intake invariants")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_grimm_mereotopology_fixtures.py
+++ b/tools/validate_grimm_mereotopology_fixtures.py
@@ -8,7 +8,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-
 RELATIONS = {"DC", "EC", "PO", "TPP", "NTPP", "EQ"}
 CROSSINGS = {"PROJECTED", "OVER", "UNDER", "TOUCH", "EXACT_STATE_ID"}
 DIRECTIONS = {"NONE", "FORWARD", "REVERSE", "BIDIRECTIONAL"}
@@ -61,9 +60,7 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
     if invariants.get("motionCarriesMeaning") is not False:
         errors.append("bundle: motionCarriesMeaning must be false")
     if set(invariants.get("readerActions", [])) != READER_ACTIONS:
-        errors.append(
-            "bundle: readerActions must contain ACCEPT, REVISE, REJECT, and SILENCE"
-        )
+        errors.append("bundle: readerActions must contain ACCEPT, REVISE, REJECT, and SILENCE")
     viewport = invariants.get("minimumViewportCssPx")
     if not isinstance(viewport, int) or isinstance(viewport, bool) or viewport < 320:
         errors.append("bundle: minimumViewportCssPx must be an integer of at least 320")
@@ -126,9 +123,7 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
             for field in ("sourceForm", "authorityStatus", "sourceVisibility"):
                 value = provenance.get(field)
                 if not isinstance(value, str) or not value.strip():
-                    errors.append(
-                        f"{prefix}: provenance.{field} must be a non-empty string"
-                    )
+                    errors.append(f"{prefix}: provenance.{field} must be a non-empty string")
             if provenance.get("sourceVisibility") == "protected-origin":
                 if provenance.get("publicReconstructionAllowed") is not False:
                     errors.append(
@@ -142,9 +137,7 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
             for field in ("linePattern", "relationLabel", "arrow", "staticFallback"):
                 value = visual.get(field)
                 if not isinstance(value, str) or not value.strip():
-                    errors.append(
-                        f"{prefix}: visualEncoding.{field} must be a non-empty string"
-                    )
+                    errors.append(f"{prefix}: visualEncoding.{field} must be a non-empty string")
             if visual.get("requiresColorForMeaning") is not False:
                 errors.append(f"{prefix}: color may not be required for meaning")
             if visual.get("requiresMotionForMeaning") is not False:
@@ -170,44 +163,30 @@ def validate_bundle(bundle: dict[str, Any]) -> list[str]:
 
         if crossing != "EXACT_STATE_ID":
             if expected_collision is not False:
-                errors.append(
-                    f"{prefix}: only EXACT_STATE_ID may produce collisionProxy=true"
-                )
+                errors.append(f"{prefix}: only EXACT_STATE_ID may produce collisionProxy=true")
             if frame_bridge.get("disposition") != "NO_FRAME_EFFECT":
-                errors.append(
-                    f"{prefix}: non-exact crossings must have NO_FRAME_EFFECT"
-                )
+                errors.append(f"{prefix}: non-exact crossings must have NO_FRAME_EFFECT")
         else:
             exact_witness_count += 1
             if relation != "EQ":
                 errors.append(f"{prefix}: EXACT_STATE_ID requires relation EQ")
             if frame_bridge.get("collisionSemantics") != "EXACT_STATE_ID":
-                errors.append(
-                    f"{prefix}: exact witness requires EXACT_STATE_ID semantics"
-                )
+                errors.append(f"{prefix}: exact witness requires EXACT_STATE_ID semantics")
             left = frame_bridge.get("leftStateId")
             right = frame_bridge.get("rightStateId")
             if not isinstance(left, str) or not left or left != right:
-                errors.append(
-                    f"{prefix}: exact witness requires equal non-empty state IDs"
-                )
+                errors.append(f"{prefix}: exact witness requires equal non-empty state IDs")
             pair_id = frame_bridge.get("transitionPairId")
             if not isinstance(pair_id, str) or not pair_id.strip():
                 errors.append(f"{prefix}: exact witness requires transitionPairId")
             if expected_collision is not True:
-                errors.append(
-                    f"{prefix}: valid exact witness must expect collisionProxy=true"
-                )
+                errors.append(f"{prefix}: valid exact witness must expect collisionProxy=true")
             if frame_bridge.get("disposition") != "FRAME_WITNESS_REQUIRED":
-                errors.append(
-                    f"{prefix}: exact crossing must have FRAME_WITNESS_REQUIRED"
-                )
+                errors.append(f"{prefix}: exact crossing must have FRAME_WITNESS_REQUIRED")
 
     if observed_relations != RELATIONS:
         missing = ", ".join(sorted(RELATIONS - observed_relations)) or "none"
-        errors.append(
-            f"bundle: fixture relation coverage incomplete; missing {missing}"
-        )
+        errors.append(f"bundle: fixture relation coverage incomplete; missing {missing}")
     if exact_witness_count != 1:
         errors.append("bundle: expected exactly one EXACT_STATE_ID frame witness")
 


### PR DESCRIPTION
FOKUS: Grimm-IR mereotopology intake

## Summary

- records the conversation-derived edge grammar as an ANNEX/SPEC-WIP sidecar, without canon or runtime promotion
- distinguishes DC, EC, PO, TPP, NTPP, and EQ from screen-space crossings
- keeps `collisionProxy` frame-owned and true only for an explicit `EXACT_STATE_ID` witness
- adds six qualitative fixtures, edge-level provenance, protected-origin handling, reversible reader actions, and colorless/static fallbacks
- hardens the read-only fixture validator against malformed JSON-shaped input, duplicate keys, unknown fields, invalid provenance vocabulary, and contradictory frame witnesses
- reconciles the local tesser3TAKT link with current `main` without creating a frame dependency

## Review gaps addressed

- type-check arrays before set comparison; reject duplicates and invalid members without tracebacks
- enforce provenance enums, pointer/flag types, and the protected-origin null-pointer rule
- require canonical exact State IDs and clear frame-owned witness fields on non-exact crossings
- carry `provenance: GrimmSourceRef` in `GrimmIREdge`
- document the six-label directional profile precisely rather than claiming the full RCC8 inverse vocabulary
- reject duplicate JSON member names and undeclared shadow fields at versioned object boundaries

## Validation

Final PR head: `5297ea3` (audit-only follow-up to validated code tree `f9e56c3`).

- fixture validator: 6/6 fixtures pass
- focused unit suite: 23/23 tests pass
- adversarial mutation sweep: 2,873 JSON-shaped single-field mutations, 0 unhandled exceptions
- `py_compile`, Ruff, Black, and mypy pass
- `make verify`: 475 passed, 104 warnings, 165 subtests passed
- `make verify-governance`: 14 workflows meet posture; 22 VOIDs match the UI mirror
- all seven GitHub workflow suites pass on final head `5297ea3`

`make verify-js` remains a documented environment/baseline HOLD: pnpm stops on ignored builds for `electron-winstaller@5.4.0` and `unrs-resolver@1.12.2`; the same failure reproduces on unmodified `main@586fc7a`, so it is not attributed to this Python/docs patch.

## Guard / HOLD

No `docs/masterindex.md`, `VOIDMAP.yml`, policy, receipt, UI runtime, persistence, telemetry, or guard-state change.

The structural protected-origin protocol passes. Content-level anonymity and re-identification resistance still require human review. Actual 320 CSS-pixel, colorless, reduced-motion, and interaction inspection also remains HOLD because this PR intentionally introduces no Grimm-IR runtime surface.

The remaining current review threads are left unresolved for independent reviewer re-evaluation. This PR is ready for re-review, not self-attested final approval.