### PR TITLE
feat(tesser3takt): add first micro-to-meso bridge candidate

### DIFF
--- a/docs/annex/MICRO_MESO_BRIDGE_v0_1.md
+++ b/docs/annex/MICRO_MESO_BRIDGE_v0_1.md
@@ -70,9 +70,10 @@ Die v0.1-Brücke verlangt:
 5. `ORIGIN_CLAIM_LEVEL`
 
 Der Ausgang führt Paarreihenfolge, Ereignisreihenfolge, gerichtete
-State-Verbindungen sowie EXIT-/ENTRY-Provenienz explizit weiter. Zwischen
-aufeinanderfolgenden Paaren müssen State-ID und globale Lattice-Position des
-vorherigen ENTRY mit dem nächsten EXIT übereinstimmen.
+State-Verbindungen sowie EXIT-/ENTRY-Provenienz explizit weiter. Paare dürfen
+nicht ineinander verschachtelt werden. Zwischen aufeinanderfolgenden Paaren
+müssen Ereignisfolge, State-ID und globale Lattice-Position des vorherigen
+ENTRY mit dem nächsten EXIT übereinstimmen.
 
 ## 4. Verlust und Restdifferenz
 
@@ -127,6 +128,7 @@ Negativtests:
 - umgeordnete Ereignisse,
 - gebrochene Konnektivität,
 - lokal gültige, aber untereinander diskontinuierliche Paare,
+- zeitlich ineinander verschachtelte Paare,
 - verlorene Provenienz,
 - lösch- beziehungsweise überschreibbarer Ursprung,
 - sparse oder malformed Transportdaten.

--- a/docs/annex/MICRO_MESO_BRIDGE_v0_1.md
+++ b/docs/annex/MICRO_MESO_BRIDGE_v0_1.md
@@ -14,7 +14,9 @@
 
 [SPEC-WIP] Dieser Annex definiert den ersten schmalen, falsifizierbaren
 Mikro→Meso-Vertical-Slice für tesser3TAKT. Er aggregiert bereits validierbare
-`BoundaryTransition`-Paare zu einem abgeleiteten `TransitionTrace`.
+  `BoundaryTransition`-Paare zu einem abgeleiteten `TransitionTrace`. Der
+  positive Fixture enthält zwei verkettete Paare, damit die Meso-Aggregation
+  nicht auf einer trivialen Einpaar-Abbildung beruht.
 
 Der Bridge-Layer:
 
@@ -68,7 +70,9 @@ Die v0.1-Brücke verlangt:
 5. `ORIGIN_CLAIM_LEVEL`
 
 Der Ausgang führt Paarreihenfolge, Ereignisreihenfolge, gerichtete
-State-Verbindungen sowie EXIT-/ENTRY-Provenienz explizit weiter.
+State-Verbindungen sowie EXIT-/ENTRY-Provenienz explizit weiter. Zwischen
+aufeinanderfolgenden Paaren müssen State-ID und globale Lattice-Position des
+vorherigen ENTRY mit dem nächsten EXIT übereinstimmen.
 
 ## 4. Verlust und Restdifferenz
 
@@ -122,6 +126,7 @@ Negativtests:
 - verwaiste Boundary-Hälfte,
 - umgeordnete Ereignisse,
 - gebrochene Konnektivität,
+- lokal gültige, aber untereinander diskontinuierliche Paare,
 - verlorene Provenienz,
 - lösch- beziehungsweise überschreibbarer Ursprung,
 - sparse oder malformed Transportdaten.

--- a/docs/annex/MICRO_MESO_BRIDGE_v0_1.md
+++ b/docs/annex/MICRO_MESO_BRIDGE_v0_1.md
@@ -1,0 +1,140 @@
+# MICRO_MESO_BRIDGE_v0_1
+
+**Status:** Draft
+
+**Claim-Status:** [BRIDGE-WIP]
+
+**Authority-Status:** ANNEX · DERIVED
+
+**Datum:** 2026-07-24
+
+**Runtime:** `ui-app/lib/tesser3takt-bridge.ts`
+
+## 0. Zweck und Grenze
+
+[SPEC-WIP] Dieser Annex definiert den ersten schmalen, falsifizierbaren
+Mikro→Meso-Vertical-Slice für tesser3TAKT. Er aggregiert bereits validierbare
+`BoundaryTransition`-Paare zu einem abgeleiteten `TransitionTrace`.
+
+Der Bridge-Layer:
+
+- erzeugt keine neue Root-Authority,
+- bewertet keine Evidenz semantisch,
+- promotet keinen Claim,
+- identifiziert Mikro- und Meso-Readout nicht miteinander,
+- ersetzt weder ERK noch tesser3TAKT-Frame-Vertrag,
+- schreibt nicht in GOLD, Receipts oder VOIDMAP.
+
+Ein erfolgreicher Lauf heißt deshalb `PASS_CANDIDATE`, nicht `PASS`.
+
+## 1. Eingangs- und Ausgangsadressen
+
+| Seite | `resolutionScale` | `extentScope` | Form |
+|---|---|---|---|
+| Eingang | `MICRO` | `TRAVERSAL_CELL` | geordnete `BoundaryTransition[]` |
+| Ausgang | `MESO` | `TRAVERSAL_SLICE` | abgeleiteter `TransitionTrace` |
+
+Die beiden Achsen bleiben getrennt. Eine Änderung der Auflösung impliziert
+nicht stillschweigend eine Änderung des räumlichen oder prozessualen Umfangs.
+
+## 2. Mechanisch verlangte Mindestfelder
+
+Jeder Request muss enthalten:
+
+- nichtleere `bridgeId`,
+- nichtleere `sourceFrameId` als Bindung an den Eingangsframe,
+- explizite Mikro-/Meso-Skalenadressen,
+- mindestens ein vollständiges EXIT/ENTRY-Paar,
+- alle fünf erhaltenen Invarianten,
+- eine nichtleere Verlustdeklaration,
+- alle vier Falsifikatoren,
+- mindestens eine Evidenzreferenz,
+- einen registrierten Claim-Ursprung mit `immutable: true`.
+
+Fehlt ein Element, lautet das Ergebnis:
+
+```text
+REJECT(BRIDGE_INCOMPLETE)
+```
+
+## 3. Erhaltene Invarianten
+
+Die v0.1-Brücke verlangt:
+
+1. `BOUNDARY_PAIR_IDENTITY`
+2. `EVENT_ORDER`
+3. `DIRECTIONAL_CONNECTIVITY`
+4. `PROVENANCE_BINDING`
+5. `ORIGIN_CLAIM_LEVEL`
+
+Der Ausgang führt Paarreihenfolge, Ereignisreihenfolge, gerichtete
+State-Verbindungen sowie EXIT-/ENTRY-Provenienz explizit weiter.
+
+## 4. Verlust und Restdifferenz
+
+[MODEL] Mikro und Meso werden verbunden, aber nicht gleichgesetzt. Der positive
+Fixture deklariert deshalb mindestens:
+
+- Verlust roher Timingdetails jenseits von `stepIndex`,
+- Verlust von Per-Cell-Zustandsdetails, die nicht Teil eines
+  `BoundaryTransition` sind.
+
+Die Liste ist Teil des Trace und darf nicht leer sein. Sie ist keine Messung,
+solange der Eintrag nicht ausdrücklich eine Messmethode und Einheit nennt.
+
+## 5. Falsifikatoren
+
+Die Brücke wird verworfen, wenn:
+
+- eine EXIT-/ENTRY-Hälfte fehlt oder die Ereignisfolge umgeordnet wurde,
+- `transformedFrom` die gerichtete Verbindung nicht bindet,
+- Transition- oder Bridge-Provenienz fehlt,
+- der Claim-Ursprung fehlt oder nicht als immutable deklariert ist.
+
+Strukturell vollständige, aber relationell gebrochene Eingaben ergeben:
+
+```text
+REJECT(BRIDGE_FALSIFIED)
+```
+
+## 6. Claim- und Provenienzrollen
+
+`origin.claimTag` verwendet die im
+`docs/audit/CLAIM_TAG_RUNTIME_MAPPING_v0_1.md` inventarisierten Claim-Tags.
+`PROVENANCE_ONLY` wird nicht als zusätzlicher Claim-Tag eingeführt, sondern als
+separates `origin.evidenceRole` geführt.
+
+Der Trace kopiert den Ursprung unverändert und friert ihn zur Laufzeit ein.
+Ein Ursprung `METAPHER` kann durch die Brücke daher nicht zu `FACT` oder
+`CANON` gewaschen werden.
+
+## 7. Fixture und Tests
+
+Positiver Fixture:
+
+- `ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json`
+
+Negativtests:
+
+- fehlende Mindestfelder,
+- fehlende einzelne Invarianten,
+- fehlende einzelne Falsifikatoren,
+- verwaiste Boundary-Hälfte,
+- umgeordnete Ereignisse,
+- gebrochene Konnektivität,
+- verlorene Provenienz,
+- lösch- beziehungsweise überschreibbarer Ursprung,
+- sparse oder malformed Transportdaten.
+
+## 8. Nicht entschieden
+
+[VOID] Diese v0.1 entscheidet nicht:
+
+- ob das spätere Switchboard Verbindungen persistent speichert,
+- ob mehrere Traversal-Slices zu einem größeren Meso-Graphen aggregiert werden,
+- wie HumanDecision authentisiert wird,
+- ob ein Bridge-Trace jemals Receipt-Status erhalten darf,
+- ob `PASS_CANDIDATE` später einen eigenen ERK-Adapter bekommt.
+
+Diese Fragen benötigen getrennte Reviews und dürfen nicht aus dem positiven
+Fixture abgeleitet werden.

--- a/docs/audit/2026-07-24_micro_meso_bridge_v0_1.md
+++ b/docs/audit/2026-07-24_micro_meso_bridge_v0_1.md
@@ -1,0 +1,113 @@
+# Audit: Micro→Meso Bridge v0.1
+
+**Datum:** 2026-07-24
+
+**Fokus:** Erster falsifizierbarer Skalenübergang
+
+**Base:** `d39b9db72dd04d6e1e2cded5a7d08287be76b9b8`
+
+**Authority:** ANNEX · DERIVED · [BRIDGE-WIP]
+
+## Ziel
+
+Den kleinsten ausführbaren tesser3TAKT-Vertical-Slice herstellen, der
+validierte Mikro-Boundary-Paare in einen Meso-Trace überführt, ohne Claim,
+Provenienz, Skalen oder Readouts still zu identifizieren.
+
+## Aktionen
+
+- [x] separaten Bridge-Request und `TransitionTrace` eingeführt
+- [x] `MICRO / TRAVERSAL_CELL` und `MESO / TRAVERSAL_SLICE` getrennt adressiert
+- [x] `bridgeId` und `sourceFrameId` mechanisch verlangt
+- [x] fünf erhaltene Invarianten mechanisch verlangt
+- [x] nichtleere Verlustdeklaration mechanisch verlangt
+- [x] vier konkrete Falsifikatoren mechanisch verlangt
+- [x] Bridge- und Transition-Provenienz mechanisch verlangt
+- [x] Claim-Tag und `PROVENANCE_ONLY` als getrennte Rollen modelliert
+- [x] Claim-Ursprung und Trace-Ausgabe zur Laufzeit eingefroren
+- [x] positiver Fixture und negative Transport-/Relations-Fixtures ergänzt
+- [x] lokalen tesser3TAKT-Index um einen ANNEX-Verweis ergänzt
+
+## Abgleich der Quellen
+
+| Quelle | Verwendete Rolle | Autoritätswirkung |
+|---|---|---|
+| GitHub `main` | Frame-Vertrag, Tests, Claim-Mapping, House Rules | repo-lokaler Ausgangspunkt |
+| Drive Save State v1.6 | Trennung von Auffindbarkeit und Autorität | keine |
+| Notion Annex F | Kontrolle auf konkurrierende aktive Bridge-Entscheidung | keine; keine gefunden |
+| lokaler Übergangsgrammatik-PDF | Kandidatenbegriffe für Skala, Verlust und Guard | keine |
+| Hugging-Face-Dokumentation | Cross-check: versionierte Repos für reproduzierbare Artefakte, mutable Buckets nur als Staging | keine; kein HF-Artefakt erzeugt |
+| Wolfram-Kontextsuche | Suche nach direkt belegbaren Graph-Coarse-Graining-Invarianten | keine; kein einschlägiger Resultatbeleg gefunden |
+
+Die externe Suche wurde nicht als mathematischer Beweis oder neue
+Protokollautorität verwendet.
+
+## Verifikation
+
+| Gate | Ergebnis |
+|---|---|
+| `pnpm --filter entaengelment-ui test` | PASS · 21/21 Tests |
+| neue Bridge-Tests | PASS · 8/8 |
+| bestehende Frame-/HUD-Regressionen | PASS · 13/13 |
+| `make verify` | PASS · 290/290 Python-Tests, Port-Lint, Pointer, Claim-Lint |
+| `make verify-governance` | PASS · 14 Workflows, VOID-Backlog und UI-Mirror synchron |
+| `make verify-js` | PASS · TypeScript, ESLint, Workspace-Typen und Next-Produktionsbuild |
+| `git diff --check` | PASS |
+
+Die Node-Testausgabe enthält weiterhin die bereits im Workspace vorhandene
+Warnung zum fehlenden `"type": "module"` in `ui-app/package.json`. Diese
+Warnung ist nicht durch die Bridge eingeführt und beeinflusst das Testergebnis
+nicht.
+
+## Mechanisch gehaltene Grenze
+
+Ein Request unterhalb der Mindeststruktur ergibt
+`REJECT(BRIDGE_INCOMPLETE)`. Ein strukturell vollständiger Request mit
+verwaister, umgeordneter oder falsch verbundener Boundary ergibt
+`REJECT(BRIDGE_FALSIFIED)`.
+
+Ein erfolgreicher Lauf ergibt ausschließlich `PASS_CANDIDATE` und
+`authorityStatus: derived`. Der Ausgang übernimmt den Ursprung unverändert.
+
+## Nicht getan
+
+- keine Änderung an GOLD, VOIDMAP, Policies oder Receipts
+- keine HumanDecision synthetisiert
+- keine PRs gemergt oder auf Ready gesetzt
+- keine Switchboard-Persistenz eingeführt
+- kein ERK-Transitiontyp wiederverwendet oder überschrieben
+- keine Grimm-Runtime aktiviert
+- kein OpenAI-API-Key angelegt; der Slice hat keine OpenAI-API-Abhängigkeit
+- kein Hugging-Face-Repository, Dataset oder Job erzeugt
+- kein mathematischer oder empirischer Geltungsanspruch aus externen Quellen abgeleitet
+
+## Risiken und verbleibende Grenzen
+
+- Der positive Fixture enthält bislang ein Boundary-Paar; ein Mehrpaar-Slice
+  braucht einen weiteren Fixture für globale Reihenfolge und Kettensemantik.
+- `sourceFrameId` ist strukturell verlangt, aber noch nicht durch einen
+  kanonischen Frame-Digest gebunden.
+- Der Trace besitzt noch keinen kanonischen Content-Digest.
+- Evidenzreferenzen werden strukturell, nicht semantisch bewertet.
+- Das registrierte Claim-Tag-Inventar ist lokal gespiegelt. Eine spätere
+  Policy-Angleichung benötigt einen getrennten Review und darf historische
+  Receipts nicht umschreiben.
+- `Object.freeze` schützt die erzeugte Laufzeitstruktur; persistente
+  Unveränderlichkeit benötigt später ein eigenes Storage-/Receipt-Modell.
+
+## Offene Human-Gates
+
+- [ ] ☐ Switchboard-Lineage ausdrücklich als `DERIVED` anerkennen oder ablehnen
+- [ ] ☐ PR #320 GOLD-Statusänderung zu VOID-027 entscheiden
+- [ ] ☐ PR #319 Grimm-Vokabular fachlich freigeben oder revidieren
+- [ ] ☐ PR #321 dem aktuellen Meilenstein zuordnen oder parken
+- [ ] ☐ entscheiden, ob der Einpaar-Fixture für v0.1 genügt oder vor Merge ein Mehrpaar-Fixture verlangt wird
+
+## Artefakte
+
+- `docs/annex/MICRO_MESO_BRIDGE_v0_1.md`
+- `docs/audit/2026-07-24_micro_meso_bridge_v0_1.md`
+- `docs/tesser3takt/README.md`
+- `ui-app/lib/tesser3takt-bridge.ts`
+- `ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json`
+- `ui-app/test/tesser3takt-bridge.test.mjs`

--- a/docs/audit/2026-07-24_micro_meso_bridge_v0_1.md
+++ b/docs/audit/2026-07-24_micro_meso_bridge_v0_1.md
@@ -26,6 +26,7 @@ Provenienz, Skalen oder Readouts still zu identifizieren.
 - [x] Claim-Tag und `PROVENANCE_ONLY` als getrennte Rollen modelliert
 - [x] Claim-Ursprung und Trace-Ausgabe zur Laufzeit eingefroren
 - [x] positiver Fixture und negative Transport-/Relations-Fixtures ergänzt
+- [x] nichttrivialen Zweipaar-Slice samt State-/Positionskontinuität ergänzt
 - [x] lokalen tesser3TAKT-Index um einen ANNEX-Verweis ergänzt
 
 ## Abgleich der Quellen
@@ -46,8 +47,8 @@ Protokollautorität verwendet.
 
 | Gate | Ergebnis |
 |---|---|
-| `pnpm --filter entaengelment-ui test` | PASS · 21/21 Tests |
-| neue Bridge-Tests | PASS · 8/8 |
+| `pnpm --filter entaengelment-ui test` | PASS · 22/22 Tests |
+| neue Bridge-Tests | PASS · 9/9 |
 | bestehende Frame-/HUD-Regressionen | PASS · 13/13 |
 | `make verify` | PASS · 290/290 Python-Tests, Port-Lint, Pointer, Claim-Lint |
 | `make verify-governance` | PASS · 14 Workflows, VOID-Backlog und UI-Mirror synchron |
@@ -83,8 +84,8 @@ Ein erfolgreicher Lauf ergibt ausschließlich `PASS_CANDIDATE` und
 
 ## Risiken und verbleibende Grenzen
 
-- Der positive Fixture enthält bislang ein Boundary-Paar; ein Mehrpaar-Slice
-  braucht einen weiteren Fixture für globale Reihenfolge und Kettensemantik.
+- Der positive Fixture enthält zwei Paare. Größere Slices und verzweigte
+  Traversals sind noch nicht abgedeckt.
 - `sourceFrameId` ist strukturell verlangt, aber noch nicht durch einen
   kanonischen Frame-Digest gebunden.
 - Der Trace besitzt noch keinen kanonischen Content-Digest.
@@ -101,7 +102,6 @@ Ein erfolgreicher Lauf ergibt ausschließlich `PASS_CANDIDATE` und
 - [ ] ☐ PR #320 GOLD-Statusänderung zu VOID-027 entscheiden
 - [ ] ☐ PR #319 Grimm-Vokabular fachlich freigeben oder revidieren
 - [ ] ☐ PR #321 dem aktuellen Meilenstein zuordnen oder parken
-- [ ] ☐ entscheiden, ob der Einpaar-Fixture für v0.1 genügt oder vor Merge ein Mehrpaar-Fixture verlangt wird
 
 ## Artefakte
 

--- a/docs/audit/2026-07-24_micro_meso_bridge_v0_1.md
+++ b/docs/audit/2026-07-24_micro_meso_bridge_v0_1.md
@@ -47,8 +47,8 @@ Protokollautorität verwendet.
 
 | Gate | Ergebnis |
 |---|---|
-| `pnpm --filter entaengelment-ui test` | PASS · 22/22 Tests |
-| neue Bridge-Tests | PASS · 9/9 |
+| `pnpm --filter entaengelment-ui test` | PASS · 23/23 Tests |
+| neue Bridge-Tests | PASS · 10/10 |
 | bestehende Frame-/HUD-Regressionen | PASS · 13/13 |
 | `make verify` | PASS · 290/290 Python-Tests, Port-Lint, Pointer, Claim-Lint |
 | `make verify-governance` | PASS · 14 Workflows, VOID-Backlog und UI-Mirror synchron |

--- a/docs/tesser3takt/README.md
+++ b/docs/tesser3takt/README.md
@@ -112,3 +112,15 @@ Each boundary pair must contain exactly one ordered `EXIT` and one `ENTRY`, use 
 
 JSON and transport inputs must enter through `validateTesserTickFrame`. The runtime validator checks the complete serialized shape, requires every transition to name `GLOBAL_REENTRY_LATTICE`, verifies the EXIT/ENTRY pair invariant, rejects a supplied `collisionProxy` that disagrees with the state IDs, and enforces the `digest`/`digestStatus` relation. TypeScript annotations alone are not an input boundary.
 
+## Micro→Meso Bridge v0.1
+
+The first bounded scale bridge is documented in
+`docs/annex/MICRO_MESO_BRIDGE_v0_1.md` and implemented by
+`ui-app/lib/tesser3takt-bridge.ts`. It maps validated, ordered
+`BoundaryTransition` pairs from `MICRO / TRAVERSAL_CELL` to a derived
+`MESO / TRAVERSAL_SLICE` trace.
+
+The bridge is ANNEX and `PASS_CANDIDATE` only. It requires an explicit source
+frame, preserved invariants, declared loss, falsifiers, evidence references,
+and an immutable claim origin. It does not promote claims, create receipts,
+change VOIDMAP, or identify the two scale readouts.

--- a/ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json
+++ b/ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json
@@ -1,0 +1,87 @@
+{
+  "bridgeId": "t3t-boundary-trace-v0.1",
+  "sourceFrameId": "tesser3takt-minimal-v0.2",
+  "from": {
+    "resolutionScale": "MICRO",
+    "extentScope": "TRAVERSAL_CELL"
+  },
+  "to": {
+    "resolutionScale": "MESO",
+    "extentScope": "TRAVERSAL_SLICE"
+  },
+  "transitions": [
+    {
+      "pairId": "bt-001",
+      "half": "EXIT",
+      "stepIndex": 2,
+      "stateId": "S4:1234",
+      "quadrant": "alpha",
+      "coordinateSpace": "GLOBAL_REENTRY_LATTICE",
+      "latticePosition": [1, 1],
+      "provenance": {
+        "kind": "fixture",
+        "source": "ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json",
+        "revision": "v0.1",
+        "digest": null,
+        "digestStatus": "UNVERIFIED",
+        "locator": "$.transitions[0]",
+        "claimLayer": "FIXTURE",
+        "authorityStatus": "repo-local"
+      }
+    },
+    {
+      "pairId": "bt-001",
+      "half": "ENTRY",
+      "stepIndex": 3,
+      "stateId": "S4:2143",
+      "quadrant": "beta",
+      "coordinateSpace": "GLOBAL_REENTRY_LATTICE",
+      "latticePosition": [2, 3],
+      "transformedFrom": "S4:1234",
+      "provenance": {
+        "kind": "fixture",
+        "source": "ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json",
+        "revision": "v0.1",
+        "digest": null,
+        "digestStatus": "UNVERIFIED",
+        "locator": "$.transitions[1]",
+        "claimLayer": "FIXTURE",
+        "authorityStatus": "repo-local"
+      }
+    }
+  ],
+  "preservedInvariants": [
+    "BOUNDARY_PAIR_IDENTITY",
+    "EVENT_ORDER",
+    "DIRECTIONAL_CONNECTIVITY",
+    "PROVENANCE_BINDING",
+    "ORIGIN_CLAIM_LEVEL"
+  ],
+  "measuredOrDeclaredLoss": [
+    "raw timing detail outside stepIndex",
+    "per-cell state detail not carried by BoundaryTransition"
+  ],
+  "falsifiers": [
+    "MISSING_OR_REORDERED_BOUNDARY_HALF",
+    "CHANGED_CONNECTIVITY",
+    "LOST_PROVENANCE",
+    "LOST_CLAIM_ORIGIN"
+  ],
+  "evidenceRefs": [
+    {
+      "kind": "transport",
+      "source": "ui-app/lib/tesser3takt-frame.ts",
+      "revision": "d39b9db72dd04d6e1e2cded5a7d08287be76b9b8",
+      "digest": null,
+      "digestStatus": "UNVERIFIED",
+      "locator": "BoundaryTransition and validateBoundaryPairs",
+      "claimLayer": "SPEC",
+      "authorityStatus": "repo-local"
+    }
+  ],
+  "origin": {
+    "claimTag": "BRIDGE-WIP",
+    "evidenceRole": "CLAIM_BEARING",
+    "immutable": true
+  }
+}

--- a/ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json
+++ b/ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json
@@ -1,6 +1,6 @@
 {
   "bridgeId": "t3t-boundary-trace-v0.1",
-  "sourceFrameId": "tesser3takt-minimal-v0.2",
+  "sourceFrameId": "tesser3takt-micro-slice-v0.1",
   "from": {
     "resolutionScale": "MICRO",
     "extentScope": "TRAVERSAL_CELL"
@@ -45,6 +45,45 @@
         "digest": null,
         "digestStatus": "UNVERIFIED",
         "locator": "$.transitions[1]",
+        "claimLayer": "FIXTURE",
+        "authorityStatus": "repo-local"
+      }
+    },
+    {
+      "pairId": "bt-002",
+      "half": "EXIT",
+      "stepIndex": 4,
+      "stateId": "S4:2143",
+      "quadrant": "beta",
+      "coordinateSpace": "GLOBAL_REENTRY_LATTICE",
+      "latticePosition": [2, 3],
+      "provenance": {
+        "kind": "fixture",
+        "source": "ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json",
+        "revision": "v0.1",
+        "digest": null,
+        "digestStatus": "UNVERIFIED",
+        "locator": "$.transitions[2]",
+        "claimLayer": "FIXTURE",
+        "authorityStatus": "repo-local"
+      }
+    },
+    {
+      "pairId": "bt-002",
+      "half": "ENTRY",
+      "stepIndex": 5,
+      "stateId": "S4:2413",
+      "quadrant": "gamma",
+      "coordinateSpace": "GLOBAL_REENTRY_LATTICE",
+      "latticePosition": [4, 4],
+      "transformedFrom": "S4:2143",
+      "provenance": {
+        "kind": "fixture",
+        "source": "ui-app/fixtures/tesser3takt-micro-meso-bridge-v0.1.json",
+        "revision": "v0.1",
+        "digest": null,
+        "digestStatus": "UNVERIFIED",
+        "locator": "$.transitions[3]",
         "claimLayer": "FIXTURE",
         "authorityStatus": "repo-local"
       }

--- a/ui-app/lib/tesser3takt-bridge.ts
+++ b/ui-app/lib/tesser3takt-bridge.ts
@@ -503,6 +503,42 @@ export function buildMicroToMesoTrace(input: unknown): BridgeResult {
       );
     }
   }
+
+  if (falsifierErrors.length === 0) {
+    const orderedPairs = transitions
+      .filter((transition) => transition.half === 'EXIT')
+      .map((exit) => ({
+        exit,
+        entry: transitions.find(
+          (transition) => transition.pairId === exit.pairId && transition.half === 'ENTRY',
+        ),
+      }));
+
+    for (let index = 1; index < orderedPairs.length; index += 1) {
+      const previousEntry = orderedPairs[index - 1].entry;
+      const currentExit = orderedPairs[index].exit;
+      if (!previousEntry) {
+        falsifierErrors.push(
+          `$.transitions: ${orderedPairs[index - 1].exit.pairId} lost its ENTRY`,
+        );
+        continue;
+      }
+      if (previousEntry.stateId !== currentExit.stateId) {
+        falsifierErrors.push(
+          `$.transitions: pair chain state continuity broke before ${currentExit.pairId}`,
+        );
+      }
+      if (
+        previousEntry.latticePosition[0] !== currentExit.latticePosition[0] ||
+        previousEntry.latticePosition[1] !== currentExit.latticePosition[1]
+      ) {
+        falsifierErrors.push(
+          `$.transitions: pair chain position continuity broke before ${currentExit.pairId}`,
+        );
+      }
+    }
+  }
+
   if (falsifierErrors.length > 0) {
     return reject('BRIDGE_FALSIFIED', falsifierErrors);
   }

--- a/ui-app/lib/tesser3takt-bridge.ts
+++ b/ui-app/lib/tesser3takt-bridge.ts
@@ -1,0 +1,529 @@
+import {
+  validateBoundaryPairs,
+  type BoundaryTransition,
+  type ProvenanceRef,
+} from './tesser3takt-frame.ts';
+
+export type ResolutionScale = 'MICRO' | 'MESO' | 'MACRO';
+export type ExtentScope = 'TRAVERSAL_CELL' | 'TRAVERSAL_SLICE';
+
+export type RegisteredClaimTag =
+  | 'ROHSEDIMENT'
+  | 'METAPHER'
+  | 'HYPOTHESE'
+  | 'INFERENZ'
+  | 'MODEL'
+  | 'FACT'
+  | 'SPEC-WIP'
+  | 'SPEC'
+  | 'CANON'
+  | 'VOID'
+  | 'ROSETTA'
+  | 'ANNEX'
+  | 'CONTEXT'
+  | 'BRIDGE-WIP'
+  | 'UI-LAB'
+  | 'SIMULATION_PROXY';
+
+export type OriginEvidenceRole = 'CLAIM_BEARING' | 'PROVENANCE_ONLY';
+
+export interface ImmutableClaimOrigin {
+  readonly claimTag: RegisteredClaimTag;
+  readonly evidenceRole: OriginEvidenceRole;
+  readonly immutable: true;
+}
+
+export const REQUIRED_PRESERVED_INVARIANTS = [
+  'BOUNDARY_PAIR_IDENTITY',
+  'EVENT_ORDER',
+  'DIRECTIONAL_CONNECTIVITY',
+  'PROVENANCE_BINDING',
+  'ORIGIN_CLAIM_LEVEL',
+] as const;
+
+export type PreservedInvariant = (typeof REQUIRED_PRESERVED_INVARIANTS)[number];
+
+export const REQUIRED_FALSIFIERS = [
+  'MISSING_OR_REORDERED_BOUNDARY_HALF',
+  'CHANGED_CONNECTIVITY',
+  'LOST_PROVENANCE',
+  'LOST_CLAIM_ORIGIN',
+] as const;
+
+export type BridgeFalsifier = (typeof REQUIRED_FALSIFIERS)[number];
+
+export interface ScaleAddress {
+  readonly resolutionScale: ResolutionScale;
+  readonly extentScope: ExtentScope;
+}
+
+export interface MicroToMesoBridgeRequest {
+  readonly bridgeId: string;
+  readonly sourceFrameId: string;
+  readonly from: ScaleAddress;
+  readonly to: ScaleAddress;
+  readonly transitions: readonly BoundaryTransition[];
+  readonly preservedInvariants: readonly PreservedInvariant[];
+  readonly measuredOrDeclaredLoss: readonly string[];
+  readonly falsifiers: readonly BridgeFalsifier[];
+  readonly evidenceRefs: readonly ProvenanceRef[];
+  readonly origin: ImmutableClaimOrigin;
+}
+
+export interface TraceEvent {
+  readonly pairId: string;
+  readonly half: BoundaryTransition['half'];
+  readonly stepIndex: number;
+}
+
+export interface TraceConnection {
+  readonly pairId: string;
+  readonly fromStateId: string;
+  readonly toStateId: string;
+  readonly fromPosition: readonly [number, number];
+  readonly toPosition: readonly [number, number];
+  readonly exitProvenance: Readonly<ProvenanceRef>;
+  readonly entryProvenance: Readonly<ProvenanceRef>;
+}
+
+export interface TransitionTrace {
+  readonly traceId: string;
+  readonly bridgeId: string;
+  readonly sourceFrameId: string;
+  readonly authorityStatus: 'derived';
+  readonly from: Readonly<ScaleAddress>;
+  readonly to: Readonly<ScaleAddress>;
+  readonly pairOrder: readonly string[];
+  readonly eventOrder: readonly Readonly<TraceEvent>[];
+  readonly connectivity: readonly Readonly<TraceConnection>[];
+  readonly preservedInvariants: readonly PreservedInvariant[];
+  readonly measuredOrDeclaredLoss: readonly string[];
+  readonly falsifiers: readonly BridgeFalsifier[];
+  readonly evidenceRefs: readonly Readonly<ProvenanceRef>[];
+  readonly origin: Readonly<ImmutableClaimOrigin>;
+}
+
+export type BridgeRejectCode = 'BRIDGE_INCOMPLETE' | 'BRIDGE_FALSIFIED';
+
+export type BridgeResult =
+  | {
+      readonly accepted: true;
+      readonly decision: 'PASS_CANDIDATE';
+      readonly errors: readonly [];
+      readonly trace: Readonly<TransitionTrace>;
+    }
+  | {
+      readonly accepted: false;
+      readonly decision: 'REJECT';
+      readonly code: BridgeRejectCode;
+      readonly errors: readonly string[];
+    };
+
+const CLAIM_TAGS = new Set<RegisteredClaimTag>([
+  'ROHSEDIMENT',
+  'METAPHER',
+  'HYPOTHESE',
+  'INFERENZ',
+  'MODEL',
+  'FACT',
+  'SPEC-WIP',
+  'SPEC',
+  'CANON',
+  'VOID',
+  'ROSETTA',
+  'ANNEX',
+  'CONTEXT',
+  'BRIDGE-WIP',
+  'UI-LAB',
+  'SIMULATION_PROXY',
+]);
+
+const EVIDENCE_ROLES = new Set<OriginEvidenceRole>(['CLAIM_BEARING', 'PROVENANCE_ONLY']);
+const PROVENANCE_KINDS = new Set<ProvenanceRef['kind']>([
+  'annex',
+  'fixture',
+  'calculation',
+  'transport',
+]);
+const CLAIM_LAYERS = new Set<ProvenanceRef['claimLayer']>([
+  'MODEL',
+  'SPEC',
+  'FIXTURE',
+  'RECEIPT',
+]);
+const AUTHORITY_STATUSES = new Set<ProvenanceRef['authorityStatus']>([
+  'repo-local',
+  'external-unverified',
+  'derived',
+]);
+const QUADRANTS = new Set<BoundaryTransition['quadrant']>([
+  'alpha',
+  'beta',
+  'gamma',
+  'delta',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validateDenseArray(value: unknown, path: string, errors: string[]): value is unknown[] {
+  if (!Array.isArray(value)) {
+    errors.push(`${path}: expected an array`);
+    return false;
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    if (!(index in value)) {
+      errors.push(`${path}[${index}]: sparse array entries are not allowed`);
+    }
+  }
+  return true;
+}
+
+function validateNonEmptyStringArray(
+  value: unknown,
+  path: string,
+  errors: string[],
+): value is string[] {
+  const errorCount = errors.length;
+  if (!validateDenseArray(value, path, errors)) {
+    return false;
+  }
+  if (value.length === 0) {
+    errors.push(`${path}: expected at least one entry`);
+  }
+  value.forEach((entry, index) => {
+    if (!isNonEmptyString(entry)) {
+      errors.push(`${path}[${index}]: expected a non-empty string`);
+    }
+  });
+  return errors.length === errorCount;
+}
+
+function validateScaleAddress(
+  value: unknown,
+  path: string,
+  expectedResolution: ResolutionScale,
+  expectedExtent: ExtentScope,
+  errors: string[],
+): value is ScaleAddress {
+  const errorCount = errors.length;
+  if (!isRecord(value)) {
+    errors.push(`${path}: expected a scale address`);
+    return false;
+  }
+  if (value.resolutionScale !== expectedResolution) {
+    errors.push(`${path}.resolutionScale: expected ${expectedResolution}`);
+  }
+  if (value.extentScope !== expectedExtent) {
+    errors.push(`${path}.extentScope: expected ${expectedExtent}`);
+  }
+  return errors.length === errorCount;
+}
+
+function validateProvenanceRef(
+  value: unknown,
+  path: string,
+  errors: string[],
+): value is ProvenanceRef {
+  const errorCount = errors.length;
+  if (!isRecord(value)) {
+    errors.push(`${path}: expected a provenance object`);
+    return false;
+  }
+
+  if (!PROVENANCE_KINDS.has(value.kind as ProvenanceRef['kind'])) {
+    errors.push(`${path}.kind: unsupported provenance kind`);
+  }
+  for (const field of ['source', 'revision', 'locator']) {
+    if (!isNonEmptyString(value[field])) {
+      errors.push(`${path}.${field}: expected a non-empty string`);
+    }
+  }
+  if (value.digestStatus !== 'VERIFIED' && value.digestStatus !== 'UNVERIFIED') {
+    errors.push(`${path}.digestStatus: expected VERIFIED or UNVERIFIED`);
+  } else if (value.digestStatus === 'VERIFIED' && !isNonEmptyString(value.digest)) {
+    errors.push(`${path}.digest: VERIFIED provenance requires a non-empty digest`);
+  } else if (value.digestStatus === 'UNVERIFIED' && value.digest !== null) {
+    errors.push(`${path}.digest: UNVERIFIED provenance requires digest: null`);
+  }
+  if (!CLAIM_LAYERS.has(value.claimLayer as ProvenanceRef['claimLayer'])) {
+    errors.push(`${path}.claimLayer: unsupported claim layer`);
+  }
+  if (!AUTHORITY_STATUSES.has(value.authorityStatus as ProvenanceRef['authorityStatus'])) {
+    errors.push(`${path}.authorityStatus: unsupported authority status`);
+  }
+  return errors.length === errorCount;
+}
+
+function validateBoundaryTransitionShape(
+  value: unknown,
+  path: string,
+  errors: string[],
+): value is BoundaryTransition {
+  const errorCount = errors.length;
+  if (!isRecord(value)) {
+    errors.push(`${path}: expected a boundary transition object`);
+    return false;
+  }
+
+  for (const field of ['pairId', 'stateId']) {
+    if (!isNonEmptyString(value[field])) {
+      errors.push(`${path}.${field}: expected a non-empty string`);
+    }
+  }
+  if (value.half !== 'EXIT' && value.half !== 'ENTRY') {
+    errors.push(`${path}.half: expected EXIT or ENTRY`);
+  }
+  if (!Number.isInteger(value.stepIndex) || (value.stepIndex as number) < 0) {
+    errors.push(`${path}.stepIndex: expected a non-negative integer`);
+  }
+  if (!QUADRANTS.has(value.quadrant as BoundaryTransition['quadrant'])) {
+    errors.push(`${path}.quadrant: unsupported quadrant`);
+  }
+  if (value.coordinateSpace !== 'GLOBAL_REENTRY_LATTICE') {
+    errors.push(`${path}.coordinateSpace: expected GLOBAL_REENTRY_LATTICE`);
+  }
+  if (
+    !Array.isArray(value.latticePosition) ||
+    value.latticePosition.length !== 2 ||
+    !value.latticePosition.every(Number.isInteger)
+  ) {
+    errors.push(`${path}.latticePosition: expected two integer global coordinates`);
+  }
+  if (value.transformedFrom !== undefined && !isNonEmptyString(value.transformedFrom)) {
+    errors.push(`${path}.transformedFrom: expected a non-empty state id when present`);
+  }
+  validateProvenanceRef(value.provenance, `${path}.provenance`, errors);
+  return errors.length === errorCount;
+}
+
+function validateClaimOrigin(
+  value: unknown,
+  path: string,
+  errors: string[],
+): value is ImmutableClaimOrigin {
+  const errorCount = errors.length;
+  if (!isRecord(value)) {
+    errors.push(`${path}: expected an origin object`);
+    return false;
+  }
+  if (!CLAIM_TAGS.has(value.claimTag as RegisteredClaimTag)) {
+    errors.push(`${path}.claimTag: expected a registered claim tag`);
+  }
+  if (!EVIDENCE_ROLES.has(value.evidenceRole as OriginEvidenceRole)) {
+    errors.push(`${path}.evidenceRole: expected CLAIM_BEARING or PROVENANCE_ONLY`);
+  }
+  if (value.immutable !== true) {
+    errors.push(`${path}.immutable: expected true`);
+  }
+  return errors.length === errorCount;
+}
+
+function validateRequiredEnumValues<T extends string>(
+  value: unknown,
+  path: string,
+  required: readonly T[],
+  errors: string[],
+): value is T[] {
+  const errorCount = errors.length;
+  if (!validateNonEmptyStringArray(value, path, errors)) {
+    return false;
+  }
+
+  const supported = new Set(required);
+  value.forEach((entry, index) => {
+    if (!supported.has(entry as T)) {
+      errors.push(`${path}[${index}]: unsupported value ${entry}`);
+    }
+  });
+  for (const requiredEntry of required) {
+    if (!value.includes(requiredEntry)) {
+      errors.push(`${path}: missing required value ${requiredEntry}`);
+    }
+  }
+  if (new Set(value).size !== value.length) {
+    errors.push(`${path}: duplicate values are not allowed`);
+  }
+  return errors.length === errorCount;
+}
+
+function reject(code: BridgeRejectCode, errors: string[]): BridgeResult {
+  return {
+    accepted: false,
+    decision: 'REJECT',
+    code,
+    errors: Object.freeze([...errors]),
+  };
+}
+
+function frozenProvenance(reference: ProvenanceRef): Readonly<ProvenanceRef> {
+  return Object.freeze({ ...reference });
+}
+
+function buildFrozenTrace(request: MicroToMesoBridgeRequest): Readonly<TransitionTrace> {
+  const pairOrder: string[] = [];
+  for (const transition of request.transitions) {
+    if (transition.half === 'EXIT') {
+      pairOrder.push(transition.pairId);
+    }
+  }
+
+  const connectivity = pairOrder.map((pairId): Readonly<TraceConnection> => {
+    const exit = request.transitions.find(
+      (transition) => transition.pairId === pairId && transition.half === 'EXIT',
+    );
+    const entry = request.transitions.find(
+      (transition) => transition.pairId === pairId && transition.half === 'ENTRY',
+    );
+
+    if (!exit || !entry) {
+      throw new Error(`validated pair ${pairId} became incomplete`);
+    }
+
+    return Object.freeze({
+      pairId,
+      fromStateId: exit.stateId,
+      toStateId: entry.stateId,
+      fromPosition: Object.freeze([...exit.latticePosition]) as readonly [number, number],
+      toPosition: Object.freeze([...entry.latticePosition]) as readonly [number, number],
+      exitProvenance: frozenProvenance(exit.provenance),
+      entryProvenance: frozenProvenance(entry.provenance),
+    });
+  });
+
+  const eventOrder = request.transitions.map((transition) =>
+    Object.freeze({
+      pairId: transition.pairId,
+      half: transition.half,
+      stepIndex: transition.stepIndex,
+    }),
+  );
+
+  return Object.freeze({
+    traceId: `${request.bridgeId}:trace`,
+    bridgeId: request.bridgeId,
+    sourceFrameId: request.sourceFrameId,
+    authorityStatus: 'derived',
+    from: Object.freeze({ ...request.from }),
+    to: Object.freeze({ ...request.to }),
+    pairOrder: Object.freeze(pairOrder),
+    eventOrder: Object.freeze(eventOrder),
+    connectivity: Object.freeze(connectivity),
+    preservedInvariants: Object.freeze([...request.preservedInvariants]),
+    measuredOrDeclaredLoss: Object.freeze([...request.measuredOrDeclaredLoss]),
+    falsifiers: Object.freeze([...request.falsifiers]),
+    evidenceRefs: Object.freeze(request.evidenceRefs.map(frozenProvenance)),
+    origin: Object.freeze({ ...request.origin }),
+  });
+}
+
+export function buildMicroToMesoTrace(input: unknown): BridgeResult {
+  const completenessErrors: string[] = [];
+  if (!isRecord(input)) {
+    return reject('BRIDGE_INCOMPLETE', ['$: expected a bridge request object']);
+  }
+
+  if (!isNonEmptyString(input.bridgeId)) {
+    completenessErrors.push('$.bridgeId: expected a non-empty string');
+  }
+  if (!isNonEmptyString(input.sourceFrameId)) {
+    completenessErrors.push('$.sourceFrameId: expected a non-empty string');
+  }
+  validateScaleAddress(
+    input.from,
+    '$.from',
+    'MICRO',
+    'TRAVERSAL_CELL',
+    completenessErrors,
+  );
+  validateScaleAddress(input.to, '$.to', 'MESO', 'TRAVERSAL_SLICE', completenessErrors);
+  validateRequiredEnumValues(
+    input.preservedInvariants,
+    '$.preservedInvariants',
+    REQUIRED_PRESERVED_INVARIANTS,
+    completenessErrors,
+  );
+  validateNonEmptyStringArray(
+    input.measuredOrDeclaredLoss,
+    '$.measuredOrDeclaredLoss',
+    completenessErrors,
+  );
+  validateRequiredEnumValues(
+    input.falsifiers,
+    '$.falsifiers',
+    REQUIRED_FALSIFIERS,
+    completenessErrors,
+  );
+  validateClaimOrigin(input.origin, '$.origin', completenessErrors);
+
+  if (validateDenseArray(input.evidenceRefs, '$.evidenceRefs', completenessErrors)) {
+    if (input.evidenceRefs.length === 0) {
+      completenessErrors.push('$.evidenceRefs: expected at least one evidence reference');
+    }
+    input.evidenceRefs.forEach((reference, index) => {
+      validateProvenanceRef(reference, `$.evidenceRefs[${index}]`, completenessErrors);
+    });
+  }
+
+  const transitions: BoundaryTransition[] = [];
+  if (validateDenseArray(input.transitions, '$.transitions', completenessErrors)) {
+    if (input.transitions.length === 0) {
+      completenessErrors.push('$.transitions: expected at least one boundary pair');
+    }
+    input.transitions.forEach((transition, index) => {
+      if (
+        validateBoundaryTransitionShape(
+          transition,
+          `$.transitions[${index}]`,
+          completenessErrors,
+        )
+      ) {
+        transitions.push(transition);
+      }
+    });
+  }
+
+  if (completenessErrors.length > 0) {
+    return reject('BRIDGE_INCOMPLETE', completenessErrors);
+  }
+
+  const falsifierErrors = validateBoundaryPairs(transitions).errors.map(
+    (error) => `$.transitions: ${error}`,
+  );
+  for (let index = 1; index < transitions.length; index += 1) {
+    if (transitions[index - 1].stepIndex >= transitions[index].stepIndex) {
+      falsifierErrors.push(
+        `$.transitions[${index}]: event order must be strictly increasing by stepIndex`,
+      );
+    }
+  }
+  if (falsifierErrors.length > 0) {
+    return reject('BRIDGE_FALSIFIED', falsifierErrors);
+  }
+
+  const request: MicroToMesoBridgeRequest = {
+    bridgeId: input.bridgeId as string,
+    sourceFrameId: input.sourceFrameId as string,
+    from: input.from as unknown as ScaleAddress,
+    to: input.to as unknown as ScaleAddress,
+    transitions,
+    preservedInvariants: input.preservedInvariants as PreservedInvariant[],
+    measuredOrDeclaredLoss: input.measuredOrDeclaredLoss as string[],
+    falsifiers: input.falsifiers as BridgeFalsifier[],
+    evidenceRefs: input.evidenceRefs as ProvenanceRef[],
+    origin: input.origin as unknown as ImmutableClaimOrigin,
+  };
+
+  return {
+    accepted: true,
+    decision: 'PASS_CANDIDATE',
+    errors: [],
+    trace: buildFrozenTrace(request),
+  };
+}

--- a/ui-app/lib/tesser3takt-bridge.ts
+++ b/ui-app/lib/tesser3takt-bridge.ts
@@ -292,6 +292,8 @@ function validateBoundaryTransitionShape(
   if (
     !Array.isArray(value.latticePosition) ||
     value.latticePosition.length !== 2 ||
+    !(0 in value.latticePosition) ||
+    !(1 in value.latticePosition) ||
     !value.latticePosition.every(Number.isInteger)
   ) {
     errors.push(`${path}.latticePosition: expected two integer global coordinates`);
@@ -522,6 +524,11 @@ export function buildMicroToMesoTrace(input: unknown): BridgeResult {
           `$.transitions: ${orderedPairs[index - 1].exit.pairId} lost its ENTRY`,
         );
         continue;
+      }
+      if (previousEntry.stepIndex >= currentExit.stepIndex) {
+        falsifierErrors.push(
+          `$.transitions: pair chain event order broke before ${currentExit.pairId}`,
+        );
       }
       if (previousEntry.stateId !== currentExit.stateId) {
         falsifierErrors.push(

--- a/ui-app/test/tesser3takt-bridge.test.mjs
+++ b/ui-app/test/tesser3takt-bridge.test.mjs
@@ -153,6 +153,20 @@ test('a locally valid pair cannot silently break the traversal chain', () => {
   assert.match(result.errors.join('\n'), /pair chain state continuity broke/);
 });
 
+test('complete pairs cannot interleave and masquerade as a sequential traversal', () => {
+  const interleaved = [
+    { ...fixture.transitions[0], stepIndex: 2 },
+    { ...fixture.transitions[2], stepIndex: 3 },
+    { ...fixture.transitions[1], stepIndex: 4 },
+    { ...fixture.transitions[3], stepIndex: 5 },
+  ];
+  const result = buildMicroToMesoTrace(request({ transitions: interleaved }));
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.code, 'BRIDGE_FALSIFIED');
+  assert.match(result.errors.join('\n'), /pair chain event order broke/);
+});
+
 test('lost transition provenance rejects the bridge before aggregation', () => {
   const entryWithoutProvenance = { ...fixture.transitions[1] };
   delete entryWithoutProvenance.provenance;
@@ -202,4 +216,18 @@ test('malformed and sparse transport inputs fail closed without throwing', () =>
   assert.equal(result.accepted, false);
   assert.equal(result.code, 'BRIDGE_INCOMPLETE');
   assert.match(result.errors.join('\n'), /sparse array entries are not allowed/);
+
+  const sparsePosition = [1];
+  sparsePosition.length = 2;
+  const sparseCoordinate = buildMicroToMesoTrace(
+    request({
+      transitions: [
+        { ...fixture.transitions[0], latticePosition: sparsePosition },
+        ...fixture.transitions.slice(1),
+      ],
+    }),
+  );
+  assert.equal(sparseCoordinate.accepted, false);
+  assert.equal(sparseCoordinate.code, 'BRIDGE_INCOMPLETE');
+  assert.match(sparseCoordinate.errors.join('\n'), /two integer global coordinates/);
 });

--- a/ui-app/test/tesser3takt-bridge.test.mjs
+++ b/ui-app/test/tesser3takt-bridge.test.mjs
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { buildMicroToMesoTrace } from '../lib/tesser3takt-bridge.ts';
+
+const fixture = JSON.parse(
+  readFileSync(
+    new URL('../fixtures/tesser3takt-micro-meso-bridge-v0.1.json', import.meta.url),
+    'utf8',
+  ),
+);
+
+function request(overrides = {}) {
+  return structuredClone({ ...fixture, ...overrides });
+}
+
+test('positive synthetic bridge emits a derived meso trace without claim promotion', () => {
+  const result = buildMicroToMesoTrace(fixture);
+
+  assert.equal(result.accepted, true);
+  assert.equal(result.decision, 'PASS_CANDIDATE');
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.trace.authorityStatus, 'derived');
+  assert.equal(result.trace.sourceFrameId, 'tesser3takt-minimal-v0.2');
+  assert.equal(result.trace.from.resolutionScale, 'MICRO');
+  assert.equal(result.trace.to.resolutionScale, 'MESO');
+  assert.deepEqual(result.trace.pairOrder, ['bt-001']);
+  assert.deepEqual(result.trace.eventOrder, [
+    { pairId: 'bt-001', half: 'EXIT', stepIndex: 2 },
+    { pairId: 'bt-001', half: 'ENTRY', stepIndex: 3 },
+  ]);
+  assert.deepEqual(result.trace.connectivity[0], {
+    pairId: 'bt-001',
+    fromStateId: 'S4:1234',
+    toStateId: 'S4:2143',
+    fromPosition: [1, 1],
+    toPosition: [2, 3],
+    exitProvenance: fixture.transitions[0].provenance,
+    entryProvenance: fixture.transitions[1].provenance,
+  });
+  assert.deepEqual(result.trace.origin, fixture.origin);
+});
+
+test('bridge metadata below the minimum is rejected as BRIDGE_INCOMPLETE', () => {
+  const cases = [
+    request({ bridgeId: '' }),
+    request({ sourceFrameId: '' }),
+    request({ preservedInvariants: [] }),
+    request({ measuredOrDeclaredLoss: [] }),
+    request({ falsifiers: [] }),
+    request({ evidenceRefs: [] }),
+    request({ origin: { ...fixture.origin, immutable: false } }),
+    request({ from: { ...fixture.from, extentScope: 'TRAVERSAL_SLICE' } }),
+  ];
+
+  for (const candidate of cases) {
+    const result = buildMicroToMesoTrace(candidate);
+    assert.equal(result.accepted, false);
+    assert.equal(result.decision, 'REJECT');
+    assert.equal(result.code, 'BRIDGE_INCOMPLETE');
+    assert.ok(result.errors.length > 0);
+  }
+});
+
+test('every required preserved invariant and falsifier is mechanically required', () => {
+  for (const invariant of fixture.preservedInvariants) {
+    const result = buildMicroToMesoTrace(
+      request({
+        preservedInvariants: fixture.preservedInvariants.filter(
+          (candidate) => candidate !== invariant,
+        ),
+      }),
+    );
+    assert.equal(result.accepted, false);
+    assert.equal(result.code, 'BRIDGE_INCOMPLETE');
+    assert.match(result.errors.join('\n'), new RegExp(invariant));
+  }
+
+  for (const falsifier of fixture.falsifiers) {
+    const result = buildMicroToMesoTrace(
+      request({
+        falsifiers: fixture.falsifiers.filter((candidate) => candidate !== falsifier),
+      }),
+    );
+    assert.equal(result.accepted, false);
+    assert.equal(result.code, 'BRIDGE_INCOMPLETE');
+    assert.match(result.errors.join('\n'), new RegExp(falsifier));
+  }
+});
+
+test('missing or reordered boundary halves falsify the bridge', () => {
+  const orphan = buildMicroToMesoTrace(request({ transitions: [fixture.transitions[0]] }));
+  assert.equal(orphan.accepted, false);
+  assert.equal(orphan.code, 'BRIDGE_FALSIFIED');
+  assert.match(orphan.errors.join('\n'), /exactly one EXIT and one ENTRY/);
+
+  const reordered = buildMicroToMesoTrace(
+    request({ transitions: [fixture.transitions[1], fixture.transitions[0]] }),
+  );
+  assert.equal(reordered.accepted, false);
+  assert.equal(reordered.code, 'BRIDGE_FALSIFIED');
+  assert.match(reordered.errors.join('\n'), /strictly increasing by stepIndex/);
+});
+
+test('changed connectivity falsifies the bridge', () => {
+  const changedEntry = {
+    ...fixture.transitions[1],
+    transformedFrom: 'S4:9999',
+  };
+  const result = buildMicroToMesoTrace(
+    request({ transitions: [fixture.transitions[0], changedEntry] }),
+  );
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.code, 'BRIDGE_FALSIFIED');
+  assert.match(result.errors.join('\n'), /transformedFrom must match EXIT stateId/);
+});
+
+test('lost transition provenance rejects the bridge before aggregation', () => {
+  const entryWithoutProvenance = { ...fixture.transitions[1] };
+  delete entryWithoutProvenance.provenance;
+
+  const result = buildMicroToMesoTrace(
+    request({ transitions: [fixture.transitions[0], entryWithoutProvenance] }),
+  );
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.code, 'BRIDGE_INCOMPLETE');
+  assert.match(result.errors.join('\n'), /provenance/);
+});
+
+test('claim origin is copied, frozen, and cannot be laundered by the bridge', () => {
+  const metaphorOrigin = {
+    claimTag: 'METAPHER',
+    evidenceRole: 'PROVENANCE_ONLY',
+    immutable: true,
+  };
+  const result = buildMicroToMesoTrace(request({ origin: metaphorOrigin }));
+
+  assert.equal(result.accepted, true);
+  assert.deepEqual(result.trace.origin, metaphorOrigin);
+  assert.equal(Object.isFrozen(result.trace), true);
+  assert.equal(Object.isFrozen(result.trace.origin), true);
+  assert.equal(Object.isFrozen(result.trace.connectivity), true);
+  assert.equal(Object.isFrozen(result.trace.connectivity[0].exitProvenance), true);
+  assert.throws(() => {
+    result.trace.origin.claimTag = 'CANON';
+  }, TypeError);
+  assert.equal(result.trace.origin.claimTag, 'METAPHER');
+});
+
+test('malformed and sparse transport inputs fail closed without throwing', () => {
+  assert.deepEqual(buildMicroToMesoTrace(null), {
+    accepted: false,
+    decision: 'REJECT',
+    code: 'BRIDGE_INCOMPLETE',
+    errors: ['$: expected a bridge request object'],
+  });
+
+  const sparse = [fixture.transitions[0]];
+  sparse.length = 3;
+  sparse[2] = fixture.transitions[1];
+  const result = buildMicroToMesoTrace(request({ transitions: sparse }));
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.code, 'BRIDGE_INCOMPLETE');
+  assert.match(result.errors.join('\n'), /sparse array entries are not allowed/);
+});

--- a/ui-app/test/tesser3takt-bridge.test.mjs
+++ b/ui-app/test/tesser3takt-bridge.test.mjs
@@ -22,13 +22,15 @@ test('positive synthetic bridge emits a derived meso trace without claim promoti
   assert.equal(result.decision, 'PASS_CANDIDATE');
   assert.deepEqual(result.errors, []);
   assert.equal(result.trace.authorityStatus, 'derived');
-  assert.equal(result.trace.sourceFrameId, 'tesser3takt-minimal-v0.2');
+  assert.equal(result.trace.sourceFrameId, 'tesser3takt-micro-slice-v0.1');
   assert.equal(result.trace.from.resolutionScale, 'MICRO');
   assert.equal(result.trace.to.resolutionScale, 'MESO');
-  assert.deepEqual(result.trace.pairOrder, ['bt-001']);
+  assert.deepEqual(result.trace.pairOrder, ['bt-001', 'bt-002']);
   assert.deepEqual(result.trace.eventOrder, [
     { pairId: 'bt-001', half: 'EXIT', stepIndex: 2 },
     { pairId: 'bt-001', half: 'ENTRY', stepIndex: 3 },
+    { pairId: 'bt-002', half: 'EXIT', stepIndex: 4 },
+    { pairId: 'bt-002', half: 'ENTRY', stepIndex: 5 },
   ]);
   assert.deepEqual(result.trace.connectivity[0], {
     pairId: 'bt-001',
@@ -38,6 +40,15 @@ test('positive synthetic bridge emits a derived meso trace without claim promoti
     toPosition: [2, 3],
     exitProvenance: fixture.transitions[0].provenance,
     entryProvenance: fixture.transitions[1].provenance,
+  });
+  assert.deepEqual(result.trace.connectivity[1], {
+    pairId: 'bt-002',
+    fromStateId: 'S4:2143',
+    toStateId: 'S4:2413',
+    fromPosition: [2, 3],
+    toPosition: [4, 4],
+    exitProvenance: fixture.transitions[2].provenance,
+    entryProvenance: fixture.transitions[3].provenance,
   });
   assert.deepEqual(result.trace.origin, fixture.origin);
 });
@@ -115,6 +126,31 @@ test('changed connectivity falsifies the bridge', () => {
   assert.equal(result.accepted, false);
   assert.equal(result.code, 'BRIDGE_FALSIFIED');
   assert.match(result.errors.join('\n'), /transformedFrom must match EXIT stateId/);
+});
+
+test('a locally valid pair cannot silently break the traversal chain', () => {
+  const disconnectedExit = {
+    ...fixture.transitions[2],
+    stateId: 'S4:9999',
+  };
+  const internallyReboundEntry = {
+    ...fixture.transitions[3],
+    transformedFrom: 'S4:9999',
+  };
+  const result = buildMicroToMesoTrace(
+    request({
+      transitions: [
+        fixture.transitions[0],
+        fixture.transitions[1],
+        disconnectedExit,
+        internallyReboundEntry,
+      ],
+    }),
+  );
+
+  assert.equal(result.accepted, false);
+  assert.equal(result.code, 'BRIDGE_FALSIFIED');
+  assert.match(result.errors.join('\n'), /pair chain state continuity broke/);
 });
 
 test('lost transition provenance rejects the bridge before aggregation', () => {


### PR DESCRIPTION
FOKUS: Falsifizierbare Mikro→Meso-Brücke v0.1

## Was sich ändert

- führt einen schmalen `BoundaryTransition[] → TransitionTrace`-Adapter ein
- adressiert `MICRO / TRAVERSAL_CELL` und `MESO / TRAVERSAL_SLICE` getrennt
- verlangt `bridgeId`, `sourceFrameId`, fünf erhaltene Invarianten, deklarierte Verluste, vier Falsifikatoren, Evidenzreferenzen und einen unveränderlichen Ursprung
- unterscheidet `REJECT(BRIDGE_INCOMPLETE)` von `REJECT(BRIDGE_FALSIFIED)`
- trägt Pair-/Event-Reihenfolge, gerichtete Konnektivität und EXIT-/ENTRY-Provenienz in den Trace
- verwendet einen nichttrivialen Zweipaar-Fixture
- erzwingt Ereignis-, State- und Positionskontinuität zwischen Paaren und weist zeitlich verschachtelte Paare zurück
- ergänzt Negativtests, ANNEX-Spezifikation und Audit-Report

## Grenze

- ANNEX · DERIVED · `[BRIDGE-WIP]`
- Erfolg heißt nur `PASS_CANDIDATE`
- keine Änderung an GOLD, VOIDMAP, Policies, Receipts oder NICHTRAUM
- keine Claim-Promotion, HumanDecision, Switchboard-Persistenz oder Grimm-Runtime
- `PROVENANCE_ONLY` bleibt eine Evidence-Rolle und wird nicht als neuer Claim-Tag eingeführt

## Verifikation

- `pnpm --filter entaengelment-ui test` — 23/23 PASS
- neue Bridge-Tests — 10/10 PASS
- `make verify` — 290/290 Python-Tests plus Port-/Pointer-/Claim-Gates PASS
- `make verify-governance` — 14 Workflows plus VOID-/UI-Drift PASS
- `make verify-js` — TypeScript, ESLint, Workspace-Typen und Next-Produktionsbuild PASS
- GitHub-Readback — alle 6 Dateien bytegleich zum lokal geprüften Commit

## Offene Reviewfrage

Muss `sourceFrameId` bereits vor dem Übergang aus Draft zusätzlich an einen kanonischen Frame-Digest gebunden werden, oder genügt für v0.1 die strukturelle ID- plus Provenienzbindung?

Kein Merge und keine Statuspromotion sind Teil dieses Drafts.