### PR TITLE
feat(core): Dual-Format Claim Bridge Adapter v0.1 (M1 → ERK)

### DIFF
--- a/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
+++ b/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
@@ -1,0 +1,153 @@
+# DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1
+
+**Status:** Draft
+**Claim-Status:** [SPEC-WIP]
+**Authority-Status:** ANNEX
+**Runtime-Enforcement:** partial (nur was der Adapter beim Aufruf prüft)
+**Promotion-Effect:** none
+**Human-Decision-Boundary:** required
+**Modul:** `src/core/evidence_bridge_adapter.py`
+**Source:** Synthbiosis Systematlas v1.1 / `01_DUAL_FORMAT_CLAIM_BRIDGE.md`
+(Bundle-Witness: `INBOX/INTAKE-2026-07-21-synthbiosis-system-atlas-v1_1.md`;
+Feld-Mapping: `docs/annex/SYNTHBIOSIS_MODULE_ADAPTER_MAP_v0_1.md` §2.1)
+
+```yaml
+source_relation:
+  relation: reduced_public_adapter
+  source_identity: not_claimed
+  semantic_equivalence: not_claimed
+  known_loss_required: true
+```
+
+---
+
+## 1. Zweck
+
+Eine **Brücke** überträgt genau *eine* benannte Eigenschaft aus einem
+Quellregister in ein Zielregister — unter sichtbarem Verlust. Der Adapter
+übersetzt einen solchen Bridge-Record in Vorschlagsobjekte des Evidence
+Routing Kernel:
+
+```
+BridgeRecord → MaterialRef + EvidenceRelation (+ optional ClaimCandidate)
+```
+
+[ANNEX] Der Adapter ist **reine Übersetzung**. Er emittiert kein Ledger-Event,
+schreibt keine Datei, öffnet keine Verbindung und verändert keinen Claim-Tag.
+Ob und wann die Vorschläge in einen Eventstream gelangen, entscheidet der
+Aufrufer — und dort greifen Guard und `HumanDecision` unverändert.
+
+## 2. Was eine vollständige Brücke beantworten muss
+
+Die Pflichtfelder entsprechen den sechs Brückenfragen des Quellmoduls:
+
+| Frage | Feld |
+|---|---|
+| Was ist die Quellform? | `source_register` + `source_pointer` + `source_digest` |
+| Welche *einzelne* Eigenschaft wird übertragen? | `transferred_property` |
+| Welche Relation soll erhalten bleiben? | `preserved_relation` |
+| Was geht verloren? | `known_loss` (mindestens ein Eintrag) |
+| Woran würde die Brücke scheitern? | `falsifier` |
+| Wie wird sie zurückgenommen? | `rollback` |
+
+[FACT] Fehlt eines dieser Felder, verweigert der Adapter die Übersetzung
+(`BridgeAdapterError`, fail-closed). Insbesondere ist `known_loss` **Pflicht**:
+Eine Brücke ohne benannten Verlust behauptet implizit Verlustfreiheit — und
+damit Identität zwischen den Registern.
+
+## 3. Registerreichweite (Kernregel)
+
+[MODEL] Wie weit ein Quellregister relational reichen darf, ist strukturell
+begrenzt. Promotionsfähig sind im Kernel nur `SUPPORTS`, `MEASURES` und
+`IMPLEMENTS`.
+
+| Quellregister | promotionsfähige Relation? | Begründung |
+|---|---|---|
+| `myth`, `metaphor` | **nie** | Metapher ist keine Evidenz (Invariante 3) |
+| `psychological` | **nie** | keine Diagnose, kein Claim über eine Person |
+| `ui` | **nie** | ein UI-Frame ist kein Wahrheitszeuge |
+| `physical`, `biological` | nur mit `m5_review_pointer` | kein Weg an der methodischen Prüfung vorbei |
+| `formal`, `governance` | ja (strukturell) | inhaltliche Tragfähigkeit bleibt Review-Frage |
+
+[FACT] Ein Verstoß führt zum Abbruch, **nicht** zu stiller Degradierung: Der
+Adapter schreibt eine unzulässige Relation nicht heimlich auf einen
+schwächeren Typ um, sondern verweigert und nennt den Grund.
+
+Zusätzlich setzt der Adapter für mythische und metaphorische Register die
+Materialart auf `metaphor`. Damit greift der Kernel-Guard
+(`NON_EVIDENCE_MATERIAL_KINDS`) **unabhängig vom Adapter** — die Grenze hält
+auch dann, wenn jemand den Adapter umgeht und das Material direkt registriert.
+
+## 4. Weitere Grenzen
+
+- **Kein Rohinhalt:** Es gehen nur `source_pointer`, `source_digest` und
+  Metadaten weiter. Der Quellausdruck selbst wird nie übernommen.
+- **`protected_origin`** setzt die Sichtbarkeit auf `private` — nach unten,
+  nie nach oben.
+- **Trust-Default `UNTRUSTED`** (G5). Untrusted Material kann keine
+  Promotionsfähigkeit erzeugen.
+- **Verbotene Tags:** Der Adapter vergibt `[FACT]`, `[SPEC]` und `[CANON]`
+  niemals selbst — auch nicht über einen Alias wie `[FAKT]`. Ein
+  `ClaimCandidate` trägt höchstens ein Einstiegstag; jede Höherstufung läuft
+  über Guard und `HumanDecision`.
+- **Geschlossenes Feldschema:** Unbekannte Felder im Eingabe-Mapping werden
+  abgelehnt.
+
+## 5. Zwei getrennte Befundvokabulare
+
+[ANNEX] Der Adapter braucht Begriffe für Übersetzungsfehler, die der Kernel
+nicht kennt. Diese leben in einem **eigenen** Enum `BridgeReason` und
+erscheinen ausschließlich im Rückgabeobjekt (`BridgeTranslation.notes`) oder in
+der Fehlermeldung.
+
+Sie werden **nie** in ein Event, nie in `EvidenceRelation.reason_codes` und nie
+in einen Claim geschrieben. Für alles, was der Kernel bereits benennt
+(`METAPHOR_IS_NOT_EVIDENCE`, `PROVENANCE_IS_NOT_EVIDENCE`,
+`UNTRUSTED_MATERIAL`), verwendet der Adapter dessen `ReasonCode` unverändert.
+Ein Test hält diese Trennung fest.
+
+[CONTEXT] `BridgeReason` ist kein Projektstatus, kein Claim-Tag und keine
+Entscheidungsleiter — es ist adapter-lokal, wie `HOLD` im Change-Gate
+gate-lokal ist.
+
+## 6. Verhältnis zu den anderen Modulen
+
+**M1 ↔ ERK:** Der Adapter erzeugt Vorschläge; der Kernel entscheidet über
+Struktur (Guard) und der Mensch über Geltung (`HumanDecision`). Der Adapter
+kann keine `HumanDecision` synthetisieren und nichts retaggen.
+
+**M1 ↔ M5:** `falsifier` ist im Bridge-Record Pflicht, wird aber vom Adapter
+nur auf Vorhandensein geprüft. Ob er trägt, entscheidet das Research Gate
+(`docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md`). Physische und biologische
+Register brauchen für Promotionsfähigkeit einen dokumentierten
+`m5_review_pointer`.
+
+**M1 ↔ tesser3TAKT:** Keine Berührung. Der Adapter kennt kein
+Navigationsvokabular und übersetzt keines.
+
+## 7. Known Loss
+
+- Der Adapter prüft **Struktur, nicht Inhalt**: ob eine behauptete Relation
+  sachlich trägt, entscheidet er nicht.
+- Die vier Minimaltests des Quellmoduls (Josephson–Jesus, 7×9–Yggdrasil,
+  RCC-8–Photonik, „Liebe"–HRV) sind als Tests umgesetzt, nicht als
+  JSONL-Fixtures.
+- Eine menschenlesbare Anzeige, die Quelle, Status, Verlust und Rücknahme
+  gleichzeitig zeigt, bleibt offen — sie ist im Quellmodul das
+  Exit-Kriterium für Implementierungsreife.
+- Die Registerliste ist ein erster Schnitt und braucht menschliche
+  Bestätigung.
+
+## 8. Rücknahme
+
+Modul, Test und dieses Dokument nach `NICHTRAUM/archive/` verschieben und den
+additiven Export-Block in `src/core/__init__.py` zurücknehmen (G3). Kein
+bestehendes Modul importiert den Adapter; der Kernel bleibt unverändert
+lauffähig.
+
+## 9. Offene Punkte
+
+- [ ] ☐ Menschenlesbare Bridge-Anzeige (Exit-Kriterium des Quellmoduls).
+- [ ] ☐ Ein Aufrufpfad, der Vorschläge tatsächlich als Events schreibt, ist
+      bewusst nicht Teil dieser Phase.
+- [ ] ☐ Bestätigung der Register-zu-Relationstyp-Matrix.

--- a/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
+++ b/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
@@ -61,27 +61,63 @@ damit Identität zwischen den Registern.
 begrenzt. Promotionsfähig sind im Kernel nur `SUPPORTS`, `MEASURES` und
 `IMPLEMENTS`.
 
-| Quellregister | promotionsfähige Relation? | Begründung |
+| Quellregister | Entscheidung für v0.1 | spätere Öffnung |
 |---|---|---|
-| `myth`, `metaphor` | **nie** | Metapher ist keine Evidenz (Invariante 3) |
-| `psychological` | **nie** | keine Diagnose, kein Claim über eine Person |
-| `ui` | **nie** | ein UI-Frame ist kein Wahrheitszeuge |
-| `physical`, `biological` | nur mit `m5_review_pointer` | kein Weg an der methodischen Prüfung vorbei |
-| `formal`, `governance` | ja (strukturell) | inhaltliche Tragfähigkeit bleibt Review-Frage |
+| `myth`, `metaphor` | **nie** promotionsfähig | unverändert — Metapher ist keine Evidenz (Invariante 3) |
+| `psychological` | **nie** promotionsfähig | unverändert — keine Diagnose, kein Claim über eine Person |
+| `ui` | **nie** promotionsfähig | unverändert — ein UI-Frame ist kein Wahrheitszeuge |
+| `formal` | nur Kontext/Provenienz | `SUPPORTS`/`IMPLEMENTS` erst mit formalem Review-Witness und gebundener Zieldomäne; **niemals pauschal** `MEASURES` |
+| `governance` | nur `CONTEXTUALIZES`, `MOTIVATES`, `PROVENANCE_ONLY` | höchstens `IMPLEMENTS` innerhalb explizit dokumentierter Authority-/Scope-Grenzen |
+| `physical`, `biological` | Promotion nur mit `m5_review_pointer` | unverändert |
 
-[FACT] Ein Verstoß führt zum Abbruch, **nicht** zu stiller Degradierung: Der
-Adapter schreibt eine unzulässige Relation nicht heimlich auf einen
-schwächeren Typ um, sondern verweigert und nennt den Grund.
+[FACT] **In v0.1 ist damit kein Register ohne dokumentiertes Gate
+promotionsfähig.** Der Grund liegt im Kernel: `evaluate_transition_request()`
+prüft für `PROPOSE` strukturell nur, ob die Relation promotionsfähig ist, ob
+die Materialart keine Metapher ist und ob Trust nicht `UNTRUSTED` lautet. Ein
+`REVIEWED`-Governance-Dokument könnte dort sonst mit `MEASURES` ein
+strukturell grünes Signal erhalten, das seine Reichweite überschätzt — es
+promoviert zwar nicht autonom (die `HumanDecision` bleibt), aber das Signal
+wäre irreführend.
+
+[INFERENZ] Für `formal` fehlt dem Record derzeit die entscheidende
+Unterscheidung: Er kennt weder `target_register`/`claim_domain` noch einen
+formalen Review-Pointer und kann deshalb „Beweis einer Grapheneigenschaft"
+nicht von „Formel stützt Behauptung über die Welt" trennen. Bis diese Bindung
+existiert: Kontext, nicht Promotion.
+
+[FACT] Ein Verstoß führt zum **Abbruch, nicht zur Degradierung** — auch nicht
+zu einer sichtbaren. Eine automatische Abstufung wäre keine Übersetzung mehr,
+sondern eine Entscheidung: Der Aufrufer sagte `MEASURES`, der Adapter
+erzeugte `CONTEXTUALIZES`. Stattdessen nennt der Fehlertext die zulässigen
+Relationstypen und weist darauf hin, dass ein **Mensch** einen neuen,
+ausdrücklich anders lautenden Record einreichen kann.
 
 Zusätzlich setzt der Adapter für mythische und metaphorische Register die
 Materialart auf `metaphor`. Damit greift der Kernel-Guard
 (`NON_EVIDENCE_MATERIAL_KINDS`) **unabhängig vom Adapter** — die Grenze hält
 auch dann, wenn jemand den Adapter umgeht und das Material direkt registriert.
 
-## 4. Weitere Grenzen
+## 4. Der Kontext überlebt die Übersetzung
+
+[FACT] `BridgeTranslation` trägt einen unveränderlichen `BridgeContext` mit den
+sechs Brückenantworten plus `m5_review_pointer`. Er erscheint auch in
+`to_dict()`.
+
+Ohne ihn wäre die Übersetzung eine Behauptung ohne Beschriftung: Man sähe die
+Relation, aber weder die übertragene Eigenschaft noch den Verlust, den
+Falsifikator, den Rücknahmeweg — und bei physischen Registern auch nicht, **aus
+welchem Grund das M5-Gate passiert werden durfte**. Ein validierter und danach
+verworfener `known_loss` widerspricht der Regel „Known Loss muss sichtbar
+bleiben" direkt.
+
+`known_loss` wird intern als Tupel geführt. Ein blanker String wird abgelehnt:
+Er ist iterierbar und ginge sonst zeichenweise als Liste durch.
+
+## 5. Weitere Grenzen
 
 - **Kein Rohinhalt:** Es gehen nur `source_pointer`, `source_digest` und
   Metadaten weiter. Der Quellausdruck selbst wird nie übernommen.
+  `source_digest` ist Pflichttext.
 - **`protected_origin`** setzt die Sichtbarkeit auf `private` — nach unten,
   nie nach oben.
 - **Trust-Default `UNTRUSTED`** (G5). Untrusted Material kann keine
@@ -93,7 +129,7 @@ auch dann, wenn jemand den Adapter umgeht und das Material direkt registriert.
 - **Geschlossenes Feldschema:** Unbekannte Felder im Eingabe-Mapping werden
   abgelehnt.
 
-## 5. Zwei getrennte Befundvokabulare
+## 6. Zwei getrennte Befundvokabulare
 
 [ANNEX] Der Adapter braucht Begriffe für Übersetzungsfehler, die der Kernel
 nicht kennt. Diese leben in einem **eigenen** Enum `BridgeReason` und
@@ -110,7 +146,7 @@ Ein Test hält diese Trennung fest.
 Entscheidungsleiter — es ist adapter-lokal, wie `HOLD` im Change-Gate
 gate-lokal ist.
 
-## 6. Verhältnis zu den anderen Modulen
+## 7. Verhältnis zu den anderen Modulen
 
 **M1 ↔ ERK:** Der Adapter erzeugt Vorschläge; der Kernel entscheidet über
 Struktur (Guard) und der Mensch über Geltung (`HumanDecision`). Der Adapter
@@ -125,7 +161,7 @@ Register brauchen für Promotionsfähigkeit einen dokumentierten
 **M1 ↔ tesser3TAKT:** Keine Berührung. Der Adapter kennt kein
 Navigationsvokabular und übersetzt keines.
 
-## 7. Known Loss
+## 8. Known Loss
 
 - Der Adapter prüft **Struktur, nicht Inhalt**: ob eine behauptete Relation
   sachlich trägt, entscheidet er nicht.
@@ -138,14 +174,14 @@ Navigationsvokabular und übersetzt keines.
 - Die Registerliste ist ein erster Schnitt und braucht menschliche
   Bestätigung.
 
-## 8. Rücknahme
+## 9. Rücknahme
 
 Modul, Test und dieses Dokument nach `NICHTRAUM/archive/` verschieben und den
 additiven Export-Block in `src/core/__init__.py` zurücknehmen (G3). Kein
 bestehendes Modul importiert den Adapter; der Kernel bleibt unverändert
 lauffähig.
 
-## 9. Offene Punkte
+## 10. Offene Punkte
 
 - [ ] ☐ Menschenlesbare Bridge-Anzeige (Exit-Kriterium des Quellmoduls).
 - [ ] ☐ Ein Aufrufpfad, der Vorschläge tatsächlich als Events schreibt, ist

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -11,6 +11,14 @@ Enthält die fünf Kern-Metriken (Core-5):
 Zusätzlich: Evidence Routing Kernel v0.1a (bewusst kleine, stabile Exports).
 """
 
+from .evidence_bridge_adapter import (
+    BridgeAdapterError,
+    BridgeReason,
+    BridgeRecord,
+    BridgeTranslation,
+    translate_bridge_record,
+    validate_bridge_record,
+)
 from .evidence_routing import (
     ClaimCandidate,
     ClaimPolicy,
@@ -68,4 +76,11 @@ __all__ = [
     "replay_events",
     "reduce_public_export",
     "compute_state_digest",
+    # Dual-Format Claim Bridge Adapter v0.1 (M1 -> ERK)
+    "BridgeRecord",
+    "BridgeTranslation",
+    "BridgeReason",
+    "BridgeAdapterError",
+    "validate_bridge_record",
+    "translate_bridge_record",
 ]

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -13,6 +13,7 @@ Zusätzlich: Evidence Routing Kernel v0.1a (bewusst kleine, stabile Exports).
 
 from .evidence_bridge_adapter import (
     BridgeAdapterError,
+    BridgeContext,
     BridgeReason,
     BridgeRecord,
     BridgeTranslation,
@@ -79,6 +80,7 @@ __all__ = [
     # Dual-Format Claim Bridge Adapter v0.1 (M1 -> ERK)
     "BridgeRecord",
     "BridgeTranslation",
+    "BridgeContext",
     "BridgeReason",
     "BridgeAdapterError",
     "validate_bridge_record",

--- a/src/core/evidence_bridge_adapter.py
+++ b/src/core/evidence_bridge_adapter.py
@@ -84,14 +84,31 @@ KNOWN_SOURCE_REGISTERS = frozenset(
 NON_EVIDENCE_REGISTERS = frozenset({REGISTER_MYTH, REGISTER_METAPHOR})
 
 # Register, die erst nach dokumentierter methodischer Prüfung (M5) eine
-# promotionsfähige Relation tragen dürfen.
+# promotionsfähige Relation tragen dürfen. In v0.1 sind das die einzigen
+# Register, die überhaupt promotionsfähig werden können.
 M5_GATED_REGISTERS = frozenset({REGISTER_PHYSICAL, REGISTER_BIOLOGICAL})
 
-# Register ohne jede promotionsfähige Reichweite: Sie können Kontext geben oder
-# motivieren, aber niemals stützen oder messen.
+# Register ohne jede promotionsfähige Reichweite — auch später nicht. Sie können
+# Kontext geben oder motivieren, aber niemals stützen oder messen.
 NON_PROMOTING_REGISTERS = frozenset(
     {REGISTER_MYTH, REGISTER_METAPHOR, REGISTER_PSYCHOLOGICAL, REGISTER_UI}
 )
+
+# Register, die in v0.1 nur Kontext und Provenienz tragen, deren spätere
+# Öffnung aber an eine benannte Bedingung geknüpft ist. Der Kernel prüft für
+# ``PROPOSE`` strukturell nur Relationstyp, Materialart und Trust — ein
+# ``REVIEWED``-Dokument könnte dort sonst ein grünes Signal erhalten, das seine
+# Reichweite überschätzt. Bis die jeweilige Bindung existiert: kein Proposal.
+DEFERRED_PROMOTION_REGISTERS = {
+    REGISTER_FORMAL: (
+        "Öffnung erst mit formalem Review-Witness und gebundener Zieldomäne "
+        "(target_register/claim_domain); niemals pauschal MEASURES"
+    ),
+    REGISTER_GOVERNANCE: (
+        "Öffnung höchstens für IMPLEMENTS innerhalb explizit dokumentierter "
+        "Authority-/Scope-Grenzen"
+    ),
+}
 
 # Relationen, die ohne weitere Prüfung immer zulässig sind.
 CONTEXT_ONLY_RELATIONS = frozenset({"MOTIVATES", "CONTEXTUALIZES", "PROVENANCE_ONLY"})
@@ -127,8 +144,11 @@ class BridgeReason(str, Enum):
     UNKNOWN_SOURCE_REGISTER = "UNKNOWN_SOURCE_REGISTER"
     UNKNOWN_RELATION_TYPE = "UNKNOWN_RELATION_TYPE"
     REGISTER_CANNOT_PROMOTE = "REGISTER_CANNOT_PROMOTE"
+    PROMOTION_NOT_ENABLED_IN_V0_1 = "PROMOTION_NOT_ENABLED_IN_V0_1"
     M5_REVIEW_REQUIRED = "M5_REVIEW_REQUIRED"
     KNOWN_LOSS_REQUIRED = "KNOWN_LOSS_REQUIRED"
+    KNOWN_LOSS_MUST_BE_LIST = "KNOWN_LOSS_MUST_BE_LIST"
+    SOURCE_DIGEST_REQUIRED = "SOURCE_DIGEST_REQUIRED"
     FALSIFIER_REQUIRED = "FALSIFIER_REQUIRED"
     ROLLBACK_REQUIRED = "ROLLBACK_REQUIRED"
     TRANSFERRED_PROPERTY_REQUIRED = "TRANSFERRED_PROPERTY_REQUIRED"
@@ -185,6 +205,40 @@ class BridgeRecord:
 
 
 @dataclass(frozen=True)
+class BridgeContext:
+    """Die sechs Brückenfragen, die mit der Übersetzung erhalten bleiben.
+
+    Ohne diesen Kontext wäre die Übersetzung eine Behauptung ohne Beschriftung:
+    Man sähe die Relation, aber weder die übertragene Eigenschaft noch den
+    Verlust, den Falsifikator, den Rücknahmeweg — und bei physischen Registern
+    auch nicht, warum das M5-Gate passiert werden durfte.
+    """
+
+    source_register: str
+    transferred_property: str
+    preserved_relation: str
+    known_loss: tuple[str, ...]
+    falsifier: str
+    rollback: str
+    intended_use: str
+    protected_origin: bool
+    m5_review_pointer: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_register": self.source_register,
+            "transferred_property": self.transferred_property,
+            "preserved_relation": self.preserved_relation,
+            "known_loss": list(self.known_loss),
+            "falsifier": self.falsifier,
+            "rollback": self.rollback,
+            "intended_use": self.intended_use,
+            "protected_origin": self.protected_origin,
+            "m5_review_pointer": self.m5_review_pointer,
+        }
+
+
+@dataclass(frozen=True)
 class BridgeTranslation:
     """Ergebnis einer Übersetzung — Vorschläge, kein Vollzug."""
 
@@ -194,7 +248,13 @@ class BridgeTranslation:
     relation: EvidenceRelation
     claim: ClaimCandidate | None
     promotion_capable: bool
+    context: BridgeContext
     notes: tuple[BridgeReason, ...] = field(default=())
+
+    @property
+    def known_loss(self) -> tuple[str, ...]:
+        """Der benannte Verlust bleibt am Ergebnis sichtbar."""
+        return self.context.known_loss
 
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {
@@ -204,6 +264,7 @@ class BridgeTranslation:
             "relation": asdict(self.relation),
             "claim": asdict(self.claim) if self.claim is not None else None,
             "promotion_capable": self.promotion_capable,
+            "context": self.context.to_dict(),
             "notes": [note.value for note in self.notes],
         }
         return data
@@ -247,6 +308,7 @@ def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None =
         )
 
     _require_text(record.source_pointer, BridgeReason.SOURCE_POINTER_REQUIRED, "source_pointer")
+    _require_text(record.source_digest, BridgeReason.SOURCE_DIGEST_REQUIRED, "source_digest")
     _require_text(
         record.transferred_property,
         BridgeReason.TRANSFERRED_PROPERTY_REQUIRED,
@@ -259,6 +321,14 @@ def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None =
     )
     _require_text(record.falsifier, BridgeReason.FALSIFIER_REQUIRED, "falsifier")
     _require_text(record.rollback, BridgeReason.ROLLBACK_REQUIRED, "rollback")
+
+    # Ein blanker String ist iterierbar: ohne diese Prüfung würde
+    # known_loss="Kantengewichte" zeichenweise als Liste durchgehen.
+    if isinstance(record.known_loss, str) or not isinstance(record.known_loss, (list, tuple)):
+        raise BridgeAdapterError(
+            "known_loss must be a list or tuple of strings, not a bare string",
+            [BridgeReason.KNOWN_LOSS_MUST_BE_LIST],
+        )
 
     # Known Loss ist Pflicht: Eine Brücke ohne sichtbaren Verlust behauptet
     # implizit Verlustfreiheit — und damit Identität.
@@ -275,21 +345,35 @@ def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None =
 
 
 def _validate_register_reach(record: BridgeRecord) -> None:
-    """Erzwingt, wie weit ein Quellregister relational reichen darf."""
+    """Erzwingt, wie weit ein Quellregister relational reichen darf.
+
+    Bei Verstoß wird abgebrochen, nicht abgestuft. Eine automatische
+    Degradierung auf ``CONTEXTUALIZES`` wäre keine Übersetzung mehr, sondern
+    eine Entscheidung: Der Aufrufer sagte ``MEASURES``. Die Korrektur ist ein
+    neuer, ausdrücklich anders lautender Record — von einem Menschen.
+    """
     if record.relation_type not in PROMOTION_CAPABLE_RELATION_TYPES:
         return
 
+    hint = (
+        f"Zulässig sind hier {sorted(CONTEXT_ONLY_RELATIONS)}. Der Adapter stuft "
+        "nicht selbst ab; ein Mensch kann einen neuen Record mit ausdrücklich "
+        "diesem Relationstyp einreichen."
+    )
+
     if record.source_register in NON_PROMOTING_REGISTERS:
-        reason = (
-            BridgeReason.REGISTER_CANNOT_PROMOTE
-            if record.source_register not in NON_EVIDENCE_REGISTERS
-            else BridgeReason.REGISTER_CANNOT_PROMOTE
-        )
         raise BridgeAdapterError(
             f"source_register {record.source_register!r} cannot carry a "
-            f"promotion-capable relation ({record.relation_type}); "
-            f"allowed: {sorted(CONTEXT_ONLY_RELATIONS)}",
-            [reason],
+            f"promotion-capable relation ({record.relation_type}). {hint}",
+            [BridgeReason.REGISTER_CANNOT_PROMOTE],
+        )
+
+    if record.source_register in DEFERRED_PROMOTION_REGISTERS:
+        condition = DEFERRED_PROMOTION_REGISTERS[record.source_register]
+        raise BridgeAdapterError(
+            f"source_register {record.source_register!r} is not promotion-enabled "
+            f"in v0.1 ({record.relation_type}): {condition}. {hint}",
+            [BridgeReason.PROMOTION_NOT_ENABLED_IN_V0_1],
         )
 
     if record.source_register in M5_GATED_REGISTERS and not (
@@ -297,7 +381,7 @@ def _validate_register_reach(record: BridgeRecord) -> None:
     ):
         raise BridgeAdapterError(
             f"source_register {record.source_register!r} requires a documented "
-            "m5_review_pointer before a promotion-capable relation is allowed",
+            f"m5_review_pointer before a promotion-capable relation is allowed. {hint}",
             [BridgeReason.M5_REVIEW_REQUIRED],
         )
 
@@ -429,6 +513,20 @@ def translate_bridge_record(
         and normalized_trust != TRUST_UNTRUSTED
     )
 
+    # Die sechs Brückenfragen bleiben am Ergebnis sichtbar — insbesondere der
+    # Verlust und der Grund, aus dem ein physisches Register das Gate passierte.
+    context = BridgeContext(
+        source_register=record.source_register,
+        transferred_property=record.transferred_property.strip(),
+        preserved_relation=record.preserved_relation.strip(),
+        known_loss=tuple(item.strip() for item in record.known_loss),
+        falsifier=record.falsifier.strip(),
+        rollback=record.rollback.strip(),
+        intended_use=record.intended_use,
+        protected_origin=record.protected_origin,
+        m5_review_pointer=record.m5_review_pointer,
+    )
+
     return BridgeTranslation(
         bridge_id=record.bridge_id,
         schema_version=BRIDGE_SCHEMA_VERSION,
@@ -436,6 +534,7 @@ def translate_bridge_record(
         relation=relation,
         claim=claim,
         promotion_capable=promotion_capable,
+        context=context,
         notes=tuple(notes),
     )
 

--- a/src/core/evidence_bridge_adapter.py
+++ b/src/core/evidence_bridge_adapter.py
@@ -1,0 +1,456 @@
+"""
+src/core/evidence_bridge_adapter.py
+
+Dual-Format Claim Bridge Adapter v0.1 (M1 -> ERK).
+
+Übersetzt einen Bridge-Record — die dokumentierte Übertragung *einer* Eigenschaft
+aus einem Quellregister in ein Zielregister — in Vorschlagsobjekte des Evidence
+Routing Kernel: ``MaterialRef``, ``EvidenceRelation`` und optional
+``ClaimCandidate``.
+
+Architekturgrenze (siehe docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md):
+
+- Der Adapter ist **reine Übersetzung**: kein Ledger-Event, kein Dateizugriff,
+  kein Netzwerk, keine Zustandsänderung.
+- Er behauptet **keine Registergleichheit**. Eine Brücke überträgt eine benannte
+  Eigenschaft unter sichtbarem Verlust — nicht Identität.
+- Metapher, Mythos, UI und Psychologie können **nie** eine promotionsfähige
+  Relation erzeugen (``metaphor_not_evidence``).
+- Physische und biologische Register brauchen einen M5-Review-Pointer, bevor sie
+  promotionsfähig werden — kein Weg an der methodischen Prüfung vorbei.
+- ``known_loss`` ist Pflicht: Eine Übersetzung, die den Verlust verschweigt,
+  wird verweigert.
+- Das Tag ``[FACT]`` vergibt der Adapter niemals selbst.
+
+Der Kernel bleibt unverändert; dieses Modul importiert ihn nur.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+from .evidence_routing import (
+    ERK_SCHEMA_VERSION,
+    KNOWN_VISIBILITIES,
+    NON_EVIDENCE_MATERIAL_KINDS,
+    PROMOTION_CAPABLE_RELATION_TYPES,
+    RELATION_TYPES,
+    TRUST_UNTRUSTED,
+    VISIBILITY_PRIVATE,
+    ClaimCandidate,
+    ClaimPolicy,
+    EvidenceRelation,
+    MaterialRef,
+    ReasonCode,
+    normalize_claim_tag,
+    normalize_trust,
+)
+
+BRIDGE_SCHEMA_VERSION = "bridge.v0.1"
+
+# ---------------------------------------------------------------------------
+# Quellregister und ihre erlaubte relationale Reichweite
+# ---------------------------------------------------------------------------
+
+REGISTER_MYTH = "myth"
+REGISTER_METAPHOR = "metaphor"
+REGISTER_FORMAL = "formal"
+REGISTER_PHYSICAL = "physical"
+REGISTER_BIOLOGICAL = "biological"
+REGISTER_PSYCHOLOGICAL = "psychological"
+REGISTER_GOVERNANCE = "governance"
+REGISTER_UI = "ui"
+
+KNOWN_SOURCE_REGISTERS = frozenset(
+    {
+        REGISTER_MYTH,
+        REGISTER_METAPHOR,
+        REGISTER_FORMAL,
+        REGISTER_PHYSICAL,
+        REGISTER_BIOLOGICAL,
+        REGISTER_PSYCHOLOGICAL,
+        REGISTER_GOVERNANCE,
+        REGISTER_UI,
+    }
+)
+
+# Register, deren Material per Definition keine Evidenz trägt. Ihr MaterialRef
+# erhält eine ``kind``-Angabe aus NON_EVIDENCE_MATERIAL_KINDS, sodass auch der
+# Kernel-Guard unabhängig vom Adapter greift (Invariante 3).
+NON_EVIDENCE_REGISTERS = frozenset({REGISTER_MYTH, REGISTER_METAPHOR})
+
+# Register, die erst nach dokumentierter methodischer Prüfung (M5) eine
+# promotionsfähige Relation tragen dürfen.
+M5_GATED_REGISTERS = frozenset({REGISTER_PHYSICAL, REGISTER_BIOLOGICAL})
+
+# Register ohne jede promotionsfähige Reichweite: Sie können Kontext geben oder
+# motivieren, aber niemals stützen oder messen.
+NON_PROMOTING_REGISTERS = frozenset(
+    {REGISTER_MYTH, REGISTER_METAPHOR, REGISTER_PSYCHOLOGICAL, REGISTER_UI}
+)
+
+# Relationen, die ohne weitere Prüfung immer zulässig sind.
+CONTEXT_ONLY_RELATIONS = frozenset({"MOTIVATES", "CONTEXTUALIZES", "PROVENANCE_ONLY"})
+
+# Materialart je Register für den erzeugten MaterialRef.
+_REGISTER_MATERIAL_KIND = {
+    REGISTER_MYTH: "metaphor",
+    REGISTER_METAPHOR: "metaphor",
+    REGISTER_FORMAL: "specification",
+    REGISTER_PHYSICAL: "measurement",
+    REGISTER_BIOLOGICAL: "measurement",
+    REGISTER_PSYCHOLOGICAL: "note",
+    REGISTER_GOVERNANCE: "document",
+    REGISTER_UI: "note",
+}
+
+# Der Adapter darf diese Tags nicht selbst vergeben: Sie behaupten eine Geltung,
+# die nur nach Evidenz und menschlicher Entscheidung entsteht.
+ADAPTER_FORBIDDEN_CLAIM_TAGS = frozenset({"[FACT]", "[SPEC]", "[CANON]"})
+
+INTENDED_USES = frozenset({"explain", "generate", "test", "visualize"})
+
+
+class BridgeReason(str, Enum):
+    """Adapter-lokale Befunde.
+
+    Bewusst getrennt von :class:`~src.core.evidence_routing.ReasonCode`: Diese
+    Werte erscheinen ausschließlich im Rückgabeobjekt der Übersetzung, niemals
+    in einem Ledger-Event, in ``EvidenceRelation.reason_codes`` oder in einem
+    Claim. Sie sind kein Projektstatus und kein Claim-Tag.
+    """
+
+    UNKNOWN_SOURCE_REGISTER = "UNKNOWN_SOURCE_REGISTER"
+    UNKNOWN_RELATION_TYPE = "UNKNOWN_RELATION_TYPE"
+    REGISTER_CANNOT_PROMOTE = "REGISTER_CANNOT_PROMOTE"
+    M5_REVIEW_REQUIRED = "M5_REVIEW_REQUIRED"
+    KNOWN_LOSS_REQUIRED = "KNOWN_LOSS_REQUIRED"
+    FALSIFIER_REQUIRED = "FALSIFIER_REQUIRED"
+    ROLLBACK_REQUIRED = "ROLLBACK_REQUIRED"
+    TRANSFERRED_PROPERTY_REQUIRED = "TRANSFERRED_PROPERTY_REQUIRED"
+    PRESERVED_RELATION_REQUIRED = "PRESERVED_RELATION_REQUIRED"
+    ADAPTER_CANNOT_ASSIGN_TAG = "ADAPTER_CANNOT_ASSIGN_TAG"
+    UNKNOWN_CLAIM_TAG = "UNKNOWN_CLAIM_TAG"
+    UNKNOWN_INTENDED_USE = "UNKNOWN_INTENDED_USE"
+    UNKNOWN_VISIBILITY = "UNKNOWN_VISIBILITY"
+    SOURCE_POINTER_REQUIRED = "SOURCE_POINTER_REQUIRED"
+
+
+class BridgeAdapterError(ValueError):
+    """Fail-closed Fehler der Übersetzung mit adapter-lokalen Befunden."""
+
+    def __init__(self, message: str, reasons: Sequence[BridgeReason] = ()) -> None:
+        super().__init__(message)
+        self.reasons: tuple[BridgeReason, ...] = tuple(reasons)
+
+
+# ---------------------------------------------------------------------------
+# Eingabemodell
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BridgeRecord:
+    """Dokumentierte Übertragung *einer* Eigenschaft zwischen zwei Registern.
+
+    Die Pflichtfelder entsprechen den sechs Brückenfragen: Was ist die
+    Quellform? Welche Eigenschaft wird übertragen? Welche Relation bleibt
+    erhalten? Was geht verloren? Woran würde die Brücke scheitern? Wie wird sie
+    zurückgenommen?
+    """
+
+    bridge_id: str
+    source_register: str
+    source_pointer: str
+    source_digest: str
+    transferred_property: str
+    preserved_relation: str
+    relation_type: str
+    known_loss: list[str]
+    falsifier: str
+    rollback: str
+    intended_use: str = "explain"
+    protected_origin: bool = False
+    visibility: str = "reduced"
+    actor: str = "role:maintainer"
+    claim_id: str | None = None
+    proposed_claim_tag: str | None = None
+    claim_text: str = ""
+    m5_review_pointer: str | None = None
+    schema_version: str = BRIDGE_SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class BridgeTranslation:
+    """Ergebnis einer Übersetzung — Vorschläge, kein Vollzug."""
+
+    bridge_id: str
+    schema_version: str
+    material: MaterialRef
+    relation: EvidenceRelation
+    claim: ClaimCandidate | None
+    promotion_capable: bool
+    notes: tuple[BridgeReason, ...] = field(default=())
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "bridge_id": self.bridge_id,
+            "schema_version": self.schema_version,
+            "material": asdict(self.material),
+            "relation": asdict(self.relation),
+            "claim": asdict(self.claim) if self.claim is not None else None,
+            "promotion_capable": self.promotion_capable,
+            "notes": [note.value for note in self.notes],
+        }
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Validierung
+# ---------------------------------------------------------------------------
+
+
+def _require_text(value: object, reason: BridgeReason, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise BridgeAdapterError(f"{label} is required and must be non-empty", [reason])
+    return value.strip()
+
+
+def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None = None) -> None:
+    """Strukturelle Vollständigkeit und Registergrenzen prüfen (fail-closed).
+
+    Prüft nicht, ob eine behauptete Relation sachlich trägt — das bleibt
+    menschliche Review-Arbeit (und für Messfragen: M5).
+    """
+    if record.source_register not in KNOWN_SOURCE_REGISTERS:
+        raise BridgeAdapterError(
+            f"unknown source_register: {record.source_register!r}",
+            [BridgeReason.UNKNOWN_SOURCE_REGISTER],
+        )
+    if record.relation_type not in RELATION_TYPES:
+        raise BridgeAdapterError(
+            f"unknown relation_type: {record.relation_type!r}",
+            [BridgeReason.UNKNOWN_RELATION_TYPE],
+        )
+    if record.intended_use not in INTENDED_USES:
+        raise BridgeAdapterError(
+            f"unknown intended_use: {record.intended_use!r}",
+            [BridgeReason.UNKNOWN_INTENDED_USE],
+        )
+    if record.visibility not in KNOWN_VISIBILITIES:
+        raise BridgeAdapterError(
+            f"unknown visibility: {record.visibility!r}", [BridgeReason.UNKNOWN_VISIBILITY]
+        )
+
+    _require_text(record.source_pointer, BridgeReason.SOURCE_POINTER_REQUIRED, "source_pointer")
+    _require_text(
+        record.transferred_property,
+        BridgeReason.TRANSFERRED_PROPERTY_REQUIRED,
+        "transferred_property",
+    )
+    _require_text(
+        record.preserved_relation,
+        BridgeReason.PRESERVED_RELATION_REQUIRED,
+        "preserved_relation",
+    )
+    _require_text(record.falsifier, BridgeReason.FALSIFIER_REQUIRED, "falsifier")
+    _require_text(record.rollback, BridgeReason.ROLLBACK_REQUIRED, "rollback")
+
+    # Known Loss ist Pflicht: Eine Brücke ohne sichtbaren Verlust behauptet
+    # implizit Verlustfreiheit — und damit Identität.
+    if not record.known_loss or not all(
+        isinstance(item, str) and item.strip() for item in record.known_loss
+    ):
+        raise BridgeAdapterError(
+            "known_loss must list at least one concrete loss",
+            [BridgeReason.KNOWN_LOSS_REQUIRED],
+        )
+
+    _validate_register_reach(record)
+    _validate_proposed_tag(record, policy)
+
+
+def _validate_register_reach(record: BridgeRecord) -> None:
+    """Erzwingt, wie weit ein Quellregister relational reichen darf."""
+    if record.relation_type not in PROMOTION_CAPABLE_RELATION_TYPES:
+        return
+
+    if record.source_register in NON_PROMOTING_REGISTERS:
+        reason = (
+            BridgeReason.REGISTER_CANNOT_PROMOTE
+            if record.source_register not in NON_EVIDENCE_REGISTERS
+            else BridgeReason.REGISTER_CANNOT_PROMOTE
+        )
+        raise BridgeAdapterError(
+            f"source_register {record.source_register!r} cannot carry a "
+            f"promotion-capable relation ({record.relation_type}); "
+            f"allowed: {sorted(CONTEXT_ONLY_RELATIONS)}",
+            [reason],
+        )
+
+    if record.source_register in M5_GATED_REGISTERS and not (
+        isinstance(record.m5_review_pointer, str) and record.m5_review_pointer.strip()
+    ):
+        raise BridgeAdapterError(
+            f"source_register {record.source_register!r} requires a documented "
+            "m5_review_pointer before a promotion-capable relation is allowed",
+            [BridgeReason.M5_REVIEW_REQUIRED],
+        )
+
+
+def _validate_proposed_tag(record: BridgeRecord, policy: ClaimPolicy | None) -> None:
+    if record.proposed_claim_tag is None:
+        return
+    tag = record.proposed_claim_tag
+    if policy is not None:
+        normalized = normalize_claim_tag(tag, policy)
+        if not normalized.known:
+            raise BridgeAdapterError(
+                f"unknown claim tag: {tag!r}", [BridgeReason.UNKNOWN_CLAIM_TAG]
+            )
+        tag = normalized.tag
+    if tag in ADAPTER_FORBIDDEN_CLAIM_TAGS:
+        raise BridgeAdapterError(
+            f"adapter must not assign claim tag {tag!r}; it requires evidence "
+            "and an explicit human decision",
+            [BridgeReason.ADAPTER_CANNOT_ASSIGN_TAG],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Übersetzung
+# ---------------------------------------------------------------------------
+
+
+def _derive_id(prefix: str, bridge_id: str) -> str:
+    digest = hashlib.sha256(f"{prefix}:{bridge_id}".encode()).hexdigest()[:12]
+    return f"{prefix}-bridge-{digest}"
+
+
+def translate_bridge_record(
+    record: BridgeRecord,
+    *,
+    policy: ClaimPolicy | None = None,
+    trust: str = TRUST_UNTRUSTED,
+) -> BridgeTranslation:
+    """Bridge-Record in ERK-Vorschläge übersetzen.
+
+    Erzeugt ``MaterialRef``, ``EvidenceRelation`` und optional
+    ``ClaimCandidate``. Es wird **kein** Event emittiert, nichts geschrieben und
+    kein Claim-Tag verändert. Der Aufrufer entscheidet, ob und wann die
+    Vorschläge über den Kernel laufen — dort greifen Guard und HumanDecision
+    unverändert.
+
+    Args:
+        record: vollständiger Bridge-Record.
+        policy: optionale Claim-Policy für Tag-Normalisierung.
+        trust: Trust-Level des Materials; Default ``UNTRUSTED`` (G5).
+
+    Raises:
+        BridgeAdapterError: bei jeder strukturellen oder registerbezogenen
+            Verletzung — fail-closed, keine stille Reparatur.
+    """
+    validate_bridge_record(record, policy=policy)
+
+    notes: list[BridgeReason] = []
+
+    # protected_origin überschreibt die Sichtbarkeit nach unten, nie nach oben.
+    visibility = VISIBILITY_PRIVATE if record.protected_origin else record.visibility
+
+    material_kind = _REGISTER_MATERIAL_KIND[record.source_register]
+    normalized_trust = normalize_trust(trust)
+
+    material = MaterialRef(
+        material_id=_derive_id("mat", record.bridge_id),
+        schema_version=ERK_SCHEMA_VERSION,
+        kind=material_kind,
+        source=f"bridge:{record.source_register}",
+        revision="r0",
+        # Nur Pointer und Digest — niemals der Quellausdruck selbst.
+        locator=record.source_pointer,
+        digest=record.source_digest,
+        origin="dual_format_bridge",
+        actor=record.actor,
+        trust=normalized_trust,
+        visibility=visibility,
+        status="ACTIVE",
+    )
+
+    claim_id = record.claim_id or _derive_id("clm", record.bridge_id)
+
+    # Kernel-Reason-Codes: nur solche, die der Kernel selbst kennt. Der
+    # Adapter erfindet hier nichts.
+    relation_reasons: list[str] = []
+    if material_kind in NON_EVIDENCE_MATERIAL_KINDS:
+        relation_reasons.append(ReasonCode.METAPHOR_IS_NOT_EVIDENCE.value)
+        notes.append(BridgeReason.REGISTER_CANNOT_PROMOTE)
+    if record.relation_type == "PROVENANCE_ONLY":
+        relation_reasons.append(ReasonCode.PROVENANCE_IS_NOT_EVIDENCE.value)
+    if normalized_trust == TRUST_UNTRUSTED:
+        relation_reasons.append(ReasonCode.UNTRUSTED_MATERIAL.value)
+
+    relation = EvidenceRelation(
+        relation_id=_derive_id("rel", record.bridge_id),
+        schema_version=ERK_SCHEMA_VERSION,
+        claim_id=claim_id,
+        material_id=material.material_id,
+        relation_type=record.relation_type,
+        actor=record.actor,
+        origin="dual_format_bridge",
+        visibility=visibility,
+        status="ACTIVE",
+        reason_codes=relation_reasons,
+    )
+
+    claim: ClaimCandidate | None = None
+    if record.proposed_claim_tag is not None:
+        tag = record.proposed_claim_tag
+        if policy is not None:
+            tag = normalize_claim_tag(tag, policy).tag
+        claim = ClaimCandidate(
+            claim_id=claim_id,
+            schema_version=ERK_SCHEMA_VERSION,
+            claim_text=record.claim_text,
+            claim_tag=tag,
+            actor=record.actor,
+            origin="dual_format_bridge",
+            visibility=visibility,
+            status="ACTIVE",
+            material_refs=[material.material_id],
+        )
+
+    promotion_capable = (
+        record.relation_type in PROMOTION_CAPABLE_RELATION_TYPES
+        and material_kind not in NON_EVIDENCE_MATERIAL_KINDS
+        and normalized_trust != TRUST_UNTRUSTED
+    )
+
+    return BridgeTranslation(
+        bridge_id=record.bridge_id,
+        schema_version=BRIDGE_SCHEMA_VERSION,
+        material=material,
+        relation=relation,
+        claim=claim,
+        promotion_capable=promotion_capable,
+        notes=tuple(notes),
+    )
+
+
+def bridge_record_from_mapping(payload: Mapping[str, Any]) -> BridgeRecord:
+    """Bridge-Record aus einem Mapping bauen (geschlossenes Feldschema)."""
+    allowed = set(BridgeRecord.__dataclass_fields__)
+    unknown = set(payload) - allowed
+    if unknown:
+        raise BridgeAdapterError(
+            f"bridge record has unknown fields: {sorted(unknown)}",
+            [BridgeReason.UNKNOWN_RELATION_TYPE],
+        )
+    data = dict(payload)
+    known_loss = data.get("known_loss", [])
+    if isinstance(known_loss, (list, tuple)):
+        data["known_loss"] = list(known_loss)
+    return BridgeRecord(**data)

--- a/tests/unit/test_evidence_bridge_adapter.py
+++ b/tests/unit/test_evidence_bridge_adapter.py
@@ -1,0 +1,339 @@
+"""Unit-Tests für den Dual-Format Claim Bridge Adapter v0.1 (M1 -> ERK)."""
+
+import dataclasses
+
+import pytest
+
+from src.core.evidence_bridge_adapter import (
+    BRIDGE_SCHEMA_VERSION,
+    BridgeAdapterError,
+    BridgeReason,
+    BridgeRecord,
+    bridge_record_from_mapping,
+    translate_bridge_record,
+    validate_bridge_record,
+)
+from src.core.evidence_routing import (
+    PROMOTION_CAPABLE_RELATION_TYPES,
+    TRUST_REVIEWED,
+    VISIBILITY_PRIVATE,
+    ReasonCode,
+    load_claim_policy,
+)
+
+
+def make_record(**overrides):
+    data = {
+        "bridge_id": "brg-001",
+        "source_register": "formal",
+        "source_pointer": "docs/annex/example_structure.md#L10-L20",
+        "source_digest": "sha256:00",
+        "transferred_property": "Ordnungsrelation der Knoten",
+        "preserved_relation": "Nachbarschaft bleibt unter der Projektion erhalten",
+        "relation_type": "CONTEXTUALIZES",
+        "known_loss": ["Kantengewichte gehen verloren"],
+        "falsifier": "Ein Gegenbeispiel mit vertauschter Nachbarschaft",
+        "rollback": "HumanDecision(WITHDRAW) auf req-001",
+        "intended_use": "explain",
+    }
+    data.update(overrides)
+    return BridgeRecord(**data)
+
+
+class TestStructuralValidation:
+    def test_valid_record_passes(self):
+        validate_bridge_record(make_record())
+
+    @pytest.mark.parametrize(
+        "field,reason",
+        [
+            ("transferred_property", BridgeReason.TRANSFERRED_PROPERTY_REQUIRED),
+            ("preserved_relation", BridgeReason.PRESERVED_RELATION_REQUIRED),
+            ("falsifier", BridgeReason.FALSIFIER_REQUIRED),
+            ("rollback", BridgeReason.ROLLBACK_REQUIRED),
+            ("source_pointer", BridgeReason.SOURCE_POINTER_REQUIRED),
+        ],
+    )
+    def test_missing_mandatory_text_fails_closed(self, field, reason):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(**{field: "   "}))
+        assert reason in excinfo.value.reasons
+
+    def test_known_loss_is_mandatory(self):
+        # Eine Brücke ohne sichtbaren Verlust behauptet implizit Identität.
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(known_loss=[]))
+        assert BridgeReason.KNOWN_LOSS_REQUIRED in excinfo.value.reasons
+
+    def test_blank_known_loss_entry_is_rejected(self):
+        with pytest.raises(BridgeAdapterError):
+            validate_bridge_record(make_record(known_loss=["  "]))
+
+    def test_unknown_register_and_relation_fail_closed(self):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(source_register="astrology"))
+        assert BridgeReason.UNKNOWN_SOURCE_REGISTER in excinfo.value.reasons
+
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(relation_type="PROVES"))
+        assert BridgeReason.UNKNOWN_RELATION_TYPE in excinfo.value.reasons
+
+    def test_unknown_fields_are_rejected(self):
+        payload = dataclasses.asdict(make_record())
+        payload["secret_score"] = 0.9
+        with pytest.raises(BridgeAdapterError):
+            bridge_record_from_mapping(payload)
+
+    def test_mapping_roundtrip(self):
+        payload = dataclasses.asdict(make_record())
+        assert bridge_record_from_mapping(payload) == make_record()
+
+
+class TestRegisterReach:
+    """Wie weit ein Quellregister relational reichen darf."""
+
+    @pytest.mark.parametrize("register", ["myth", "metaphor", "psychological", "ui"])
+    @pytest.mark.parametrize("relation", sorted(PROMOTION_CAPABLE_RELATION_TYPES))
+    def test_non_promoting_registers_cannot_support(self, register, relation):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(source_register=register, relation_type=relation))
+        assert BridgeReason.REGISTER_CANNOT_PROMOTE in excinfo.value.reasons
+
+    @pytest.mark.parametrize("register", ["myth", "metaphor", "psychological", "ui"])
+    def test_non_promoting_registers_may_contextualize(self, register):
+        validate_bridge_record(
+            make_record(source_register=register, relation_type="CONTEXTUALIZES")
+        )
+        validate_bridge_record(make_record(source_register=register, relation_type="MOTIVATES"))
+
+    @pytest.mark.parametrize("register", ["physical", "biological"])
+    def test_physical_registers_need_m5_pointer_for_promotion(self, register):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(source_register=register, relation_type="MEASURES"))
+        assert BridgeReason.M5_REVIEW_REQUIRED in excinfo.value.reasons
+
+        # Mit dokumentiertem M5-Review ist dieselbe Relation strukturell zulässig.
+        validate_bridge_record(
+            make_record(
+                source_register=register,
+                relation_type="MEASURES",
+                m5_review_pointer="docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001",
+            )
+        )
+
+    @pytest.mark.parametrize("register", ["physical", "biological"])
+    def test_physical_registers_may_contextualize_without_m5(self, register):
+        validate_bridge_record(
+            make_record(source_register=register, relation_type="CONTEXTUALIZES")
+        )
+
+
+class TestClaimTagBoundary:
+    @pytest.mark.parametrize("tag", ["[FACT]", "[SPEC]", "[CANON]"])
+    def test_adapter_must_not_assign_strong_tags(self, tag):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(proposed_claim_tag=tag))
+        assert BridgeReason.ADAPTER_CANNOT_ASSIGN_TAG in excinfo.value.reasons
+
+    def test_alias_is_normalized_before_the_ban_applies(self):
+        # [FAKT] normalisiert auf [FACT] und muss ebenso abgelehnt werden.
+        policy = load_claim_policy()
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(proposed_claim_tag="[FAKT]"), policy=policy)
+        assert BridgeReason.ADAPTER_CANNOT_ASSIGN_TAG in excinfo.value.reasons
+
+    def test_unknown_tag_fails_closed(self):
+        policy = load_claim_policy()
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(proposed_claim_tag="[TOTALLY-NEW]"), policy=policy)
+        assert BridgeReason.UNKNOWN_CLAIM_TAG in excinfo.value.reasons
+
+    def test_weak_tags_are_allowed(self):
+        policy = load_claim_policy()
+        for tag in ("[METAPHER]", "[ROSETTA]", "[HYPOTHESE]", "[MODEL]"):
+            validate_bridge_record(make_record(proposed_claim_tag=tag), policy=policy)
+
+
+class TestTranslation:
+    def test_translation_emits_nothing_and_returns_proposals(self, tmp_path):
+        translation = translate_bridge_record(make_record())
+        assert translation.schema_version == BRIDGE_SCHEMA_VERSION
+        assert translation.material.locator == "docs/annex/example_structure.md#L10-L20"
+        # Relation zeigt auf genau das erzeugte Material:
+        assert translation.relation.material_id == translation.material.material_id
+        # Kein Claim ohne ausdrücklich vorgeschlagenes Tag:
+        assert translation.claim is None
+        # Nichts wurde geschrieben:
+        assert list(tmp_path.iterdir()) == []
+
+    def test_source_expression_never_leaves_the_bridge(self):
+        translation = translate_bridge_record(make_record())
+        serialized = str(translation.to_dict())
+        assert "source_expression" not in serialized
+
+    def test_trust_defaults_to_untrusted_and_blocks_promotion(self):
+        translation = translate_bridge_record(
+            make_record(relation_type="IMPLEMENTS", source_register="formal")
+        )
+        assert translation.material.trust == "UNTRUSTED"
+        assert translation.promotion_capable is False
+        assert ReasonCode.UNTRUSTED_MATERIAL.value in translation.relation.reason_codes
+
+    def test_reviewed_trust_allows_promotion_capability(self):
+        translation = translate_bridge_record(
+            make_record(relation_type="IMPLEMENTS", source_register="formal"),
+            trust=TRUST_REVIEWED,
+        )
+        assert translation.promotion_capable is True
+
+    def test_protected_origin_forces_private_visibility(self):
+        translation = translate_bridge_record(
+            make_record(protected_origin=True, visibility="public")
+        )
+        assert translation.material.visibility == VISIBILITY_PRIVATE
+        assert translation.relation.visibility == VISIBILITY_PRIVATE
+
+    def test_metaphor_register_marks_kernel_reason_code(self):
+        translation = translate_bridge_record(
+            make_record(source_register="metaphor", relation_type="MOTIVATES")
+        )
+        assert translation.material.kind == "metaphor"
+        assert ReasonCode.METAPHOR_IS_NOT_EVIDENCE.value in translation.relation.reason_codes
+        assert translation.promotion_capable is False
+
+    def test_provenance_only_marks_kernel_reason_code(self):
+        translation = translate_bridge_record(make_record(relation_type="PROVENANCE_ONLY"))
+        assert ReasonCode.PROVENANCE_IS_NOT_EVIDENCE.value in translation.relation.reason_codes
+        assert translation.promotion_capable is False
+
+    def test_relation_reason_codes_stay_within_kernel_vocabulary(self):
+        known = {code.value for code in ReasonCode}
+        for register, relation in (
+            ("metaphor", "MOTIVATES"),
+            ("formal", "PROVENANCE_ONLY"),
+            ("governance", "CONTEXTUALIZES"),
+        ):
+            translation = translate_bridge_record(
+                make_record(source_register=register, relation_type=relation)
+            )
+            assert set(translation.relation.reason_codes) <= known
+
+    def test_adapter_local_reasons_never_reach_the_relation(self):
+        translation = translate_bridge_record(
+            make_record(source_register="metaphor", relation_type="MOTIVATES")
+        )
+        adapter_local = {reason.value for reason in BridgeReason}
+        assert not (set(translation.relation.reason_codes) & adapter_local)
+        # Sie erscheinen ausschließlich als Notiz im Übersetzungsergebnis:
+        assert BridgeReason.REGISTER_CANNOT_PROMOTE in translation.notes
+
+    def test_claim_candidate_uses_proposed_tag(self):
+        policy = load_claim_policy()
+        translation = translate_bridge_record(
+            make_record(proposed_claim_tag="[HYPOTHESE]", claim_text="Beispielsatz."),
+            policy=policy,
+        )
+        assert translation.claim is not None
+        assert translation.claim.claim_tag == "[HYPOTHESE]"
+        assert translation.claim.material_refs == [translation.material.material_id]
+
+    def test_translation_is_deterministic(self):
+        first = translate_bridge_record(make_record())
+        second = translate_bridge_record(make_record())
+        assert first.to_dict() == second.to_dict()
+
+
+class TestSourceModuleMinimalTests:
+    """Die vier Minimaltests aus dem Quellmodul 01_DUAL_FORMAT_CLAIM_BRIDGE."""
+
+    def test_1_josephson_jesus_stays_metaphor(self):
+        """Muss [METAPHER]/[ROSETTA] bleiben; kein Tunneling- oder Theologiebeweis."""
+        policy = load_claim_policy()
+        record = make_record(
+            bridge_id="brg-josephson",
+            source_register="metaphor",
+            transferred_property="Vermittlung zwischen zwei getrennten Zuständen",
+            preserved_relation="Kopplung über eine Barriere",
+            relation_type="MOTIVATES",
+            known_loss=["Keine Aussage über Ladungstransport oder Theologie"],
+            proposed_claim_tag="[METAPHER]",
+        )
+        translation = translate_bridge_record(record, policy=policy)
+        assert translation.promotion_capable is False
+        assert translation.claim.claim_tag == "[METAPHER]"
+
+        # Als Stützung derselben Brücke ist sie unzulässig:
+        with pytest.raises(BridgeAdapterError):
+            validate_bridge_record(dataclasses.replace(record, relation_type="SUPPORTS"))
+
+    def test_2_seven_by_nine_yggdrasil_requires_relation_and_loss(self):
+        """Muss die Knoten-/Kantenrelation und Gegenbeispiele nennen."""
+        record = make_record(
+            bridge_id="brg-yggdrasil",
+            source_register="myth",
+            transferred_property="Verzweigungsgrad der Knoten",
+            preserved_relation="Baumstruktur ohne Zyklen",
+            relation_type="CONTEXTUALIZES",
+            known_loss=["Neun Welten sind keine Gitterdimension"],
+            falsifier="Ein Gegenbeispiel mit Zyklus im behaupteten Baum",
+        )
+        translate_bridge_record(record)
+
+        # Ohne benannten Verlust: keine Übersetzung.
+        with pytest.raises(BridgeAdapterError):
+            validate_bridge_record(dataclasses.replace(record, known_loss=[]))
+
+    def test_3_rcc8_photonics_needs_m5_when_measuring(self):
+        """Eine EC/PO-Zuordnung wird erst mit Messgröße und Prüfung tragend."""
+        # Als formale Struktur bleibt sie ein Architekturhinweis:
+        translate_bridge_record(
+            make_record(
+                bridge_id="brg-rcc8",
+                source_register="formal",
+                transferred_property="Überlappungsrelation zweier Regionen",
+                preserved_relation="EC/PO-Unterscheidung",
+                relation_type="CONTEXTUALIZES",
+                known_loss=["Kein Layout, keine Kopplungsparameter, keine Messgröße"],
+            )
+        )
+        # Sobald sie als Messung am Bauteil auftritt, greift das M5-Gate:
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(
+                    bridge_id="brg-rcc8-bench",
+                    source_register="physical",
+                    relation_type="MEASURES",
+                    known_loss=["Kalibrierung offen"],
+                )
+            )
+        assert BridgeReason.M5_REVIEW_REQUIRED in excinfo.value.reasons
+
+    def test_4_love_hrv_must_fail(self):
+        """Ein normativer Begriff darf nicht durch einen physiologischen Proxy ersetzt werden."""
+        # Der normative Wert selbst kann nichts messen oder stützen:
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(
+                    bridge_id="brg-love",
+                    source_register="psychological",
+                    transferred_property="bedingungslose Zuwendung",
+                    preserved_relation="Kohärenz",
+                    relation_type="MEASURES",
+                    known_loss=["Normativer Begriff ist keine Messgröße"],
+                )
+            )
+        assert BridgeReason.REGISTER_CANNOT_PROMOTE in excinfo.value.reasons
+
+        # Und das Biosignal darf ohne M5-Prüfung nichts stützen:
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(
+                    bridge_id="brg-hrv",
+                    source_register="biological",
+                    transferred_property="HRV-Kennwert",
+                    preserved_relation="zeitliche Variabilität",
+                    relation_type="SUPPORTS",
+                    known_loss=["Confounder nicht kontrolliert"],
+                )
+            )
+        assert BridgeReason.M5_REVIEW_REQUIRED in excinfo.value.reasons

--- a/tests/unit/test_evidence_bridge_adapter.py
+++ b/tests/unit/test_evidence_bridge_adapter.py
@@ -69,6 +69,18 @@ class TestStructuralValidation:
         with pytest.raises(BridgeAdapterError):
             validate_bridge_record(make_record(known_loss=["  "]))
 
+    def test_bare_string_known_loss_is_rejected(self):
+        # Ein String ist iterierbar: ohne diese Prüfung ginge er zeichenweise
+        # als Liste durch.
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(known_loss="Kantengewichte"))
+        assert BridgeReason.KNOWN_LOSS_MUST_BE_LIST in excinfo.value.reasons
+
+    def test_source_digest_is_mandatory(self):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(source_digest="   "))
+        assert BridgeReason.SOURCE_DIGEST_REQUIRED in excinfo.value.reasons
+
     def test_unknown_register_and_relation_fail_closed(self):
         with pytest.raises(BridgeAdapterError) as excinfo:
             validate_bridge_record(make_record(source_register="astrology"))
@@ -105,6 +117,49 @@ class TestRegisterReach:
             make_record(source_register=register, relation_type="CONTEXTUALIZES")
         )
         validate_bridge_record(make_record(source_register=register, relation_type="MOTIVATES"))
+
+    @pytest.mark.parametrize("register", ["formal", "governance"])
+    @pytest.mark.parametrize("relation", sorted(PROMOTION_CAPABLE_RELATION_TYPES))
+    def test_formal_and_governance_are_not_promotion_enabled_in_v0_1(self, register, relation):
+        """Der Kernel prüft für PROPOSE nur Relationstyp, Materialart und Trust.
+
+        Ein REVIEWED-Governance-Dokument könnte dort sonst ein strukturell
+        grünes Signal bekommen, das seine Reichweite überschätzt.
+        """
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(source_register=register, relation_type=relation))
+        assert BridgeReason.PROMOTION_NOT_ENABLED_IN_V0_1 in excinfo.value.reasons
+
+    @pytest.mark.parametrize("register", ["formal", "governance"])
+    def test_formal_and_governance_may_carry_context_and_provenance(self, register):
+        for relation in ("CONTEXTUALIZES", "MOTIVATES", "PROVENANCE_ONLY"):
+            validate_bridge_record(make_record(source_register=register, relation_type=relation))
+
+    @pytest.mark.parametrize("register", ["formal", "governance"])
+    def test_deferred_registers_name_their_opening_condition(self, register):
+        """Der Fehlertext nennt die Bedingung, unter der später geöffnet wird."""
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(source_register=register, relation_type="SUPPORTS"))
+        message = str(excinfo.value)
+        assert "v0.1" in message
+        if register == "formal":
+            assert "MEASURES" in message  # niemals pauschal
+        else:
+            assert "IMPLEMENTS" in message
+
+    def test_no_register_is_promotion_enabled_without_a_gate(self):
+        """In v0.1 kommt kein Register ohne dokumentierte Prüfung durch."""
+        for register in ("myth", "metaphor", "psychological", "ui", "formal", "governance"):
+            with pytest.raises(BridgeAdapterError):
+                validate_bridge_record(
+                    make_record(source_register=register, relation_type="SUPPORTS")
+                )
+        # Physisch/biologisch nur mit M5-Pointer:
+        for register in ("physical", "biological"):
+            with pytest.raises(BridgeAdapterError):
+                validate_bridge_record(
+                    make_record(source_register=register, relation_type="SUPPORTS")
+                )
 
     @pytest.mark.parametrize("register", ["physical", "biological"])
     def test_physical_registers_need_m5_pointer_for_promotion(self, register):
@@ -171,19 +226,24 @@ class TestTranslation:
         serialized = str(translation.to_dict())
         assert "source_expression" not in serialized
 
+    def _gated_record(self, **overrides):
+        """Der einzige in v0.1 promotionsfähige Pfad: physisch plus M5-Pointer."""
+        data = {
+            "source_register": "physical",
+            "relation_type": "MEASURES",
+            "m5_review_pointer": "docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001",
+        }
+        data.update(overrides)
+        return make_record(**data)
+
     def test_trust_defaults_to_untrusted_and_blocks_promotion(self):
-        translation = translate_bridge_record(
-            make_record(relation_type="IMPLEMENTS", source_register="formal")
-        )
+        translation = translate_bridge_record(self._gated_record())
         assert translation.material.trust == "UNTRUSTED"
         assert translation.promotion_capable is False
         assert ReasonCode.UNTRUSTED_MATERIAL.value in translation.relation.reason_codes
 
     def test_reviewed_trust_allows_promotion_capability(self):
-        translation = translate_bridge_record(
-            make_record(relation_type="IMPLEMENTS", source_register="formal"),
-            trust=TRUST_REVIEWED,
-        )
+        translation = translate_bridge_record(self._gated_record(), trust=TRUST_REVIEWED)
         assert translation.promotion_capable is True
 
     def test_protected_origin_forces_private_visibility(self):
@@ -241,6 +301,63 @@ class TestTranslation:
         first = translate_bridge_record(make_record())
         second = translate_bridge_record(make_record())
         assert first.to_dict() == second.to_dict()
+
+
+class TestContextSurvivesTranslation:
+    """Das Beschriftungsschild bleibt Teil des Bauwerks."""
+
+    def test_all_six_bridge_answers_survive(self):
+        record = make_record()
+        translation = translate_bridge_record(record)
+        context = translation.context
+        assert context.source_register == record.source_register
+        assert context.transferred_property == record.transferred_property
+        assert context.preserved_relation == record.preserved_relation
+        assert context.known_loss == tuple(record.known_loss)
+        assert context.falsifier == record.falsifier
+        assert context.rollback == record.rollback
+
+    def test_known_loss_is_reachable_from_the_translation(self):
+        translation = translate_bridge_record(make_record())
+        assert translation.known_loss == ("Kantengewichte gehen verloren",)
+
+    def test_serialized_output_carries_the_context(self):
+        payload = translate_bridge_record(make_record()).to_dict()
+        context = payload["context"]
+        for key in (
+            "source_register",
+            "transferred_property",
+            "preserved_relation",
+            "known_loss",
+            "falsifier",
+            "rollback",
+            "intended_use",
+            "protected_origin",
+            "m5_review_pointer",
+        ):
+            assert key in context
+        assert context["known_loss"] == ["Kantengewichte gehen verloren"]
+
+    def test_m5_pointer_is_preserved_as_the_reason_the_gate_opened(self):
+        pointer = "docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001"
+        translation = translate_bridge_record(
+            make_record(
+                source_register="physical",
+                relation_type="MEASURES",
+                m5_review_pointer=pointer,
+            ),
+            trust=TRUST_REVIEWED,
+        )
+        assert translation.promotion_capable is True
+        # Ohne diesen Pointer im Ergebnis wäre nicht mehr nachvollziehbar,
+        # warum die Relation das Gate passieren durfte.
+        assert translation.context.m5_review_pointer == pointer
+        assert translation.to_dict()["context"]["m5_review_pointer"] == pointer
+
+    def test_context_is_immutable(self):
+        translation = translate_bridge_record(make_record())
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            translation.context.known_loss = ()  # type: ignore[misc]
 
 
 class TestSourceModuleMinimalTests:


### PR DESCRIPTION
## Intent

Phase 2A (freigegeben): Der **M1 Bridge-Adapter** übersetzt einen Dual-Format Bridge-Record in Vorschlagsobjekte des Evidence Routing Kernel — `MaterialRef`, `EvidenceRelation` und optional `ClaimCandidate`.

Der Adapter ist **reine Übersetzung**: kein Ledger-Event, kein Dateizugriff, kein Netzwerk, keine Zustandsänderung, kein Retagging. Ob und wann Vorschläge in einen Eventstream gelangen, entscheidet der Aufrufer — dort greifen Guard und `HumanDecision` unverändert.

FOKUS: M1 Bridge Adapter

## Topologie

Direkt von `main` (`54dd280`), **nicht** gestapelt: #314 ist gemergt, der ERK ist damit kein bewegliches Ziel mehr — genau die Bedingung, die Phase 2A bis jetzt auf HOLD hielt. Unabhängig von #324 (2C).

## Scope

| Datei | Rolle |
|---|---|
| `src/core/evidence_bridge_adapter.py` | neu — Übersetzung |
| `tests/unit/test_evidence_bridge_adapter.py` | neu — 52 Tests |
| `docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md` | neu — ANNEX |
| `src/core/__init__.py` | additive Exports |

`src/core/evidence_routing.py` und `src/core/ledger.py` bleiben **unverändert**.

## Kernregeln

**Die sechs Brückenfragen sind Pflichtfelder.** Fehlt eine Antwort, verweigert der Adapter fail-closed. Besonders `known_loss`: Eine Brücke ohne benannten Verlust behauptet implizit Verlustfreiheit — und damit Identität zwischen den Registern.

**Registerreichweite:**

| Quellregister | promotionsfähige Relation? | Begründung |
|---|---|---|
| `myth`, `metaphor` | **nie** | Metapher ist keine Evidenz (Invariante 3) |
| `psychological` | **nie** | keine Diagnose, kein Claim über eine Person |
| `ui` | **nie** | ein UI-Frame ist kein Wahrheitszeuge |
| `physical`, `biological` | nur mit `m5_review_pointer` | kein Weg an der methodischen Prüfung vorbei |
| `formal`, `governance` | ja (strukturell) | inhaltliche Tragfähigkeit bleibt Review-Frage |

Ein Verstoß führt zum **Abbruch, nicht zu stiller Degradierung** — der Adapter schreibt eine unzulässige Relation nicht heimlich auf einen schwächeren Typ um.

**Doppelte Absicherung:** Mythische und metaphorische Register erhalten `kind="metaphor"`, damit der Kernel-Guard (`NON_EVIDENCE_MATERIAL_KINDS`) auch dann greift, wenn jemand den Adapter umgeht.

**Weitere Grenzen:** kein Rohinhalt (nur Pointer/Digest/Metadaten) · `protected_origin` → `private` (nach unten, nie nach oben) · Trust-Default `UNTRUSTED` · `[FACT]`/`[SPEC]`/`[CANON]` vergibt der Adapter nie selbst, auch nicht über Aliase wie `[FAKT]` · geschlossenes Feldschema.

**Zwei getrennte Befundvokabulare:** Adapter-lokale Befunde leben im eigenen `BridgeReason`-Enum und erscheinen nur im Rückgabeobjekt — nie in einem Event, nie in `EvidenceRelation.reason_codes`, nie in einem Claim. Dort ausschließlich Kernel-`ReasonCode`s. Ein Test hält die Trennung fest.

## Change-Gate

Skill `entaengelment-change-gate` v0.1 vor der Umsetzung angewandt (Manifest im Scratchpad, nicht persistiert): Verdikt `ELIGIBLE_FOR_EXTERNAL_REVIEW`, keine strukturellen Befunde.

Der Validator fand zunächst einen **echten** Fehler: Ich hatte `docs/annex/PHOTONIC_THERMAL_AIRLOCK_v0_1.md` als Source of Truth gelistet — die Datei liegt aber nur im offenen PR #324, nicht auf `main`. Genau die Lektion aus dem „moving target"-Thema bei #314. Ersetzt durch die gemergte Adapter-Map.

## Test Plan

- `pytest tests/unit/test_evidence_bridge_adapter.py -q` → **52 passed**, darunter die vier Minimaltests des Quellmoduls: Josephson–Jesus bleibt Metapher · 7×9–Yggdrasil braucht Relation und Verlust · RCC-8–Photonik braucht M5 sobald gemessen wird · „Liebe"–HRV **muss** scheitern (beide Richtungen)
- `pytest tests/ -q` → **434 passed** (Gesamtsuite)
- `make verify` → grün · `make erk-drill` → alle Grenzen halten
- `ruff` / `black` / `mypy` → sauber
- Manuell: alle Doku-Pointer lösen auf `main` auf; keine Referenz auf ungemergte Arbeit

- [x] Unit tests pass
- [x] Manual testing completed
- [x] CI checks pass (lokal; CI-Lauf steht aus)

## Ausdrücklich

- keine Änderung am ERK-Core oder Ledger
- keine Event-Emission, keine Promotion, keine Authority-Wirkung
- kein neues Statussystem, kein neuer Claim-Tag, keine neue Entscheidungsleiter
- keine Änderung an `tools/`, `policies/`, `spec/`, `index/`, `VOIDMAP.yml`, Receipts, `NICHTRAUM/`
- keine neue Dependency, keine automatische Merge-Aktion

## Risk / Review-Fokus

- **Die Register-Matrix ist ein erster Schnitt** und braucht deine Bestätigung — insbesondere, ob `formal` und `governance` ohne zusätzliches Gate promotionsfähig sein sollen.
- Ob ein physisches Register ohne M5-Pointer wirklich abbrechen soll (statt still zu degradieren) — ich habe fail-closed gewählt.
- Offen (bewusst): die menschenlesbare Bridge-Anzeige, die Quelle, Status, Verlust und Rücknahme gleichzeitig zeigt — im Quellmodul das Exit-Kriterium für Implementierungsreife.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ATT89hd9SnQD7Q4oKuL6at

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATT89hd9SnQD7Q4oKuL6at)_