### PR TITLE
fix(core): harden bridge intake after #325 review

### DIFF
--- a/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
+++ b/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
@@ -10,6 +10,7 @@
 **Source:** Synthbiosis Systematlas v1.1 / `01_DUAL_FORMAT_CLAIM_BRIDGE.md`
 (Bundle-Witness: `INBOX/INTAKE-2026-07-21-synthbiosis-system-atlas-v1_1.md`;
 Feld-Mapping: `docs/annex/SYNTHBIOSIS_MODULE_ADAPTER_MAP_v0_1.md` §2.1)
+**Validation-Refresh:** 2026-07-26 (Post-Merge-Hardening nach PR #325)
 
 ```yaml
 source_relation:
@@ -68,7 +69,14 @@ begrenzt. Promotionsfähig sind im Kernel nur `SUPPORTS`, `MEASURES` und
 | `ui` | **nie** promotionsfähig | unverändert — ein UI-Frame ist kein Wahrheitszeuge |
 | `formal` | nur Kontext/Provenienz | `SUPPORTS`/`IMPLEMENTS` erst mit formalem Review-Witness und gebundener Zieldomäne; **niemals pauschal** `MEASURES` |
 | `governance` | nur `CONTEXTUALIZES`, `MOTIVATES`, `PROVENANCE_ONLY` | höchstens `IMPLEMENTS` innerhalb explizit dokumentierter Authority-/Scope-Grenzen |
-| `physical`, `biological` | Promotion nur mit `m5_review_pointer` | unverändert |
+| `physical`, `biological` | `CONTEXTUALIZES`, `MOTIVATES`, `PROVENANCE_ONLY` ohne M5; `SUPPORTS`, `MEASURES`, `IMPLEMENTS` nur mit `m5_review_pointer`; `CONTRADICTS` ist in v0.1 nicht geöffnet | unverändert |
+
+[FACT] Diese Matrix ist als geschlossenes, registerbezogenes Vokabular
+implementiert. Dass eine Relation im Kernel bekannt oder nicht
+promotionsfähig ist, reicht nicht: `CONTRADICTS` darf beispielsweise nicht aus
+einem Bridge-Record am Register-Gate vorbeilaufen. Da v0.1 dafür in keinem
+Register eine explizite Öffnungsbedingung definiert, wird die Relation überall
+abgelehnt.
 
 [FACT] **In v0.1 ist damit kein Register ohne dokumentiertes Gate
 promotionsfähig.** Der Grund liegt im Kernel: `evaluate_transition_request()`
@@ -125,9 +133,24 @@ Er ist iterierbar und ginge sonst zeichenweise als Liste durch.
 - **Verbotene Tags:** Der Adapter vergibt `[FACT]`, `[SPEC]` und `[CANON]`
   niemals selbst — auch nicht über einen Alias wie `[FAKT]`. Ein
   `ClaimCandidate` trägt höchstens ein Einstiegstag; jede Höherstufung läuft
-  über Guard und `HumanDecision`.
+  über Guard und `HumanDecision`. Sobald ein Candidate vorgeschlagen wird, ist
+  eine geladene `ClaimPolicy` Pflicht; ohne Policy fällt der Adapter
+  fail-closed aus, statt Alias-/Unknown-Tag-Prüfung zu überspringen.
+- **Claim-Bindung:** Ohne neuen `ClaimCandidate` ist eine nicht-leere
+  `claim_id` Pflicht. Mit Candidate ist nicht-leerer `claim_text` Pflicht; nur
+  auf diesem Pfad darf die Claim-ID deterministisch aus `bridge_id` abgeleitet
+  werden.
+- **Identität und Attribution:** `bridge_id` und `actor` müssen nicht-leere,
+  kanonische Strings ohne Rand-Whitespace sein. Das gilt ebenso für Claim-ID,
+  Quell-/Digest- und M5-Pointer. So kollidieren keine anonymen oder optisch
+  identischen IDs und es entstehen keine ERK-Vorschläge mit ungültiger
+  Attribution.
+- **Schema-Pin:** Nur `bridge.v0.1` wird interpretiert. Zukünftige oder
+  unbekannte Versionen werden nicht still unter v0.1-Semantik umgedeutet.
 - **Geschlossenes Feldschema:** Unbekannte Felder im Eingabe-Mapping werden
-  abgelehnt.
+  mit `UNKNOWN_FIELD`, fehlende Pflichtfelder mit `MISSING_REQUIRED_FIELD`
+  abgelehnt. Mapping-Intake akzeptiert nur ein eingebautes `dict`, damit ein
+  frei implementiertes Mapping beim Lesen keinen Aufrufercode ausführen kann.
 
 ## 6. Zwei getrennte Befundvokabulare
 

--- a/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
+++ b/docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md
@@ -145,8 +145,11 @@ Er ist iterierbar und ginge sonst zeichenweise als Liste durch.
   Quell-/Digest- und M5-Pointer. So kollidieren keine anonymen oder optisch
   identischen IDs und es entstehen keine ERK-Vorschläge mit ungültiger
   Attribution.
-- **Schema-Pin:** Nur `bridge.v0.1` wird interpretiert. Zukünftige oder
-  unbekannte Versionen werden nicht still unter v0.1-Semantik umgedeutet.
+- **Schema-Pin:** Nur `bridge.v0.1` wird interpretiert. Ein externes
+  Eingabe-Mapping muss `schema_version` ausdrücklich mitsenden; die
+  Dataclass-Vorgabe gilt nur für direkte programmatische Konstruktion.
+  Unversionierte, zukünftige oder unbekannte Payloads werden nicht still unter
+  v0.1-Semantik umgedeutet.
 - **Geschlossenes Feldschema:** Unbekannte Felder im Eingabe-Mapping werden
   mit `UNKNOWN_FIELD`, fehlende Pflichtfelder mit `MISSING_REQUIRED_FIELD`
   abgelehnt. Mapping-Intake akzeptiert nur ein eingebautes `dict`, damit ein

--- a/src/core/evidence_bridge_adapter.py
+++ b/src/core/evidence_bridge_adapter.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import MISSING, asdict, dataclass, field, fields
 from enum import Enum
 from typing import Any
 
@@ -113,6 +113,17 @@ DEFERRED_PROMOTION_REGISTERS = {
 # Relationen, die ohne weitere Prüfung immer zulässig sind.
 CONTEXT_ONLY_RELATIONS = frozenset({"MOTIVATES", "CONTEXTUALIZES", "PROVENANCE_ONLY"})
 
+_REGISTER_ALLOWED_RELATIONS = {
+    REGISTER_MYTH: CONTEXT_ONLY_RELATIONS,
+    REGISTER_METAPHOR: CONTEXT_ONLY_RELATIONS,
+    REGISTER_FORMAL: CONTEXT_ONLY_RELATIONS,
+    REGISTER_PHYSICAL: CONTEXT_ONLY_RELATIONS | PROMOTION_CAPABLE_RELATION_TYPES,
+    REGISTER_BIOLOGICAL: CONTEXT_ONLY_RELATIONS | PROMOTION_CAPABLE_RELATION_TYPES,
+    REGISTER_PSYCHOLOGICAL: CONTEXT_ONLY_RELATIONS,
+    REGISTER_GOVERNANCE: CONTEXT_ONLY_RELATIONS,
+    REGISTER_UI: CONTEXT_ONLY_RELATIONS,
+}
+
 # Materialart je Register für den erzeugten MaterialRef.
 _REGISTER_MATERIAL_KIND = {
     REGISTER_MYTH: "metaphor",
@@ -158,6 +169,17 @@ class BridgeReason(str, Enum):
     UNKNOWN_INTENDED_USE = "UNKNOWN_INTENDED_USE"
     UNKNOWN_VISIBILITY = "UNKNOWN_VISIBILITY"
     SOURCE_POINTER_REQUIRED = "SOURCE_POINTER_REQUIRED"
+    BRIDGE_ID_REQUIRED = "BRIDGE_ID_REQUIRED"
+    ACTOR_REQUIRED = "ACTOR_REQUIRED"
+    CLAIM_ID_REQUIRED = "CLAIM_ID_REQUIRED"
+    CLAIM_TEXT_REQUIRED = "CLAIM_TEXT_REQUIRED"
+    CLAIM_POLICY_REQUIRED = "CLAIM_POLICY_REQUIRED"
+    UNSUPPORTED_SCHEMA_VERSION = "UNSUPPORTED_SCHEMA_VERSION"
+    RELATION_NOT_ALLOWED_FOR_REGISTER = "RELATION_NOT_ALLOWED_FOR_REGISTER"
+    UNKNOWN_FIELD = "UNKNOWN_FIELD"
+    MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD"
+    INVALID_MAPPING = "INVALID_MAPPING"
+    INVALID_BOOLEAN = "INVALID_BOOLEAN"
 
 
 class BridgeAdapterError(ValueError):
@@ -276,9 +298,19 @@ class BridgeTranslation:
 
 
 def _require_text(value: object, reason: BridgeReason, label: str) -> str:
-    if not isinstance(value, str) or not value.strip():
+    if type(value) is not str or not value.strip():
         raise BridgeAdapterError(f"{label} is required and must be non-empty", [reason])
     return value.strip()
+
+
+def _require_canonical_text(value: object, reason: BridgeReason, label: str) -> str:
+    text = _require_text(value, reason, label)
+    if value != text:
+        raise BridgeAdapterError(
+            f"{label} must not contain leading or trailing whitespace",
+            [reason],
+        )
+    return text
 
 
 def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None = None) -> None:
@@ -287,28 +319,62 @@ def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None =
     Prüft nicht, ob eine behauptete Relation sachlich trägt — das bleibt
     menschliche Review-Arbeit (und für Messfragen: M5).
     """
-    if record.source_register not in KNOWN_SOURCE_REGISTERS:
+    if type(record) is not BridgeRecord:
+        raise BridgeAdapterError(
+            "record must be a BridgeRecord; use bridge_record_from_mapping for JSON data",
+            [BridgeReason.INVALID_MAPPING],
+        )
+    if type(record.schema_version) is not str or (record.schema_version != BRIDGE_SCHEMA_VERSION):
+        raise BridgeAdapterError(
+            f"schema_version must equal {BRIDGE_SCHEMA_VERSION!r}",
+            [BridgeReason.UNSUPPORTED_SCHEMA_VERSION],
+        )
+
+    _require_canonical_text(record.bridge_id, BridgeReason.BRIDGE_ID_REQUIRED, "bridge_id")
+    _require_canonical_text(record.actor, BridgeReason.ACTOR_REQUIRED, "actor")
+
+    if type(record.source_register) is not str or (
+        record.source_register not in KNOWN_SOURCE_REGISTERS
+    ):
         raise BridgeAdapterError(
             f"unknown source_register: {record.source_register!r}",
             [BridgeReason.UNKNOWN_SOURCE_REGISTER],
         )
-    if record.relation_type not in RELATION_TYPES:
+    if type(record.relation_type) is not str or record.relation_type not in RELATION_TYPES:
         raise BridgeAdapterError(
             f"unknown relation_type: {record.relation_type!r}",
             [BridgeReason.UNKNOWN_RELATION_TYPE],
         )
-    if record.intended_use not in INTENDED_USES:
+    if type(record.intended_use) is not str or record.intended_use not in INTENDED_USES:
         raise BridgeAdapterError(
             f"unknown intended_use: {record.intended_use!r}",
             [BridgeReason.UNKNOWN_INTENDED_USE],
         )
-    if record.visibility not in KNOWN_VISIBILITIES:
+    if type(record.visibility) is not str or record.visibility not in KNOWN_VISIBILITIES:
         raise BridgeAdapterError(
             f"unknown visibility: {record.visibility!r}", [BridgeReason.UNKNOWN_VISIBILITY]
         )
+    if type(record.protected_origin) is not bool:
+        raise BridgeAdapterError("protected_origin must be a bool", [BridgeReason.INVALID_BOOLEAN])
+    if record.claim_id is not None:
+        _require_canonical_text(record.claim_id, BridgeReason.CLAIM_ID_REQUIRED, "claim_id")
+    if record.m5_review_pointer is not None:
+        _require_canonical_text(
+            record.m5_review_pointer,
+            BridgeReason.M5_REVIEW_REQUIRED,
+            "m5_review_pointer",
+        )
 
-    _require_text(record.source_pointer, BridgeReason.SOURCE_POINTER_REQUIRED, "source_pointer")
-    _require_text(record.source_digest, BridgeReason.SOURCE_DIGEST_REQUIRED, "source_digest")
+    _require_canonical_text(
+        record.source_pointer,
+        BridgeReason.SOURCE_POINTER_REQUIRED,
+        "source_pointer",
+    )
+    _require_canonical_text(
+        record.source_digest,
+        BridgeReason.SOURCE_DIGEST_REQUIRED,
+        "source_digest",
+    )
     _require_text(
         record.transferred_property,
         BridgeReason.TRANSFERRED_PROPERTY_REQUIRED,
@@ -324,7 +390,7 @@ def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None =
 
     # Ein blanker String ist iterierbar: ohne diese Prüfung würde
     # known_loss="Kantengewichte" zeichenweise als Liste durchgehen.
-    if isinstance(record.known_loss, str) or not isinstance(record.known_loss, (list, tuple)):
+    if type(record.known_loss) not in (list, tuple):
         raise BridgeAdapterError(
             "known_loss must be a list or tuple of strings, not a bare string",
             [BridgeReason.KNOWN_LOSS_MUST_BE_LIST],
@@ -333,7 +399,7 @@ def validate_bridge_record(record: BridgeRecord, *, policy: ClaimPolicy | None =
     # Known Loss ist Pflicht: Eine Brücke ohne sichtbaren Verlust behauptet
     # implizit Verlustfreiheit — und damit Identität.
     if not record.known_loss or not all(
-        isinstance(item, str) and item.strip() for item in record.known_loss
+        type(item) is str and item.strip() for item in record.known_loss
     ):
         raise BridgeAdapterError(
             "known_loss must list at least one concrete loss",
@@ -352,32 +418,43 @@ def _validate_register_reach(record: BridgeRecord) -> None:
     eine Entscheidung: Der Aufrufer sagte ``MEASURES``. Die Korrektur ist ein
     neuer, ausdrücklich anders lautender Record — von einem Menschen.
     """
-    if record.relation_type not in PROMOTION_CAPABLE_RELATION_TYPES:
-        return
-
     hint = (
         f"Zulässig sind hier {sorted(CONTEXT_ONLY_RELATIONS)}. Der Adapter stuft "
         "nicht selbst ab; ein Mensch kann einen neuen Record mit ausdrücklich "
         "diesem Relationstyp einreichen."
     )
 
-    if record.source_register in NON_PROMOTING_REGISTERS:
+    allowed = _REGISTER_ALLOWED_RELATIONS[record.source_register]
+    if record.relation_type not in allowed:
+        if (
+            record.relation_type in PROMOTION_CAPABLE_RELATION_TYPES
+            and record.source_register in NON_PROMOTING_REGISTERS
+        ):
+            raise BridgeAdapterError(
+                f"source_register {record.source_register!r} cannot carry a "
+                f"promotion-capable relation ({record.relation_type}). {hint}",
+                [BridgeReason.REGISTER_CANNOT_PROMOTE],
+            )
+        if (
+            record.relation_type in PROMOTION_CAPABLE_RELATION_TYPES
+            and record.source_register in DEFERRED_PROMOTION_REGISTERS
+        ):
+            condition = DEFERRED_PROMOTION_REGISTERS[record.source_register]
+            raise BridgeAdapterError(
+                f"source_register {record.source_register!r} is not promotion-enabled "
+                f"in v0.1 ({record.relation_type}): {condition}. {hint}",
+                [BridgeReason.PROMOTION_NOT_ENABLED_IN_V0_1],
+            )
         raise BridgeAdapterError(
-            f"source_register {record.source_register!r} cannot carry a "
-            f"promotion-capable relation ({record.relation_type}). {hint}",
-            [BridgeReason.REGISTER_CANNOT_PROMOTE],
+            f"relation_type {record.relation_type!r} is outside the allowed "
+            f"vocabulary for source_register {record.source_register!r}. {hint}",
+            [BridgeReason.RELATION_NOT_ALLOWED_FOR_REGISTER],
         )
 
-    if record.source_register in DEFERRED_PROMOTION_REGISTERS:
-        condition = DEFERRED_PROMOTION_REGISTERS[record.source_register]
-        raise BridgeAdapterError(
-            f"source_register {record.source_register!r} is not promotion-enabled "
-            f"in v0.1 ({record.relation_type}): {condition}. {hint}",
-            [BridgeReason.PROMOTION_NOT_ENABLED_IN_V0_1],
-        )
-
-    if record.source_register in M5_GATED_REGISTERS and not (
-        isinstance(record.m5_review_pointer, str) and record.m5_review_pointer.strip()
+    if (
+        record.source_register in M5_GATED_REGISTERS
+        and record.relation_type in PROMOTION_CAPABLE_RELATION_TYPES
+        and record.m5_review_pointer is None
     ):
         raise BridgeAdapterError(
             f"source_register {record.source_register!r} requires a documented "
@@ -388,15 +465,27 @@ def _validate_register_reach(record: BridgeRecord) -> None:
 
 def _validate_proposed_tag(record: BridgeRecord, policy: ClaimPolicy | None) -> None:
     if record.proposed_claim_tag is None:
-        return
-    tag = record.proposed_claim_tag
-    if policy is not None:
-        normalized = normalize_claim_tag(tag, policy)
-        if not normalized.known:
+        if record.claim_id is None:
             raise BridgeAdapterError(
-                f"unknown claim tag: {tag!r}", [BridgeReason.UNKNOWN_CLAIM_TAG]
+                "claim_id is required when no ClaimCandidate is emitted",
+                [BridgeReason.CLAIM_ID_REQUIRED],
             )
-        tag = normalized.tag
+        return
+    tag = _require_text(
+        record.proposed_claim_tag,
+        BridgeReason.UNKNOWN_CLAIM_TAG,
+        "proposed_claim_tag",
+    )
+    _require_text(record.claim_text, BridgeReason.CLAIM_TEXT_REQUIRED, "claim_text")
+    if type(policy) is not ClaimPolicy:
+        raise BridgeAdapterError(
+            "a loaded ClaimPolicy is required when proposing a ClaimCandidate",
+            [BridgeReason.CLAIM_POLICY_REQUIRED],
+        )
+    normalized = normalize_claim_tag(tag, policy)
+    if not normalized.known:
+        raise BridgeAdapterError(f"unknown claim tag: {tag!r}", [BridgeReason.UNKNOWN_CLAIM_TAG])
+    tag = normalized.tag
     if tag in ADAPTER_FORBIDDEN_CLAIM_TAGS:
         raise BridgeAdapterError(
             f"adapter must not assign claim tag {tag!r}; it requires evidence "
@@ -431,7 +520,8 @@ def translate_bridge_record(
 
     Args:
         record: vollständiger Bridge-Record.
-        policy: optionale Claim-Policy für Tag-Normalisierung.
+        policy: Claim-Policy für Tag-Normalisierung; Pflicht, sobald der Record
+            einen ``ClaimCandidate`` vorschlägt.
         trust: Trust-Level des Materials; Default ``UNTRUSTED`` (G5).
 
     Raises:
@@ -492,9 +582,10 @@ def translate_bridge_record(
 
     claim: ClaimCandidate | None = None
     if record.proposed_claim_tag is not None:
-        tag = record.proposed_claim_tag
-        if policy is not None:
-            tag = normalize_claim_tag(tag, policy).tag
+        # validate_bridge_record() garantiert für diesen Pfad eine geladene
+        # Policy und einen bekannten, normalisierten Tag.
+        assert policy is not None
+        tag = normalize_claim_tag(record.proposed_claim_tag, policy).tag
         claim = ClaimCandidate(
             claim_id=claim_id,
             schema_version=ERK_SCHEMA_VERSION,
@@ -541,15 +632,42 @@ def translate_bridge_record(
 
 def bridge_record_from_mapping(payload: Mapping[str, Any]) -> BridgeRecord:
     """Bridge-Record aus einem Mapping bauen (geschlossenes Feldschema)."""
+    if type(payload) is not dict:
+        raise BridgeAdapterError(
+            "bridge record payload must be a built-in dict",
+            [BridgeReason.INVALID_MAPPING],
+        )
+    if not all(type(key) is str for key in payload):
+        raise BridgeAdapterError(
+            "bridge record field names must be strings",
+            [BridgeReason.UNKNOWN_FIELD],
+        )
     allowed = set(BridgeRecord.__dataclass_fields__)
     unknown = set(payload) - allowed
     if unknown:
         raise BridgeAdapterError(
             f"bridge record has unknown fields: {sorted(unknown)}",
-            [BridgeReason.UNKNOWN_RELATION_TYPE],
+            [BridgeReason.UNKNOWN_FIELD],
+        )
+    required = {
+        item.name
+        for item in fields(BridgeRecord)
+        if item.default is MISSING and item.default_factory is MISSING
+    }
+    missing = required - set(payload)
+    if missing:
+        raise BridgeAdapterError(
+            f"bridge record is missing required fields: {sorted(missing)}",
+            [BridgeReason.MISSING_REQUIRED_FIELD],
         )
     data = dict(payload)
     known_loss = data.get("known_loss", [])
-    if isinstance(known_loss, (list, tuple)):
+    if type(known_loss) in (list, tuple):
         data["known_loss"] = list(known_loss)
-    return BridgeRecord(**data)
+    try:
+        return BridgeRecord(**data)
+    except TypeError as exc:
+        raise BridgeAdapterError(
+            "bridge record payload does not match bridge.v0.1",
+            [BridgeReason.INVALID_MAPPING],
+        ) from exc

--- a/src/core/evidence_bridge_adapter.py
+++ b/src/core/evidence_bridge_adapter.py
@@ -582,9 +582,14 @@ def translate_bridge_record(
 
     claim: ClaimCandidate | None = None
     if record.proposed_claim_tag is not None:
-        # validate_bridge_record() garantiert für diesen Pfad eine geladene
-        # Policy und einen bekannten, normalisierten Tag.
-        assert policy is not None
+        # Defense in depth: validate_bridge_record() prüft dies bereits. Die
+        # Übersetzung darf sich trotzdem nicht auf ein ``assert`` verlassen,
+        # das Python unter ``-O`` entfernen würde.
+        if type(policy) is not ClaimPolicy:
+            raise BridgeAdapterError(
+                "a loaded ClaimPolicy is required when proposing a ClaimCandidate",
+                [BridgeReason.CLAIM_POLICY_REQUIRED],
+            )
         tag = normalize_claim_tag(record.proposed_claim_tag, policy).tag
         claim = ClaimCandidate(
             claim_id=claim_id,

--- a/src/core/evidence_bridge_adapter.py
+++ b/src/core/evidence_bridge_adapter.py
@@ -418,13 +418,13 @@ def _validate_register_reach(record: BridgeRecord) -> None:
     eine Entscheidung: Der Aufrufer sagte ``MEASURES``. Die Korrektur ist ein
     neuer, ausdrücklich anders lautender Record — von einem Menschen.
     """
+    allowed = _REGISTER_ALLOWED_RELATIONS[record.source_register]
     hint = (
-        f"Zulässig sind hier {sorted(CONTEXT_ONLY_RELATIONS)}. Der Adapter stuft "
+        f"Zulässig sind hier {sorted(allowed)}. Der Adapter stuft "
         "nicht selbst ab; ein Mensch kann einen neuen Record mit ausdrücklich "
         "diesem Relationstyp einreichen."
     )
 
-    allowed = _REGISTER_ALLOWED_RELATIONS[record.source_register]
     if record.relation_type not in allowed:
         if (
             record.relation_type in PROMOTION_CAPABLE_RELATION_TYPES
@@ -659,6 +659,10 @@ def bridge_record_from_mapping(payload: Mapping[str, Any]) -> BridgeRecord:
         for item in fields(BridgeRecord)
         if item.default is MISSING and item.default_factory is MISSING
     }
+    # Programmatic construction may use the dataclass default, but external
+    # JSON-shaped input must declare its semantics explicitly. Otherwise an
+    # unversioned payload would be interpreted silently as bridge.v0.1.
+    required.add("schema_version")
     missing = required - set(payload)
     if missing:
         raise BridgeAdapterError(

--- a/tests/unit/test_evidence_bridge_adapter.py
+++ b/tests/unit/test_evidence_bridge_adapter.py
@@ -351,6 +351,16 @@ class TestTranslation:
         # Nichts wurde geschrieben:
         assert list(tmp_path.iterdir()) == []
 
+    def test_translation_fails_closed_without_candidate_policy(self):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            translate_bridge_record(
+                make_record(
+                    proposed_claim_tag="[HYPOTHESE]",
+                    claim_text="Prüfbarer Satz.",
+                )
+            )
+        assert BridgeReason.CLAIM_POLICY_REQUIRED in excinfo.value.reasons
+
     def test_source_expression_never_leaves_the_bridge(self):
         translation = translate_bridge_record(make_record())
         serialized = str(translation.to_dict())

--- a/tests/unit/test_evidence_bridge_adapter.py
+++ b/tests/unit/test_evidence_bridge_adapter.py
@@ -35,6 +35,7 @@ def make_record(**overrides):
         "falsifier": "Ein Gegenbeispiel mit vertauschter Nachbarschaft",
         "rollback": "HumanDecision(WITHDRAW) auf req-001",
         "intended_use": "explain",
+        "claim_id": "clm-existing-001",
     }
     data.update(overrides)
     return BridgeRecord(**data)
@@ -93,12 +94,79 @@ class TestStructuralValidation:
     def test_unknown_fields_are_rejected(self):
         payload = dataclasses.asdict(make_record())
         payload["secret_score"] = 0.9
-        with pytest.raises(BridgeAdapterError):
+        with pytest.raises(BridgeAdapterError) as excinfo:
             bridge_record_from_mapping(payload)
+        assert BridgeReason.UNKNOWN_FIELD in excinfo.value.reasons
+
+    @pytest.mark.parametrize("field", ["bridge_id", "source_pointer", "known_loss"])
+    def test_missing_mapping_fields_are_structured_errors(self, field):
+        payload = dataclasses.asdict(make_record())
+        del payload[field]
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            bridge_record_from_mapping(payload)
+        assert BridgeReason.MISSING_REQUIRED_FIELD in excinfo.value.reasons
+
+    def test_non_dict_mapping_is_rejected_without_invoking_it(self):
+        class ExecutableMapping(dict):
+            def __iter__(self):  # pragma: no cover - must not run
+                raise AssertionError("custom mapping executed")
+
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            bridge_record_from_mapping(ExecutableMapping(dataclasses.asdict(make_record())))
+        assert BridgeReason.INVALID_MAPPING in excinfo.value.reasons
 
     def test_mapping_roundtrip(self):
         payload = dataclasses.asdict(make_record())
         assert bridge_record_from_mapping(payload) == make_record()
+
+    def test_blank_bridge_id_is_rejected_before_id_derivation(self):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(bridge_id="  "))
+        assert BridgeReason.BRIDGE_ID_REQUIRED in excinfo.value.reasons
+
+    @pytest.mark.parametrize(
+        ("field", "reason"),
+        [
+            ("bridge_id", BridgeReason.BRIDGE_ID_REQUIRED),
+            ("actor", BridgeReason.ACTOR_REQUIRED),
+            ("claim_id", BridgeReason.CLAIM_ID_REQUIRED),
+            ("source_pointer", BridgeReason.SOURCE_POINTER_REQUIRED),
+            ("source_digest", BridgeReason.SOURCE_DIGEST_REQUIRED),
+            ("m5_review_pointer", BridgeReason.M5_REVIEW_REQUIRED),
+        ],
+    )
+    def test_identity_and_pointer_fields_reject_edge_whitespace(self, field, reason):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(**{field: " value "}))
+        assert reason in excinfo.value.reasons
+
+    @pytest.mark.parametrize("actor", ["", "  ", None, 7])
+    def test_actor_must_be_nonempty_text(self, actor):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(actor=actor))
+        assert BridgeReason.ACTOR_REQUIRED in excinfo.value.reasons
+
+    @pytest.mark.parametrize("version", ["bridge.v9.9", None, [], 7])
+    def test_unsupported_schema_version_is_rejected(self, version):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(schema_version=version))
+        assert BridgeReason.UNSUPPORTED_SCHEMA_VERSION in excinfo.value.reasons
+
+    @pytest.mark.parametrize(
+        ("field", "value", "reason"),
+        [
+            ("source_register", [], BridgeReason.UNKNOWN_SOURCE_REGISTER),
+            ("relation_type", {}, BridgeReason.UNKNOWN_RELATION_TYPE),
+            ("intended_use", [], BridgeReason.UNKNOWN_INTENDED_USE),
+            ("visibility", {}, BridgeReason.UNKNOWN_VISIBILITY),
+            ("protected_origin", "false", BridgeReason.INVALID_BOOLEAN),
+            ("claim_id", [], BridgeReason.CLAIM_ID_REQUIRED),
+        ],
+    )
+    def test_json_shaped_type_errors_fail_closed(self, field, value, reason):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(**{field: value}))
+        assert reason in excinfo.value.reasons
 
 
 class TestRegisterReach:
@@ -134,6 +202,34 @@ class TestRegisterReach:
     def test_formal_and_governance_may_carry_context_and_provenance(self, register):
         for relation in ("CONTEXTUALIZES", "MOTIVATES", "PROVENANCE_ONLY"):
             validate_bridge_record(make_record(source_register=register, relation_type=relation))
+
+    @pytest.mark.parametrize(
+        "register",
+        [
+            "myth",
+            "metaphor",
+            "formal",
+            "physical",
+            "biological",
+            "psychological",
+            "governance",
+            "ui",
+        ],
+    )
+    def test_contradicts_is_rejected_for_every_register_in_v0_1(self, register):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(
+                    source_register=register,
+                    relation_type="CONTRADICTS",
+                    m5_review_pointer=(
+                        "docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001"
+                        if register in {"physical", "biological"}
+                        else None
+                    ),
+                )
+            )
+        assert BridgeReason.RELATION_NOT_ALLOWED_FOR_REGISTER in excinfo.value.reasons
 
     @pytest.mark.parametrize("register", ["formal", "governance"])
     def test_deferred_registers_name_their_opening_condition(self, register):
@@ -186,27 +282,61 @@ class TestRegisterReach:
 class TestClaimTagBoundary:
     @pytest.mark.parametrize("tag", ["[FACT]", "[SPEC]", "[CANON]"])
     def test_adapter_must_not_assign_strong_tags(self, tag):
+        policy = load_claim_policy()
         with pytest.raises(BridgeAdapterError) as excinfo:
-            validate_bridge_record(make_record(proposed_claim_tag=tag))
+            validate_bridge_record(
+                make_record(proposed_claim_tag=tag, claim_text="Unzulässiger Satz."),
+                policy=policy,
+            )
         assert BridgeReason.ADAPTER_CANNOT_ASSIGN_TAG in excinfo.value.reasons
 
     def test_alias_is_normalized_before_the_ban_applies(self):
         # [FAKT] normalisiert auf [FACT] und muss ebenso abgelehnt werden.
         policy = load_claim_policy()
         with pytest.raises(BridgeAdapterError) as excinfo:
-            validate_bridge_record(make_record(proposed_claim_tag="[FAKT]"), policy=policy)
+            validate_bridge_record(
+                make_record(proposed_claim_tag="[FAKT]", claim_text="Unzulässiger Satz."),
+                policy=policy,
+            )
         assert BridgeReason.ADAPTER_CANNOT_ASSIGN_TAG in excinfo.value.reasons
 
     def test_unknown_tag_fails_closed(self):
         policy = load_claim_policy()
         with pytest.raises(BridgeAdapterError) as excinfo:
-            validate_bridge_record(make_record(proposed_claim_tag="[TOTALLY-NEW]"), policy=policy)
+            validate_bridge_record(
+                make_record(proposed_claim_tag="[TOTALLY-NEW]", claim_text="Offener Satz."),
+                policy=policy,
+            )
         assert BridgeReason.UNKNOWN_CLAIM_TAG in excinfo.value.reasons
 
     def test_weak_tags_are_allowed(self):
         policy = load_claim_policy()
         for tag in ("[METAPHER]", "[ROSETTA]", "[HYPOTHESE]", "[MODEL]"):
-            validate_bridge_record(make_record(proposed_claim_tag=tag), policy=policy)
+            validate_bridge_record(
+                make_record(proposed_claim_tag=tag, claim_text="Prüfbarer Satz."),
+                policy=policy,
+            )
+
+    def test_claim_policy_is_required_for_every_proposed_tag(self):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(proposed_claim_tag="[FAKT]", claim_text="Alias-Bypass.")
+            )
+        assert BridgeReason.CLAIM_POLICY_REQUIRED in excinfo.value.reasons
+
+    def test_claim_text_is_required_for_candidate(self):
+        policy = load_claim_policy()
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(proposed_claim_tag="[HYPOTHESE]", claim_text="  "),
+                policy=policy,
+            )
+        assert BridgeReason.CLAIM_TEXT_REQUIRED in excinfo.value.reasons
+
+    def test_existing_claim_id_is_required_without_candidate(self):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(make_record(claim_id=None))
+        assert BridgeReason.CLAIM_ID_REQUIRED in excinfo.value.reasons
 
 
 class TestTranslation:
@@ -297,6 +427,19 @@ class TestTranslation:
         assert translation.claim.claim_tag == "[HYPOTHESE]"
         assert translation.claim.material_refs == [translation.material.material_id]
 
+    def test_candidate_may_derive_claim_id_when_none_is_supplied(self):
+        policy = load_claim_policy()
+        translation = translate_bridge_record(
+            make_record(
+                claim_id=None,
+                proposed_claim_tag="[HYPOTHESE]",
+                claim_text="Beispielsatz.",
+            ),
+            policy=policy,
+        )
+        assert translation.claim is not None
+        assert translation.relation.claim_id == translation.claim.claim_id
+
     def test_translation_is_deterministic(self):
         first = translate_bridge_record(make_record())
         second = translate_bridge_record(make_record())
@@ -374,6 +517,7 @@ class TestSourceModuleMinimalTests:
             relation_type="MOTIVATES",
             known_loss=["Keine Aussage über Ladungstransport oder Theologie"],
             proposed_claim_tag="[METAPHER]",
+            claim_text="Die Barriere dient hier ausschließlich als Metapher.",
         )
         translation = translate_bridge_record(record, policy=policy)
         assert translation.promotion_capable is False

--- a/tests/unit/test_evidence_bridge_adapter.py
+++ b/tests/unit/test_evidence_bridge_adapter.py
@@ -240,9 +240,7 @@ class TestRegisterReach:
                 make_record(
                     source_register=register,
                     relation_type="CONTRADICTS",
-                    m5_review_pointer=(
-                        "docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001"
-                    ),
+                    m5_review_pointer=("docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001"),
                 )
             )
         message = str(excinfo.value)

--- a/tests/unit/test_evidence_bridge_adapter.py
+++ b/tests/unit/test_evidence_bridge_adapter.py
@@ -98,7 +98,9 @@ class TestStructuralValidation:
             bridge_record_from_mapping(payload)
         assert BridgeReason.UNKNOWN_FIELD in excinfo.value.reasons
 
-    @pytest.mark.parametrize("field", ["bridge_id", "source_pointer", "known_loss"])
+    @pytest.mark.parametrize(
+        "field", ["bridge_id", "source_pointer", "known_loss", "schema_version"]
+    )
     def test_missing_mapping_fields_are_structured_errors(self, field):
         payload = dataclasses.asdict(make_record())
         del payload[field]
@@ -230,6 +232,29 @@ class TestRegisterReach:
                 )
             )
         assert BridgeReason.RELATION_NOT_ALLOWED_FOR_REGISTER in excinfo.value.reasons
+
+    @pytest.mark.parametrize("register", ["physical", "biological"])
+    def test_invalid_gated_relation_names_complete_allowed_vocabulary(self, register):
+        with pytest.raises(BridgeAdapterError) as excinfo:
+            validate_bridge_record(
+                make_record(
+                    source_register=register,
+                    relation_type="CONTRADICTS",
+                    m5_review_pointer=(
+                        "docs/annex/RESEARCH_VALIDATION_GATE_v0_1.md#bench-001"
+                    ),
+                )
+            )
+        message = str(excinfo.value)
+        for relation in (
+            "CONTEXTUALIZES",
+            "MOTIVATES",
+            "PROVENANCE_ONLY",
+            "SUPPORTS",
+            "MEASURES",
+            "IMPLEMENTS",
+        ):
+            assert relation in message
 
     @pytest.mark.parametrize("register", ["formal", "governance"])
     def test_deferred_registers_name_their_opening_condition(self, register):


### PR DESCRIPTION
## Intent

Post-merge follow-up to #325. This closes the nine validation gaps reported after merge without changing the ERK core, ledger, claim policy, or authority semantics.

The old review threads remain unresolved for independent re-review; this PR is the separate corrective change.

## Scope

- `src/core/evidence_bridge_adapter.py`
  - require a loaded `ClaimPolicy` for every proposed `ClaimCandidate`, so aliases and unknown tags cannot bypass normalization
  - enforce the policy requirement with an explicit fail-closed exception rather than a removable runtime `assert`
  - enforce a closed relation vocabulary per source register; `CONTRADICTS` remains disallowed everywhere in v0.1 because no explicit opening gate exists
  - require an existing `claim_id` when no candidate is emitted and nonblank `claim_text` when one is emitted
  - reject blank or edge-whitespace bridge/claim IDs, actor attribution, and source/M5 pointers
  - pin `schema_version` to `bridge.v0.1` and require exact JSON-shaped control types
  - return schema-specific adapter reasons for unknown fields, missing required fields, invalid mappings, and invalid booleans
- `tests/unit/test_evidence_bridge_adapter.py`: expand the boundary matrix from 70 to 111 tests
- `docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md`: document the refreshed fail-closed contract

FOKUS: Bridge intake hardening

## Test Plan

- [x] Focused adapter tests pass on the follow-up head — `111 passed`
- [x] Manual testing completed — 299-case mutation/boundary sweep, zero unexpected outcomes
- [x] CI checks pass on the follow-up head
- [x] `make verify` — `490 passed`, pointer and claim lint green
- [x] `make verify-governance` — 14/14 workflows pass posture checks; 22 VOIDs in sync
- [x] Ruff, Black, mypy, Bandit, and `git diff --check` pass

## Risk

This intentionally tightens malformed-input behavior: callers that relied on missing claim bindings, implicit tag-policy bypasses, unsupported schema versions, noncanonical identifiers, or undocumented relation reach will now receive a structured `BridgeAdapterError`.

No event emission, file/network I/O, dependency change, promotion, retagging, or human-decision synthesis is added. Physical/biological promotion-capable relations still require an M5 pointer; `CONTRADICTS` is not newly authorized by inference.

---

Review focus: verify the exact register/relation matrix and the candidate-vs-existing-claim split before merge.