### PR TITLE
ci: harden supply-chain workflows

### DIFF
--- a/.github/workflows/ci-js-workspace.yml
+++ b/.github/workflows/ci-js-workspace.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deepjump-audit.reusable.yml
+++ b/.github/workflows/deepjump-audit.reusable.yml
@@ -31,8 +31,6 @@ concurrency:
 jobs:
   deepjump-audit:
     runs-on: ubuntu-latest
-    env:
-      ENTA_HMAC_SECRET: ${{ secrets.ENTA_HMAC_SECRET }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -49,6 +47,8 @@ jobs:
 
       - name: Mask HMAC secret
         shell: bash
+        env:
+          ENTA_HMAC_SECRET: ${{ secrets.ENTA_HMAC_SECRET }}
         run: |
           if [ -n "${ENTA_HMAC_SECRET:-}" ]; then
             echo "::add-mask::$ENTA_HMAC_SECRET"
@@ -57,22 +57,22 @@ jobs:
       - name: Check HMAC availability
         id: hmac
         shell: bash
+        env:
+          ALLOW_UNSIGNED_STATUS_SKIP: ${{ inputs.allow-unsigned-status-skip }}
+          ENTA_HMAC_SECRET: ${{ secrets.ENTA_HMAC_SECRET }}
         run: |
-          # Graceful degradation: when the signing key is configured we emit and
-          # verify a signed status; when it is absent we skip ONLY the signing
-          # step (with a warning) instead of failing the whole audit. All
-          # verification phases below (pointers, receipts, claims, tests,
-          # snapshot, verify-json) always run and still gate the job.
           if [ -n "${ENTA_HMAC_SECRET:-}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
             echo "skip_allowed=false" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "skip_allowed=true" >> "$GITHUB_OUTPUT"
-            if [ "${{ inputs.allow-unsigned-status-skip }}" = "true" ]; then
+            if [ "$ALLOW_UNSIGNED_STATUS_SKIP" = "true" ]; then
+              echo "skip_allowed=true" >> "$GITHUB_OUTPUT"
               echo "::notice title=DeepJump HMAC skipped::Signing key unavailable in dependency/fork PR context; signed status skipped."
             else
-              echo "::warning title=DeepJump HMAC skipped::ENTA_HMAC_SECRET not configured; signed status emit/verify skipped. Add the repo secret to re-enable signing. Verification phases still ran."
+              echo "skip_allowed=false" >> "$GITHUB_OUTPUT"
+              echo "::error title=DeepJump HMAC required::ENTA_HMAC_SECRET is unavailable in a trusted run; refusing an unsigned status."
+              exit 1
             fi
           fi
 
@@ -90,6 +90,8 @@ jobs:
 
       - name: "Phase 2: Emit & Verify Status"
         if: ${{ steps.hmac.outputs.available == 'true' }}
+        env:
+          ENTA_HMAC_SECRET: ${{ secrets.ENTA_HMAC_SECRET }}
         run: make status-verify STATUS=PASS H=0.85 DMI=4.8 PHI=0.75
 
       - name: "Phase 2: Record unsigned status skip"

--- a/.github/workflows/deepjump-ci.yml
+++ b/.github/workflows/deepjump-ci.yml
@@ -51,7 +51,11 @@ jobs:
   deepjump-audit:
     needs: verify-lint
     uses: ./.github/workflows/deepjump-audit.reusable.yml
-    secrets: inherit
+    secrets:
+      # Never pass the signing key into pull-request execution. Fork and
+      # dependency PRs receive no repository secrets; this also keeps
+      # same-repository PR verification on the unsigned path by construction.
+      ENTA_HMAC_SECRET: ${{ secrets[github.event_name == 'pull_request' && 'UNAVAILABLE_ON_PULL_REQUESTS' || 'ENTA_HMAC_SECRET'] }}
     with:
       python-version: "3.11"
       # Pull requests may not have access to ENTA_HMAC_SECRET. Keep PR verification

--- a/.github/workflows/deepjump-ci.yml
+++ b/.github/workflows/deepjump-ci.yml
@@ -49,15 +49,21 @@ jobs:
         run: python3 tools/port_lint.py
 
   deepjump-audit:
+    if: ${{ github.event_name == 'pull_request' }}
+    needs: verify-lint
+    uses: ./.github/workflows/deepjump-audit.reusable.yml
+    with:
+      python-version: "3.11"
+      # Pull requests never receive a secrets mapping. Verification remains
+      # strict, while signed-status emission is explicitly skipped.
+      allow-unsigned-status-skip: true
+
+  deepjump-audit-signed:
+    if: ${{ github.event_name != 'pull_request' }}
     needs: verify-lint
     uses: ./.github/workflows/deepjump-audit.reusable.yml
     secrets:
-      # Never pass the signing key into pull-request execution. Fork and
-      # dependency PRs receive no repository secrets; this also keeps
-      # same-repository PR verification on the unsigned path by construction.
-      ENTA_HMAC_SECRET: ${{ secrets[github.event_name == 'pull_request' && 'UNAVAILABLE_ON_PULL_REQUESTS' || 'ENTA_HMAC_SECRET'] }}
+      ENTA_HMAC_SECRET: ${{ secrets.ENTA_HMAC_SECRET }}
     with:
       python-version: "3.11"
-      # Pull requests may not have access to ENTA_HMAC_SECRET. Keep PR verification
-      # strict for pointers/claims/tests, but allow signed-status emission to be skipped.
-      allow-unsigned-status-skip: ${{ github.event_name == 'pull_request' }}
+      allow-unsigned-status-skip: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,9 +28,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -e ".[dev]" || pip install -e . || true
-          pip install pyyaml
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
 
       - name: Gate 1 — Pointer Integrity
         run: python3 tools/verify_pointers.py --strict
@@ -79,6 +78,8 @@ jobs:
     name: Create GitHub Release
     needs: gate-check
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -109,14 +110,18 @@ jobs:
 
       - name: Create Release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v7
+        env:
+          RELEASE_TAG: ${{ steps.notes.outputs.tag }}
+          RELEASE_NOTES: ${{ steps.notes.outputs.notes }}
         with:
           script: |
+            const tag = process.env.RELEASE_TAG;
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: '${{ steps.notes.outputs.tag }}',
-              name: 'EntaENGELment ${{ steps.notes.outputs.tag }}',
-              body: `${{ steps.notes.outputs.notes }}`,
+              tag_name: tag,
+              name: `EntaENGELment ${tag}`,
+              body: process.env.RELEASE_NOTES,
               draft: false,
-              prerelease: '${{ steps.notes.outputs.tag }}'.includes('-rc')
+              prerelease: tag.includes('-rc')
             });

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -20,14 +20,28 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: "3.11"
+
       - name: Generate Python SBOM
         run: |
-          pip install pip-audit cyclonedx-bom
-          cyclonedx-py requirements -r requirements.txt -o sbom-python.json --format json || true
+          python -m venv .sbom-venv
+          .sbom-venv/bin/python -m pip install --upgrade pip
+          .sbom-venv/bin/python -m pip install -r requirements.txt
+          python -m pip install "cyclonedx-bom==7.3.1"
+          cyclonedx-py environment .sbom-venv/bin/python \
+            --pyproject pyproject.toml \
+            --spec-version 1.6 \
+            --output-reproducible \
+            --output-format JSON \
+            --output-file sbom-python.cdx.json
 
       - name: Upload SBOM
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: sbom
-          path: sbom-*.json
+          name: python-sbom
+          path: sbom-python.cdx.json
+          if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -56,7 +56,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Audit report (all severities, non-blocking)
-        run: pnpm audit || true
+        continue-on-error: true
+        run: pnpm audit
 
       - name: Audit gate (fail on high+)
         run: pnpm audit --audit-level=high

--- a/docs/ci/WORKFLOW_MAP.md
+++ b/docs/ci/WORKFLOW_MAP.md
@@ -21,6 +21,20 @@ Exception: `release.yml` keeps top-level `contents: read`; only its
 `create-release` job receives `contents: write`, because that job creates a
 GitHub Release from a version tag.
 
+The checker reads the following exact exception contract. A filename mention
+outside this block does not authorize a broader or different scope.
+
+<!-- workflow-posture-permissions
+release.yml:
+  jobs:
+    create-release:
+      contents: write
+void-sync.yml:
+  workflow:
+    contents: read
+    issues: write
+-->
+
 ## Workflows
 
 | Workflow file | Purpose | Permissions | Concurrency |
@@ -31,7 +45,7 @@ GitHub Release from a version tag.
 | `.github/workflows/ci-policy-lint.yml` | Policy JSON lint | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/ci-smoke.yml` | Python smoke tests | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/deepjump-audit.reusable.yml` | Reusable DeepJump audit core; HMAC secret is step-scoped and missing keys fail trusted runs | `contents: read` | literal `deepjump-audit-reusable-${{ github.ref }}`, cancel in progress |
-| `.github/workflows/deepjump-ci.yml` | DeepJump verify/lint plus reusable audit call; PRs pass no HMAC secret | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/deepjump-ci.yml` | DeepJump verify/lint plus separate reusable audit calls: PRs pass no secrets mapping; trusted events pass only `ENTA_HMAC_SECRET` | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/metatron-guard.yml` | FOKUS marker advisory guard for PRs/branch pushes | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/release.yml` | Release gate and GitHub Release creation | top-level `contents: read`; `create-release` job: `contents: write` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/sbom.yml` | Fail-closed Python environment SBOM generation and artifact upload | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
@@ -40,13 +54,17 @@ GitHub Release from a version tag.
 
 ## Maintenance rule
 
-[FACT] New workflows must document any permission broader than `contents: read` in this file. The reason should be action-specific, not symbolic or implied.
+[FACT] New workflows must document any permission broader than `contents: read`
+in the machine-readable exception contract above. The exact workflow/job scope
+and permission mapping must match; a filename mention alone grants nothing.
 
 [FACT] `make workflow-posture-check` (`tools/workflow_posture_check.py`) verifies
 this contract locally. Every workflow must declare explicit `permissions` and
 `concurrency` with `cancel-in-progress: true`; broader top-level or job
 permissions must be named here. External actions must use full commit SHAs.
 Executable shell/`github-script` bodies may not interpolate Actions expressions
-directly or hide failure with `|| true`. Reusable calls must pass named secrets,
-and secrets may not live in a job-wide environment. The check is read-only and
-deterministic.
+directly or hide failure with `|| true`, including before another shell
+separator. Reusable calls must pass named secrets, and secrets may not live in
+a job-wide environment. Docker actions require an immutable `sha256` digest;
+only reusable-job and step `uses` nodes are interpreted as actions. The check
+is read-only and deterministic.

--- a/docs/ci/WORKFLOW_MAP.md
+++ b/docs/ci/WORKFLOW_MAP.md
@@ -57,14 +57,19 @@ void-sync.yml:
 [FACT] New workflows must document any permission broader than `contents: read`
 in the machine-readable exception contract above. The exact workflow/job scope
 and permission mapping must match; a filename mention alone grants nothing.
+Exceptions without a currently matching broad permission are rejected as stale.
 
 [FACT] `make workflow-posture-check` (`tools/workflow_posture_check.py`) verifies
 this contract locally. Every workflow must declare explicit `permissions` and
 `concurrency` with `cancel-in-progress: true`; broader top-level or job
 permissions must be named here. External actions must use full commit SHAs.
-Executable shell/`github-script` bodies may not interpolate Actions expressions
-directly or hide failure with `|| true`, including before another shell
-separator. Reusable calls must pass named secrets, and secrets may not live in
-a job-wide environment. Docker actions require an immutable `sha256` digest;
-only reusable-job and step `uses` nodes are interpreted as actions. The check
-is read-only and deterministic.
+Checked-in composite actions are followed recursively so they cannot hide a
+mutable external reference. Executable shell bodies and the official
+`actions/github-script` action may not interpolate Actions expressions directly
+or hide failure with `|| true`, including before another shell separator or a
+closing subshell. Reusable calls must pass named secrets, and secrets may not
+live in a workflow-wide or job-wide environment. A reusable-call secret mapping
+must reference one explicit `secrets.NAME`, never the whole context. Docker
+actions plus job and service container images require an immutable `sha256`
+digest; only reusable-job and step `uses` nodes are interpreted as actions.
+The check is read-only and deterministic.

--- a/docs/ci/WORKFLOW_MAP.md
+++ b/docs/ci/WORKFLOW_MAP.md
@@ -17,7 +17,9 @@ concurrency:
   cancel-in-progress: true
 ```
 
-Exception: `release.yml` keeps `contents: write` because it creates GitHub Releases from version tags.
+Exception: `release.yml` keeps top-level `contents: read`; only its
+`create-release` job receives `contents: write`, because that job creates a
+GitHub Release from a version tag.
 
 ## Workflows
 
@@ -28,11 +30,11 @@ Exception: `release.yml` keeps `contents: write` because it creates GitHub Relea
 | `.github/workflows/ci-js-workspace.yml` | JS/TS workspace membrane: frozen pnpm install plus Turbo typecheck/lint/build for UI/package changes | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/ci-policy-lint.yml` | Policy JSON lint | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/ci-smoke.yml` | Python smoke tests | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
-| `.github/workflows/deepjump-audit.reusable.yml` | Reusable DeepJump audit core | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
-| `.github/workflows/deepjump-ci.yml` | DeepJump verify/lint plus reusable audit call | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/deepjump-audit.reusable.yml` | Reusable DeepJump audit core; HMAC secret is step-scoped and missing keys fail trusted runs | `contents: read` | literal `deepjump-audit-reusable-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/deepjump-ci.yml` | DeepJump verify/lint plus reusable audit call; PRs pass no HMAC secret | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/metatron-guard.yml` | FOKUS marker advisory guard for PRs/branch pushes | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
-| `.github/workflows/release.yml` | Release gate and GitHub Release creation | `contents: write` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
-| `.github/workflows/sbom.yml` | SBOM generation and artifact upload | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/release.yml` | Release gate and GitHub Release creation | top-level `contents: read`; `create-release` job: `contents: write` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
+| `.github/workflows/sbom.yml` | Fail-closed Python environment SBOM generation and artifact upload | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/test.yml` | JavaScript, Python, and UI build tests | `contents: read` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 | `.github/workflows/void-sync.yml` | Scheduled VOID deadline monitoring and issue creation | `contents: read`, `issues: write` | `${{ github.workflow }}-${{ github.ref }}`, cancel in progress |
 
@@ -40,4 +42,11 @@ Exception: `release.yml` keeps `contents: write` because it creates GitHub Relea
 
 [FACT] New workflows must document any permission broader than `contents: read` in this file. The reason should be action-specific, not symbolic or implied.
 
-[FACT] `make workflow-posture-check` (`tools/workflow_posture_check.py`) verifies this contract locally: every workflow must declare explicit `permissions` and a `concurrency` block with `cancel-in-progress: true`, and any permission broader than `contents: read` must be named in this file. The check is read-only and deterministic.
+[FACT] `make workflow-posture-check` (`tools/workflow_posture_check.py`) verifies
+this contract locally. Every workflow must declare explicit `permissions` and
+`concurrency` with `cancel-in-progress: true`; broader top-level or job
+permissions must be named here. External actions must use full commit SHAs.
+Executable shell/`github-script` bodies may not interpolate Actions expressions
+directly or hide failure with `|| true`. Reusable calls must pass named secrets,
+and secrets may not live in a job-wide environment. The check is read-only and
+deterministic.

--- a/tests/test_workflow_posture_check.py
+++ b/tests/test_workflow_posture_check.py
@@ -111,11 +111,39 @@ def test_broad_permissions_require_documentation(tmp_path: Path) -> None:
 def test_broad_permissions_pass_when_documented(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace("contents: read", "contents: write")
     _make_workflow(tmp_path, "release.yml", body)
-    _make_map(tmp_path, "Exception: `release.yml` keeps `contents: write`.\n")
+    _make_map(
+        tmp_path,
+        "<!-- workflow-posture-permissions\n"
+        "release.yml:\n"
+        "  workflow:\n"
+        "    contents: write\n"
+        "-->\n",
+    )
 
     ok, lines = wpc.build_results(tmp_path)
 
     assert ok is True
+
+
+def test_documented_filename_does_not_allow_a_different_scope(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "contents: read",
+        "contents: read\n  issues: write",
+    )
+    _make_workflow(tmp_path, "release.yml", body)
+    _make_map(
+        tmp_path,
+        "<!-- workflow-posture-permissions\n"
+        "release.yml:\n"
+        "  workflow:\n"
+        "    contents: write\n"
+        "-->\n",
+    )
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("do not exactly match" in line for line in lines)
 
 
 def test_job_level_broad_permissions_require_documentation(tmp_path: Path) -> None:
@@ -130,6 +158,27 @@ def test_job_level_broad_permissions_require_documentation(tmp_path: Path) -> No
 
     assert ok is False
     assert any("job 'noop' has permissions broader" in line for line in lines)
+
+
+def test_job_level_broad_permissions_match_exact_exception(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "permissions:\n      contents: write\n    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "release.yml", body)
+    _make_map(
+        tmp_path,
+        "<!-- workflow-posture-permissions\n"
+        "release.yml:\n"
+        "  jobs:\n"
+        "    noop:\n"
+        "      contents: write\n"
+        "-->\n",
+    )
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
 
 
 def test_external_actions_must_use_full_commit_sha(tmp_path: Path) -> None:
@@ -151,6 +200,47 @@ def test_full_sha_and_local_actions_are_allowed(tmp_path: Path) -> None:
         "- run: echo ok",
         "- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n"
         "      - uses: ./.github/actions/local",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
+
+
+def test_docker_actions_require_immutable_digest(tmp_path: Path) -> None:
+    mutable = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: docker://vendor/image:latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", mutable)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("immutable sha256 digest" in line for line in lines)
+
+
+def test_digest_pinned_docker_action_is_allowed(tmp_path: Path) -> None:
+    digest = "a" * 64
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        f"- uses: docker://vendor/image@sha256:{digest}",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
+
+
+def test_non_action_uses_field_is_ignored(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "env:\n      uses: helper\n    runs-on: ubuntu-latest",
     )
     _make_workflow(tmp_path, "ci.yml", body)
     _make_map(tmp_path, "# map\n")
@@ -201,6 +291,20 @@ def test_shell_failure_mask_is_rejected(tmp_path: Path) -> None:
     assert any("masks failure" in line for line in lines)
 
 
+def test_shell_failure_mask_before_separator_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- run: generate-sbom || true; echo done",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("masks failure" in line for line in lines)
+
+
 def test_inherited_and_job_wide_secrets_are_rejected(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace(
         "runs-on: ubuntu-latest",
@@ -224,6 +328,22 @@ def test_bracketed_job_wide_secret_is_rejected(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace(
         "runs-on: ubuntu-latest",
         "env:\n" "      TOKEN: ${{ secrets['REPO_TOKEN'] }}\n" "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("job-wide env" in line for line in lines)
+
+
+def test_whole_context_job_wide_secret_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "env:\n"
+        "      ALL_SECRETS: ${{ toJSON(secrets) }}\n"
+        "    runs-on: ubuntu-latest",
     )
     _make_workflow(tmp_path, "ci.yml", body)
     _make_map(tmp_path, "# map\n")

--- a/tests/test_workflow_posture_check.py
+++ b/tests/test_workflow_posture_check.py
@@ -118,6 +118,122 @@ def test_broad_permissions_pass_when_documented(tmp_path: Path) -> None:
     assert ok is True
 
 
+def test_job_level_broad_permissions_require_documentation(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "permissions:\n      contents: write\n    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "release.yml", body)
+    _make_map(tmp_path, "# map without the workflow\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("job 'noop' has permissions broader" in line for line in lines)
+
+
+def test_external_actions_must_use_full_commit_sha(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: actions/checkout@v7",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("not pinned to a full commit SHA" in line for line in lines)
+
+
+def test_full_sha_and_local_actions_are_allowed(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0\n"
+        "      - uses: ./.github/actions/local",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
+
+
+def test_executable_expressions_must_pass_through_env(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        '- run: echo "${{ github.event.pull_request.title }}"',
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("direct Actions expression" in line for line in lines)
+
+
+def test_github_script_expressions_are_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3\n"
+        "        with:\n"
+        "          script: console.log('${{ github.event.issue.title }}')",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("github-script body" in line for line in lines)
+
+
+def test_shell_failure_mask_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace("- run: echo ok", "- run: generate-sbom || true")
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("masks failure" in line for line in lines)
+
+
+def test_inherited_and_job_wide_secrets_are_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "secrets: inherit\n"
+        "    env:\n"
+        "      TOKEN: ${{ secrets.REPO_TOKEN }}\n"
+        "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    report = "\n".join(lines)
+    assert "secrets: inherit" in report
+    assert "job-wide env" in report
+
+
+def test_bracketed_job_wide_secret_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "env:\n" "      TOKEN: ${{ secrets['REPO_TOKEN'] }}\n" "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("job-wide env" in line for line in lines)
+
+
 def test_no_workflows_is_ok(tmp_path: Path) -> None:
     ok, lines = wpc.build_results(tmp_path)
     assert ok is True

--- a/tests/test_workflow_posture_check.py
+++ b/tests/test_workflow_posture_check.py
@@ -17,6 +17,12 @@ def _make_map(root: Path, text: str) -> None:
     map_path.write_text(text, encoding="utf-8")
 
 
+def _make_local_action(root: Path, relative_dir: str, body: str) -> None:
+    action_dir = root / relative_dir
+    action_dir.mkdir(parents=True, exist_ok=True)
+    (action_dir / "action.yml").write_text(body, encoding="utf-8")
+
+
 GOOD_READ_ONLY = """\
 name: Good
 on: [push]
@@ -181,6 +187,23 @@ def test_job_level_broad_permissions_match_exact_exception(tmp_path: Path) -> No
     assert ok is True
 
 
+def test_stale_permission_exception_is_rejected(tmp_path: Path) -> None:
+    _make_workflow(tmp_path, "release.yml", GOOD_READ_ONLY)
+    _make_map(
+        tmp_path,
+        "<!-- workflow-posture-permissions\n"
+        "release.yml:\n"
+        "  workflow:\n"
+        "    contents: write\n"
+        "-->\n",
+    )
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("stale permission exception" in line for line in lines)
+
+
 def test_external_actions_must_use_full_commit_sha(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace(
         "- run: echo ok",
@@ -202,11 +225,82 @@ def test_full_sha_and_local_actions_are_allowed(tmp_path: Path) -> None:
         "      - uses: ./.github/actions/local",
     )
     _make_workflow(tmp_path, "ci.yml", body)
+    _make_local_action(
+        tmp_path,
+        ".github/actions/local",
+        "name: Local\n"
+        "description: Local test action\n"
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - run: echo local\n"
+        "      shell: bash\n",
+    )
     _make_map(tmp_path, "# map\n")
 
     ok, _ = wpc.build_results(tmp_path)
 
     assert ok is True
+
+
+def test_local_composite_actions_cannot_hide_mutable_external_actions(
+    tmp_path: Path,
+) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: ./.github/actions/wrapper",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_local_action(
+        tmp_path,
+        ".github/actions/wrapper",
+        "name: Wrapper\n"
+        "description: Wrapper test action\n"
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - uses: actions/checkout@v7\n",
+    )
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("not pinned to a full commit SHA" in line for line in lines)
+
+
+def test_nested_local_composites_are_scanned_recursively(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: ./.github/actions/outer",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_local_action(
+        tmp_path,
+        ".github/actions/outer",
+        "name: Outer\n"
+        "description: Outer wrapper\n"
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - uses: ./.github/actions/inner\n",
+    )
+    _make_local_action(
+        tmp_path,
+        ".github/actions/inner",
+        "name: Inner\n"
+        "description: Inner wrapper\n"
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - uses: actions/checkout@v7\n",
+    )
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("not pinned to a full commit SHA" in line for line in lines)
 
 
 def test_docker_actions_require_immutable_digest(tmp_path: Path) -> None:
@@ -228,6 +322,43 @@ def test_digest_pinned_docker_action_is_allowed(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace(
         "- run: echo ok",
         f"- uses: docker://vendor/image@sha256:{digest}",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
+
+
+def test_job_and_service_containers_require_immutable_digests(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "container:\n"
+        "      image: vendor/job:latest\n"
+        "    services:\n"
+        "      database:\n"
+        "        image: vendor/database:latest\n"
+        "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert sum("immutable sha256 digest" in line for line in lines) == 2
+
+
+def test_digest_pinned_job_and_service_containers_are_allowed(tmp_path: Path) -> None:
+    digest = "b" * 64
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        f"container: vendor/job@sha256:{digest}\n"
+        "    services:\n"
+        "      database:\n"
+        f"        image: vendor/database@sha256:{digest}\n"
+        "    runs-on: ubuntu-latest",
     )
     _make_workflow(tmp_path, "ci.yml", body)
     _make_map(tmp_path, "# map\n")
@@ -280,6 +411,21 @@ def test_github_script_expressions_are_rejected(tmp_path: Path) -> None:
     assert any("github-script body" in line for line in lines)
 
 
+def test_other_actions_may_use_script_as_data_input(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- uses: vendor/custom-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        "        with:\n"
+        "          script: ${{ github.event.issue.title }}",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
+
+
 def test_shell_failure_mask_is_rejected(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace("- run: echo ok", "- run: generate-sbom || true")
     _make_workflow(tmp_path, "ci.yml", body)
@@ -305,6 +451,64 @@ def test_shell_failure_mask_before_separator_is_rejected(tmp_path: Path) -> None
     assert any("masks failure" in line for line in lines)
 
 
+def test_shell_failure_mask_before_closing_subshell_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- run: (generate-sbom || true)",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("masks failure" in line for line in lines)
+
+
+def test_shell_failure_mask_across_newline_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "- run: echo ok",
+        "- run: |\n" "          generate-sbom ||\n" "            true\n",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("masks failure" in line for line in lines)
+
+
+def test_workflow_wide_secret_environment_is_rejected(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "concurrency:",
+        "env:\n" "  TOKEN: ${{ secrets.REPO_TOKEN }}\n" "concurrency:",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("workflow-wide env" in line for line in lines)
+
+
+def test_secret_environment_detection_scans_past_quoted_braces(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "env:\n"
+        "      TOKEN: ${{ format('{0}', secrets.REPO_TOKEN) }}\n"
+        "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("job-wide env" in line for line in lines)
+
+
 def test_inherited_and_job_wide_secrets_are_rejected(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace(
         "runs-on: ubuntu-latest",
@@ -322,6 +526,35 @@ def test_inherited_and_job_wide_secrets_are_rejected(tmp_path: Path) -> None:
     report = "\n".join(lines)
     assert "secrets: inherit" in report
     assert "job-wide env" in report
+
+
+def test_reusable_call_secret_mapping_requires_named_secret_reference(
+    tmp_path: Path,
+) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "secrets:\n" "      ALL_SECRETS: ${{ toJSON(secrets) }}\n" "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, lines = wpc.build_results(tmp_path)
+
+    assert ok is False
+    assert any("explicit named secrets reference" in line for line in lines)
+
+
+def test_reusable_call_named_secret_mapping_is_allowed(tmp_path: Path) -> None:
+    body = GOOD_READ_ONLY.replace(
+        "runs-on: ubuntu-latest",
+        "secrets:\n" "      TOKEN: ${{ secrets.REPO_TOKEN }}\n" "    runs-on: ubuntu-latest",
+    )
+    _make_workflow(tmp_path, "ci.yml", body)
+    _make_map(tmp_path, "# map\n")
+
+    ok, _ = wpc.build_results(tmp_path)
+
+    assert ok is True
 
 
 def test_bracketed_job_wide_secret_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_workflow_posture_check.py
+++ b/tests/test_workflow_posture_check.py
@@ -341,9 +341,7 @@ def test_bracketed_job_wide_secret_is_rejected(tmp_path: Path) -> None:
 def test_whole_context_job_wide_secret_is_rejected(tmp_path: Path) -> None:
     body = GOOD_READ_ONLY.replace(
         "runs-on: ubuntu-latest",
-        "env:\n"
-        "      ALL_SECRETS: ${{ toJSON(secrets) }}\n"
-        "    runs-on: ubuntu-latest",
+        "env:\n" "      ALL_SECRETS: ${{ toJSON(secrets) }}\n" "    runs-on: ubuntu-latest",
     )
     _make_workflow(tmp_path, "ci.yml", body)
     _make_map(tmp_path, "# map\n")

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -7,9 +7,8 @@ that each workflow keeps the CI/CD membrane contract:
 - a top-level ``permissions`` block is declared;
 - a top-level ``concurrency`` block is declared;
 - ``concurrency.cancel-in-progress`` is ``true``;
-- any top-level or job-level permission broader than ``contents: read`` is documented as an
-  exception in ``docs/ci/WORKFLOW_MAP.md`` (the workflow filename must be
-  mentioned there);
+- any top-level or job-level permission broader than ``contents: read`` exactly
+  matches a machine-readable exception in ``docs/ci/WORKFLOW_MAP.md``;
 - external actions are pinned to full 40-character commit SHAs;
 - executable ``run``/``github-script`` bodies do not interpolate Actions
   expressions directly;
@@ -42,18 +41,29 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 WORKFLOW_MAP_REL = "docs/ci/WORKFLOW_MAP.md"
 FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
-SECRET_EXPRESSION = re.compile(r"\$\{\{\s*secrets(?:\.|\[)")
+DOCKER_ACTION_DIGEST = re.compile(r"^docker://[^@\s]+@sha256:[0-9a-fA-F]{64}$")
+SECRET_EXPRESSION = re.compile(r"\$\{\{[^}]*\bsecrets\b")
+PERMISSION_CONTRACT = re.compile(
+    r"<!-- workflow-posture-permissions\n(?P<yaml>.*?)\n-->",
+    re.DOTALL,
+)
 
 
-def iter_mappings(value: Any):
-    """Yield every mapping nested in a workflow document."""
-    if isinstance(value, dict):
-        yield value
-        for item in value.values():
-            yield from iter_mappings(item)
-    elif isinstance(value, list):
-        for item in value:
-            yield from iter_mappings(item)
+def iter_action_nodes(doc: dict[str, Any]):
+    """Yield only reusable-job and step mappings where ``uses`` is meaningful."""
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        if "uses" in job:
+            yield job
+        steps = job.get("steps")
+        if isinstance(steps, list):
+            for step in steps:
+                if isinstance(step, dict):
+                    yield step
 
 
 def has_direct_expression(script: object) -> bool:
@@ -62,10 +72,58 @@ def has_direct_expression(script: object) -> bool:
 
 
 def masks_shell_failure(script: object) -> bool:
-    """Return whether a shell body has a line ending in ``|| true``."""
+    """Return whether a shell body masks a failure with ``|| true``."""
     if not isinstance(script, str):
         return False
-    return any(re.search(r"\|\|\s*true\s*(?:#.*)?$", line) for line in script.splitlines())
+    return any(
+        re.search(r"\|\|\s*true(?:\s*(?:[;&|]|#)|\s*$)", line)
+        for line in script.splitlines()
+    )
+
+
+def load_permission_contract(workflow_map_text: str) -> dict[str, Any]:
+    """Load exact broad-permission exceptions from the workflow map."""
+    match = PERMISSION_CONTRACT.search(workflow_map_text)
+    if match is None:
+        return {}
+    try:
+        contract = yaml.safe_load(match.group("yaml"))
+    except yaml.YAMLError:
+        return {}
+    return contract if isinstance(contract, dict) else {}
+
+
+def permission_is_documented(
+    contract: dict[str, Any],
+    workflow_name: str,
+    permissions: Any,
+    *,
+    job_name: str | None = None,
+) -> bool:
+    """Return whether a broad permission mapping matches its exact exception."""
+    workflow = contract.get(workflow_name)
+    if not isinstance(workflow, dict):
+        return False
+    if job_name is None:
+        documented = workflow.get("workflow")
+    else:
+        jobs = workflow.get("jobs")
+        documented = jobs.get(job_name) if isinstance(jobs, dict) else None
+    return documented == permissions
+
+
+def action_reference_problem(uses: str) -> str | None:
+    """Return a posture problem for a mutable external action reference."""
+    if uses.startswith("./"):
+        return None
+    if uses.startswith("docker://"):
+        if DOCKER_ACTION_DIGEST.fullmatch(uses):
+            return None
+        return f"Docker action is not pinned to an immutable sha256 digest: {uses}"
+    _, separator, ref = uses.rpartition("@")
+    if not separator or not FULL_COMMIT_SHA.fullmatch(ref):
+        return f"external action is not pinned to a full commit SHA: {uses}"
+    return None
 
 
 def find_workflows(root: Path) -> list[Path]:
@@ -97,7 +155,7 @@ def is_minimal_permissions(permissions: Any) -> bool:
     return False
 
 
-def check_workflow(path: Path, workflow_map_text: str) -> list[str]:
+def check_workflow(path: Path, permission_contract: dict[str, Any]) -> list[str]:
     """Return a list of posture problems for a single workflow file."""
     problems: list[str] = []
     try:
@@ -112,10 +170,14 @@ def check_workflow(path: Path, workflow_map_text: str) -> list[str]:
     if "permissions" not in doc:
         problems.append("missing top-level 'permissions'")
     elif not is_minimal_permissions(doc["permissions"]):
-        if path.name not in workflow_map_text:
+        if not permission_is_documented(
+            permission_contract,
+            path.name,
+            doc["permissions"],
+        ):
             problems.append(
-                "permissions broader than 'contents: read' but not documented "
-                f"in {WORKFLOW_MAP_REL}"
+                "permissions broader than 'contents: read' are not documented "
+                f"or do not exactly match the exception in {WORKFLOW_MAP_REL}"
             )
 
     jobs = doc.get("jobs")
@@ -125,10 +187,16 @@ def check_workflow(path: Path, workflow_map_text: str) -> list[str]:
                 continue
             job_permissions = job.get("permissions")
             if job_permissions is not None and not is_minimal_permissions(job_permissions):
-                if path.name not in workflow_map_text:
+                if not permission_is_documented(
+                    permission_contract,
+                    path.name,
+                    job_permissions,
+                    job_name=str(job_name),
+                ):
                     problems.append(
                         f"job {job_name!r} has permissions broader than "
-                        f"'contents: read' but is not documented in {WORKFLOW_MAP_REL}"
+                        f"'contents: read' that do not exactly match the exception "
+                        f"in {WORKFLOW_MAP_REL}"
                     )
             if job.get("secrets") == "inherit":
                 problems.append(
@@ -144,12 +212,12 @@ def check_workflow(path: Path, workflow_map_text: str) -> list[str]:
                     "scope it to the consuming step"
                 )
 
-    for item in iter_mappings(doc):
+    for item in iter_action_nodes(doc):
         uses = item.get("uses")
-        if isinstance(uses, str) and not uses.startswith(("./", "docker://")):
-            _, separator, ref = uses.rpartition("@")
-            if not separator or not FULL_COMMIT_SHA.fullmatch(ref):
-                problems.append(f"external action is not pinned to a full commit SHA: {uses}")
+        if isinstance(uses, str):
+            problem = action_reference_problem(uses)
+            if problem is not None:
+                problems.append(problem)
 
         run = item.get("run")
         if has_direct_expression(run):
@@ -188,6 +256,7 @@ def build_results(root: Path) -> tuple[bool, list[str]]:
     workflows = find_workflows(root)
     map_path = root / WORKFLOW_MAP_REL
     workflow_map_text = map_path.read_text(encoding="utf-8") if map_path.exists() else ""
+    permission_contract = load_permission_contract(workflow_map_text)
 
     lines: list[str] = ["# Workflow Posture Check", ""]
     if not workflows:
@@ -196,7 +265,7 @@ def build_results(root: Path) -> tuple[bool, list[str]]:
 
     all_ok = True
     for wf in workflows:
-        problems = check_workflow(wf, workflow_map_text)
+        problems = check_workflow(wf, permission_contract)
         rel = wf.relative_to(root) if wf.is_relative_to(root) else wf
         if problems:
             all_ok = False

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -8,13 +8,14 @@ that each workflow keeps the CI/CD membrane contract:
 - a top-level ``concurrency`` block is declared;
 - ``concurrency.cancel-in-progress`` is ``true``;
 - any top-level or job-level permission broader than ``contents: read`` exactly
-  matches a machine-readable exception in ``docs/ci/WORKFLOW_MAP.md``;
-- external actions are pinned to full 40-character commit SHAs;
+  matches a current machine-readable exception in ``docs/ci/WORKFLOW_MAP.md``;
+- external actions are pinned to full 40-character commit SHAs, including
+  actions reached through checked-in composite wrappers;
 - executable ``run``/``github-script`` bodies do not interpolate Actions
   expressions directly;
 - shell commands do not hide failure with ``|| true``;
 - reusable calls do not use ``secrets: inherit`` and secrets are not exposed
-  through job-wide environment variables.
+  through workflow-wide or job-wide environment variables.
 
 The check is read-only, deterministic, and needs no network access. It
 prints a PASS/FAIL summary and exits non-zero on drift.
@@ -42,7 +43,10 @@ WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 WORKFLOW_MAP_REL = "docs/ci/WORKFLOW_MAP.md"
 FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
 DOCKER_ACTION_DIGEST = re.compile(r"^docker://[^@\s]+@sha256:[0-9a-fA-F]{64}$")
-SECRET_EXPRESSION = re.compile(r"\$\{\{[^}]*\bsecrets\b")
+CONTAINER_IMAGE_DIGEST = re.compile(r"^[^@\s]+@sha256:[0-9a-fA-F]{64}$")
+NAMED_SECRET_REFERENCE = re.compile(
+    r"""^\$\{\{\s*secrets(?:\.[A-Za-z0-9_]+|\[['"][A-Za-z0-9_]+['"]\])\s*\}\}$"""
+)
 PERMISSION_CONTRACT = re.compile(
     r"<!-- workflow-posture-permissions\n(?P<yaml>.*?)\n-->",
     re.DOTALL,
@@ -50,7 +54,7 @@ PERMISSION_CONTRACT = re.compile(
 
 
 def iter_action_nodes(doc: dict[str, Any]):
-    """Yield only reusable-job and step mappings where ``uses`` is meaningful."""
+    """Yield reusable-job and step mappings plus whether each is a step."""
     jobs = doc.get("jobs")
     if not isinstance(jobs, dict):
         return
@@ -58,12 +62,12 @@ def iter_action_nodes(doc: dict[str, Any]):
         if not isinstance(job, dict):
             continue
         if "uses" in job:
-            yield job
+            yield job, False
         steps = job.get("steps")
         if isinstance(steps, list):
             for step in steps:
                 if isinstance(step, dict):
-                    yield step
+                    yield step, True
 
 
 def has_direct_expression(script: object) -> bool:
@@ -75,9 +79,64 @@ def masks_shell_failure(script: object) -> bool:
     """Return whether a shell body masks a failure with ``|| true``."""
     if not isinstance(script, str):
         return False
-    return any(
-        re.search(r"\|\|\s*true(?:\s*(?:[;&|]|#)|\s*$)", line) for line in script.splitlines()
+    return bool(
+        re.search(
+            r"\|\|(?:[ \t]|\\\r?\n|\r?\n)*true" r"(?=[ \t]*(?:[;&|)]|#|\r?$))",
+            script,
+            re.MULTILINE,
+        )
     )
+
+
+def env_contains_secret(env: object) -> bool:
+    """Return whether an environment mapping references the secrets context."""
+    return isinstance(env, dict) and any(
+        isinstance(value, str) and has_actions_context_reference(value, "secrets")
+        for value in env.values()
+    )
+
+
+def has_actions_context_reference(value: str, context: str) -> bool:
+    """Find an unquoted context token inside an Actions expression.
+
+    The scanner deliberately does not use ``[^}]*`` as an expression boundary:
+    braces are valid inside quoted format strings such as ``'{0}'``.
+    """
+    lowered_value = value.lower()
+    lowered_context = context.lower()
+    cursor = 0
+    while (expression_start := value.find("${{", cursor)) != -1:
+        index = expression_start + 3
+        quote: str | None = None
+        while index < len(value):
+            char = value[index]
+            if quote is not None:
+                if char == quote:
+                    if index + 1 < len(value) and value[index + 1] == quote:
+                        index += 2
+                        continue
+                    quote = None
+                index += 1
+                continue
+            if char in {"'", '"'}:
+                quote = char
+                index += 1
+                continue
+            if value.startswith("}}", index):
+                cursor = index + 2
+                break
+            if lowered_value.startswith(lowered_context, index):
+                before = value[index - 1] if index > expression_start + 3 else ""
+                after_index = index + len(lowered_context)
+                after = value[after_index] if after_index < len(value) else ""
+                if not (before.isalnum() or before == "_") and not (
+                    after.isalnum() or after == "_"
+                ):
+                    return True
+            index += 1
+        else:
+            return False
+    return False
 
 
 def load_permission_contract(workflow_map_text: str) -> dict[str, Any]:
@@ -125,6 +184,116 @@ def action_reference_problem(uses: str) -> str | None:
     return None
 
 
+def container_image_problem(image: object) -> str | None:
+    """Return a posture problem for a mutable job or service image."""
+    if not isinstance(image, str):
+        return "container image is missing or is not a string"
+    if CONTAINER_IMAGE_DIGEST.fullmatch(image):
+        return None
+    return f"container image is not pinned to an immutable sha256 digest: {image}"
+
+
+def is_github_script_action(uses: object) -> bool:
+    """Return whether a step invokes the official github-script action."""
+    return isinstance(uses, str) and uses.lower().startswith("actions/github-script@")
+
+
+def inspect_action_item(
+    item: dict[str, Any],
+    *,
+    root: Path,
+    problems: list[str],
+    seen_local_actions: set[Path],
+    is_step: bool,
+    context: str = "",
+) -> None:
+    """Inspect one reusable job or action step and recurse into local composites."""
+
+    def add_problem(problem: str) -> None:
+        problems.append(f"{context}: {problem}" if context else problem)
+
+    uses = item.get("uses")
+    if isinstance(uses, str):
+        problem = action_reference_problem(uses)
+        if problem is not None:
+            add_problem(problem)
+
+    run = item.get("run")
+    if has_direct_expression(run):
+        add_problem(
+            "executable 'run' body contains a direct Actions expression; "
+            "pass it through a step env variable"
+        )
+    if masks_shell_failure(run):
+        add_problem(
+            "shell command masks failure with '|| true'; use an explicit "
+            "non-blocking step or handle the exit code"
+        )
+
+    with_args = item.get("with")
+    script = with_args.get("script") if isinstance(with_args, dict) else None
+    if is_github_script_action(uses) and has_direct_expression(script):
+        add_problem(
+            "github-script body contains a direct Actions expression; "
+            "pass it through a step env variable"
+        )
+
+    if not (is_step and isinstance(uses, str) and uses.startswith("./")):
+        return
+
+    repo_root = root.resolve()
+    action_dir = (repo_root / uses[2:]).resolve()
+    if not action_dir.is_relative_to(repo_root):
+        add_problem(f"local action path escapes the repository: {uses}")
+        return
+
+    manifest = next(
+        (
+            candidate
+            for candidate in (action_dir / "action.yml", action_dir / "action.yaml")
+            if candidate.is_file()
+        ),
+        None,
+    )
+    if manifest is None:
+        add_problem(f"local action manifest not found: {uses}")
+        return
+    if manifest in seen_local_actions:
+        return
+    seen_local_actions.add(manifest)
+
+    try:
+        action_doc = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        add_problem(f"local action manifest has invalid YAML ({manifest}): {exc}")
+        return
+    if not isinstance(action_doc, dict):
+        add_problem(f"local action manifest is not a mapping: {manifest}")
+        return
+
+    runs = action_doc.get("runs")
+    if not isinstance(runs, dict) or str(runs.get("using")).lower() != "composite":
+        return
+    steps = runs.get("steps")
+    if not isinstance(steps, list):
+        add_problem(f"composite action has no valid steps list: {manifest}")
+        return
+
+    manifest_context = str(manifest.relative_to(repo_root))
+    for step in steps:
+        if not isinstance(step, dict):
+            problems.append(f"{manifest_context}: composite step is not a mapping")
+            continue
+        inspect_action_item(
+            step,
+            root=repo_root,
+            problems=problems,
+            seen_local_actions=seen_local_actions,
+            is_step=True,
+            context=manifest_context,
+        )
+
+
 def find_workflows(root: Path) -> list[Path]:
     """Return workflow files under ``.github/workflows`` sorted by name."""
     wf_dir = root / ".github" / "workflows"
@@ -154,6 +323,52 @@ def is_minimal_permissions(permissions: Any) -> bool:
     return False
 
 
+def stale_permission_exception_problems(
+    workflows: list[Path],
+    permission_contract: dict[str, Any],
+) -> list[str]:
+    """Return exceptions that no longer match a current broad permission."""
+    problems: list[str] = []
+    workflow_paths = {path.name: path for path in workflows}
+
+    for workflow_name, exception in permission_contract.items():
+        path = workflow_paths.get(str(workflow_name))
+        if path is None:
+            problems.append(f"stale permission exception names missing workflow {workflow_name!r}")
+            continue
+        if not isinstance(exception, dict):
+            problems.append(f"permission exception for {workflow_name!r} is not a mapping")
+            continue
+        try:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except yaml.YAMLError:
+            continue
+        if not isinstance(doc, dict):
+            continue
+
+        if "workflow" in exception:
+            actual = doc.get("permissions")
+            if actual != exception["workflow"] or is_minimal_permissions(actual):
+                problems.append(f"stale permission exception for {workflow_name!r} workflow scope")
+
+        jobs_exception = exception.get("jobs")
+        if jobs_exception is None:
+            continue
+        if not isinstance(jobs_exception, dict):
+            problems.append(f"permission job exceptions for {workflow_name!r} are not a mapping")
+            continue
+        jobs = doc.get("jobs")
+        for job_name, documented in jobs_exception.items():
+            job = jobs.get(job_name) if isinstance(jobs, dict) else None
+            actual = job.get("permissions") if isinstance(job, dict) else None
+            if actual != documented or is_minimal_permissions(actual):
+                problems.append(
+                    f"stale permission exception for {workflow_name!r} " f"job {job_name!r}"
+                )
+
+    return problems
+
+
 def check_workflow(path: Path, permission_contract: dict[str, Any]) -> list[str]:
     """Return a list of posture problems for a single workflow file."""
     problems: list[str] = []
@@ -164,6 +379,11 @@ def check_workflow(path: Path, permission_contract: dict[str, Any]) -> list[str]
 
     if not isinstance(doc, dict):
         return ["top-level YAML is not a mapping"]
+
+    if env_contains_secret(doc.get("env")):
+        problems.append(
+            "workflow exposes a secret through workflow-wide env; " "scope it to the consuming step"
+        )
 
     # permissions
     if "permissions" not in doc:
@@ -197,46 +417,53 @@ def check_workflow(path: Path, permission_contract: dict[str, Any]) -> list[str]
                         f"'contents: read' that do not exactly match the exception "
                         f"in {WORKFLOW_MAP_REL}"
                     )
-            if job.get("secrets") == "inherit":
+            job_secrets = job.get("secrets")
+            if job_secrets == "inherit":
                 problems.append(
                     f"job {job_name!r} uses 'secrets: inherit'; pass only named secrets"
                 )
-            job_env = job.get("env")
-            if isinstance(job_env, dict) and any(
-                isinstance(value, str) and SECRET_EXPRESSION.search(value)
-                for value in job_env.values()
-            ):
+            elif isinstance(job_secrets, dict):
+                for secret_name, value in job_secrets.items():
+                    if not isinstance(value, str) or not NAMED_SECRET_REFERENCE.fullmatch(value):
+                        problems.append(
+                            f"job {job_name!r} secret {secret_name!r} is not an "
+                            "explicit named secrets reference"
+                        )
+            elif job_secrets is not None:
+                problems.append(
+                    f"job {job_name!r} has an invalid secrets mapping; " "pass only named secrets"
+                )
+            if env_contains_secret(job.get("env")):
                 problems.append(
                     f"job {job_name!r} exposes a secret through job-wide env; "
                     "scope it to the consuming step"
                 )
 
-    for item in iter_action_nodes(doc):
-        uses = item.get("uses")
-        if isinstance(uses, str):
-            problem = action_reference_problem(uses)
-            if problem is not None:
-                problems.append(problem)
+            container = job.get("container")
+            if container is not None:
+                image = container.get("image") if isinstance(container, dict) else container
+                problem = container_image_problem(image)
+                if problem is not None:
+                    problems.append(f"job {job_name!r} {problem}")
 
-        run = item.get("run")
-        if has_direct_expression(run):
-            problems.append(
-                "executable 'run' body contains a direct Actions expression; "
-                "pass it through a step env variable"
-            )
-        if masks_shell_failure(run):
-            problems.append(
-                "shell command masks failure with '|| true'; use an explicit "
-                "non-blocking step or handle the exit code"
-            )
+            services = job.get("services")
+            if isinstance(services, dict):
+                for service_name, service in services.items():
+                    image = service.get("image") if isinstance(service, dict) else None
+                    problem = container_image_problem(image)
+                    if problem is not None:
+                        problems.append(f"job {job_name!r} service {service_name!r} {problem}")
 
-        with_args = item.get("with")
-        script = with_args.get("script") if isinstance(with_args, dict) else None
-        if has_direct_expression(script):
-            problems.append(
-                "github-script body contains a direct Actions expression; "
-                "pass it through a step env variable"
-            )
+    root = path.parents[2]
+    seen_local_actions: set[Path] = set()
+    for item, is_step in iter_action_nodes(doc):
+        inspect_action_item(
+            item,
+            root=root,
+            problems=problems,
+            seen_local_actions=seen_local_actions,
+            is_step=is_step,
+        )
 
     # concurrency
     concurrency = doc.get("concurrency")
@@ -263,6 +490,16 @@ def build_results(root: Path) -> tuple[bool, list[str]]:
         return True, lines
 
     all_ok = True
+    contract_problems = stale_permission_exception_problems(
+        workflows,
+        permission_contract,
+    )
+    if contract_problems:
+        all_ok = False
+        lines.append(f"FAIL {WORKFLOW_MAP_REL}")
+        for problem in contract_problems:
+            lines.append(f"  - {problem}")
+
     for wf in workflows:
         problems = check_workflow(wf, permission_contract)
         rel = wf.relative_to(root) if wf.is_relative_to(root) else wf

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -7,9 +7,15 @@ that each workflow keeps the CI/CD membrane contract:
 - a top-level ``permissions`` block is declared;
 - a top-level ``concurrency`` block is declared;
 - ``concurrency.cancel-in-progress`` is ``true``;
-- any permission broader than ``contents: read`` is documented as an
+- any top-level or job-level permission broader than ``contents: read`` is documented as an
   exception in ``docs/ci/WORKFLOW_MAP.md`` (the workflow filename must be
-  mentioned there).
+  mentioned there);
+- external actions are pinned to full 40-character commit SHAs;
+- executable ``run``/``github-script`` bodies do not interpolate Actions
+  expressions directly;
+- shell commands do not hide failure with ``|| true``;
+- reusable calls do not use ``secrets: inherit`` and secrets are not exposed
+  through job-wide environment variables.
 
 The check is read-only, deterministic, and needs no network access. It
 prints a PASS/FAIL summary and exits non-zero on drift.
@@ -21,6 +27,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -34,6 +41,31 @@ except ImportError:  # pragma: no cover
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 WORKFLOW_MAP_REL = "docs/ci/WORKFLOW_MAP.md"
+FULL_COMMIT_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
+SECRET_EXPRESSION = re.compile(r"\$\{\{\s*secrets(?:\.|\[)")
+
+
+def iter_mappings(value: Any):
+    """Yield every mapping nested in a workflow document."""
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from iter_mappings(item)
+    elif isinstance(value, list):
+        for item in value:
+            yield from iter_mappings(item)
+
+
+def has_direct_expression(script: object) -> bool:
+    """Return whether executable code directly contains an Actions expression."""
+    return isinstance(script, str) and "${{" in script
+
+
+def masks_shell_failure(script: object) -> bool:
+    """Return whether a shell body has a line ending in ``|| true``."""
+    if not isinstance(script, str):
+        return False
+    return any(re.search(r"\|\|\s*true\s*(?:#.*)?$", line) for line in script.splitlines())
 
 
 def find_workflows(root: Path) -> list[Path]:
@@ -84,6 +116,59 @@ def check_workflow(path: Path, workflow_map_text: str) -> list[str]:
             problems.append(
                 "permissions broader than 'contents: read' but not documented "
                 f"in {WORKFLOW_MAP_REL}"
+            )
+
+    jobs = doc.get("jobs")
+    if isinstance(jobs, dict):
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            job_permissions = job.get("permissions")
+            if job_permissions is not None and not is_minimal_permissions(job_permissions):
+                if path.name not in workflow_map_text:
+                    problems.append(
+                        f"job {job_name!r} has permissions broader than "
+                        f"'contents: read' but is not documented in {WORKFLOW_MAP_REL}"
+                    )
+            if job.get("secrets") == "inherit":
+                problems.append(
+                    f"job {job_name!r} uses 'secrets: inherit'; pass only named secrets"
+                )
+            job_env = job.get("env")
+            if isinstance(job_env, dict) and any(
+                isinstance(value, str) and SECRET_EXPRESSION.search(value)
+                for value in job_env.values()
+            ):
+                problems.append(
+                    f"job {job_name!r} exposes a secret through job-wide env; "
+                    "scope it to the consuming step"
+                )
+
+    for item in iter_mappings(doc):
+        uses = item.get("uses")
+        if isinstance(uses, str) and not uses.startswith(("./", "docker://")):
+            _, separator, ref = uses.rpartition("@")
+            if not separator or not FULL_COMMIT_SHA.fullmatch(ref):
+                problems.append(f"external action is not pinned to a full commit SHA: {uses}")
+
+        run = item.get("run")
+        if has_direct_expression(run):
+            problems.append(
+                "executable 'run' body contains a direct Actions expression; "
+                "pass it through a step env variable"
+            )
+        if masks_shell_failure(run):
+            problems.append(
+                "shell command masks failure with '|| true'; use an explicit "
+                "non-blocking step or handle the exit code"
+            )
+
+        with_args = item.get("with")
+        script = with_args.get("script") if isinstance(with_args, dict) else None
+        if has_direct_expression(script):
+            problems.append(
+                "github-script body contains a direct Actions expression; "
+                "pass it through a step env variable"
             )
 
     # concurrency

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -76,8 +76,7 @@ def masks_shell_failure(script: object) -> bool:
     if not isinstance(script, str):
         return False
     return any(
-        re.search(r"\|\|\s*true(?:\s*(?:[;&|]|#)|\s*$)", line)
-        for line in script.splitlines()
+        re.search(r"\|\|\s*true(?:\s*(?:[;&|]|#)|\s*$)", line) for line in script.splitlines()
     )
 
 

--- a/tools/workflow_posture_check.py
+++ b/tools/workflow_posture_check.py
@@ -108,7 +108,7 @@ def permission_is_documented(
     else:
         jobs = workflow.get("jobs")
         documented = jobs.get(job_name) if isinstance(jobs, dict) else None
-    return documented == permissions
+    return bool(documented == permissions)
 
 
 def action_reference_problem(uses: str) -> str | None:


### PR DESCRIPTION
## Intent

Harden the repository's CI/release supply-chain boundary with fail-closed, regression-tested controls.

## Scope

- pin the remaining mutable GitHub Action reference to a full commit SHA
- reduce release permissions to job scope and remove the swallowed editable-install failure
- pass release data through environment variables instead of interpolating it into executable JavaScript
- generate a validated CycloneDX 1.6 SBOM from the resolved Python environment and fail if the artifact is absent
- keep the all-severity pnpm report explicitly non-blocking while preserving the blocking high+ gate
- prevent PR executions from receiving the DeepJump HMAC key; scope the key to the two consuming steps and fail trusted unsigned runs
- enforce exact, current permission exceptions in both directions so stale grants fail
- scan checked-in composite actions recursively for mutable external actions and unsafe executable bodies
- inspect only real action nodes; restrict `script`-body injection checks to the official `actions/github-script` action
- reject workflow/job-wide secret exposure, whole-context reusable-call mappings, mutable Docker/job/service images, and shell failure masks across separators, subshells, or line breaks
- parse complete Actions expressions so quoted braces cannot hide a `secrets` reference
- update the workflow map to document the enforced contract

FOKUS: CI supply-chain hardening

## Test Plan

- [x] Full Python suite passes — 674 tests (104 existing deprecation warnings)
- [x] 36 focused workflow-posture regression tests pass
- [x] Ruff and Black pass on the changed Python files
- [x] Mypy passes across all 46 source files
- [x] Governance checks pass — all 14 workflows satisfy posture; 22 VOIDs are synchronized
- [x] All 10 GitHub workflow runs pass on head `847b25a7c8761c3e5851ab78bbbc89f0da394eb0`

## Risk

No application runtime or evidence-policy behavior changes. Trusted push/schedule/manual DeepJump runs now fail closed when `ENTA_HMAC_SECRET` is missing; pull-request runs remain unsigned by design and never receive that secret. SBOM output reflects the environment resolved during that run. Dependency ranges remain a separate reproducibility gap and are intentionally not changed here.

## Dependency state

The #329/#330 JavaScript advisory remediation is already integrated into `main`; this branch includes that updated tree. The blocking high-severity audit remains enforced and is no longer intentionally waiting on the dependency stack.