### PR TITLE
fix: harden Electron packaging dependencies

### DIFF
--- a/__tests__/unit/electron-packaging-glob-compat.test.js
+++ b/__tests__/unit/electron-packaging-glob-compat.test.js
@@ -1,4 +1,6 @@
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { pathToFileURL } = require('node:url');
 
 function resolveDependency(parentEntry, dependency) {
   return require.resolve(dependency, {
@@ -58,4 +60,37 @@ describe('Electron packaging glob compatibility', () => {
       expect(braceExpansion.expand).toBe(braceExpansion);
     }
   );
+
+  test('@electron/universal minimatch ESM link uses patched brace-expansion', () => {
+    const electronBuilder = require.resolve('electron-builder');
+    const appBuilderLib = resolveDependency(
+      electronBuilder,
+      'app-builder-lib'
+    );
+    const universal = resolveDependency(appBuilderLib, '@electron/universal');
+    const universalMinimatch = resolveDependency(universal, 'minimatch');
+    const universalMinimatchEsmEntry = path.resolve(
+      path.dirname(universalMinimatch),
+      '..',
+      '..',
+      'dist',
+      'esm',
+      'index.js'
+    );
+    const importScript = `
+      const { minimatch } = await import(${JSON.stringify(
+        pathToFileURL(universalMinimatchEsmEntry).href
+      )});
+      if (!minimatch('foo7.txt', 'foo{1..9}.txt')) process.exit(1);
+      if (!minimatch('app/main.ts', '**/*.{js,ts}')) process.exit(1);
+    `;
+    const result = spawnSync(
+      process.execPath,
+      ['--input-type=module', '--eval', importScript],
+      { encoding: 'utf8' }
+    );
+
+    expect(result.stderr).toBe('');
+    expect(result.status).toBe(0);
+  });
 });

--- a/__tests__/unit/electron-packaging-glob-compat.test.js
+++ b/__tests__/unit/electron-packaging-glob-compat.test.js
@@ -1,0 +1,61 @@
+const path = require('node:path');
+
+function resolveDependency(parentEntry, dependency) {
+  return require.resolve(dependency, {
+    paths: [path.dirname(parentEntry)],
+  });
+}
+
+function packagingMinimatchEntries() {
+  const electronBuilder = require.resolve('electron-builder');
+  const appBuilderLib = resolveDependency(electronBuilder, 'app-builder-lib');
+  const asar = resolveDependency(appBuilderLib, '@electron/asar');
+  const universal = resolveDependency(appBuilderLib, '@electron/universal');
+  const ejs = resolveDependency(appBuilderLib, 'ejs');
+  const jake = resolveDependency(ejs, 'jake');
+  const filelist = resolveDependency(jake, 'filelist');
+
+  return [
+    ['@electron/asar', resolveDependency(asar, 'minimatch')],
+    ['@electron/universal', resolveDependency(universal, 'minimatch')],
+    ['filelist', resolveDependency(filelist, 'minimatch')],
+    ['app-builder-lib', resolveDependency(appBuilderLib, 'minimatch')],
+  ];
+}
+
+const globCases = [
+  ['app/main.js', '**/*.js', true],
+  ['app/main.txt', '**/*.js', false],
+  ['app/main.ts', '**/*.{js,ts}', true],
+  ['dist/linux/app', 'dist/{linux,win}/**', true],
+  ['dist/mac/app', 'dist/{linux,win}/**', false],
+  ['resources/app.asar', 'resources/**/app.asar', true],
+  ['.hidden/config.json', '**/*.json', true],
+  ['foo7.txt', 'foo{1..9}.txt', true],
+];
+
+describe('Electron packaging glob compatibility', () => {
+  test.each(packagingMinimatchEntries())(
+    '%s accepts the security-fixed brace-expansion API',
+    (_consumer, minimatchEntry) => {
+      const minimatchModule = require(minimatchEntry);
+      const minimatch =
+        typeof minimatchModule === 'function'
+          ? minimatchModule
+          : minimatchModule.minimatch;
+
+      expect(typeof minimatch).toBe('function');
+      for (const [input, pattern, expected] of globCases) {
+        expect(minimatch(input, pattern, { dot: true })).toBe(expected);
+      }
+
+      const braceExpansionEntry = resolveDependency(
+        minimatchEntry,
+        'brace-expansion'
+      );
+      const braceExpansion = require(braceExpansionEntry);
+      expect(typeof braceExpansion).toBe('function');
+      expect(braceExpansion.expand).toBe(braceExpansion);
+    }
+  );
+});

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/commonjs/index.js b/dist/commonjs/index.js
+index be9df86be09c7655787a65c55ae6da01858894c3..09ab2a9d4a2c6736d3acf687bbddc9cee2197a35 100644
+--- a/dist/commonjs/index.js
++++ b/dist/commonjs/index.js
+@@ -260,4 +260,12 @@ function expand_(str, max, maxLength, isTop) {
+     }
+     return acc;
+ }
++// Keep the v1/v2 CommonJS callable shape while also exposing the v5 named
++// exports. This lets legacy minimatch majors consume the security-fixed v5
++// implementation without changing minimatch's public API.
++module.exports = Object.assign(expand, {
++    EXPANSION_MAX: exports.EXPANSION_MAX,
++    EXPANSION_MAX_LENGTH: exports.EXPANSION_MAX_LENGTH,
++    expand,
++});
+ //# sourceMappingURL=index.js.map

--- a/patches/brace-expansion@5.0.8.patch
+++ b/patches/brace-expansion@5.0.8.patch
@@ -15,3 +15,13 @@ index be9df86be09c7655787a65c55ae6da01858894c3..09ab2a9d4a2c6736d3acf687bbddc9ce
 +    expand,
 +});
  //# sourceMappingURL=index.js.map
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index 42f4b0fa512db73d65b3c20558f2f7e554fa25e2..37ea704ad74defc9c42b1661753ca903ab2a3366 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -255,4 +255,5 @@ function expand_(str, max, maxLength, isTop) {
+     }
+     return acc;
+ }
++export default expand;
+ //# sourceMappingURL=index.js.map

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,11 +8,26 @@ overrides:
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
   postcss@<8.5.10: '>=8.5.10'
   js-yaml@<=4.1.1: '>=4.2.0'
+  app-builder-lib@26.15.3>js-yaml: 5.2.2
+  '@istanbuljs/load-nyc-config@1.1.0>js-yaml': 5.2.2
+  '@eslint/eslintrc@3.3.5>js-yaml': 5.2.2
+  builder-util@26.15.3>js-yaml: 5.2.2
+  dmg-builder@26.15.3>js-yaml: 5.2.2
   undici@<6.27.0: ^6.27.0
   brace-expansion@<1.1.16: ^1.1.16
   brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  minimatch@3.1.5>brace-expansion: 5.0.8
+  minimatch@5.1.9>brace-expansion: 5.0.8
+  minimatch@9.0.9>brace-expansion: 5.0.8
+  minimatch@10.2.5>brace-expansion: 5.0.8
   fast-uri@>=3.0.0 <=3.1.3: 3.1.4
   sharp@<0.35.0: 0.35.3
+  tar@<=7.5.20: 7.5.22
+
+patchedDependencies:
+  brace-expansion@5.0.8:
+    hash: b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b
+    path: patches/brace-expansion@5.0.8.patch
 
 importers:
 
@@ -1422,9 +1437,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1444,15 +1456,9 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1581,9 +1587,6 @@ packages:
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -2591,8 +2594,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -3504,8 +3507,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   temp-file@3.4.0:
@@ -4178,7 +4181,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4334,7 +4337,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -5109,7 +5112,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -5118,7 +5121,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.19
+      tar: 7.5.22
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       unzipper: 0.12.5
@@ -5286,8 +5289,6 @@ snapshots:
       babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -5299,16 +5300,7 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b):
     dependencies:
       balanced-match: 4.0.4
 
@@ -5347,7 +5339,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -5444,8 +5436,6 @@ snapshots:
     optional: true
 
   compare-version@0.1.2: {}
-
-  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5547,7 +5537,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -6853,7 +6843,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -7066,19 +7056,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
 
   minimist@1.2.8: {}
 
@@ -7148,7 +7138,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.8.5
-      tar: 7.5.19
+      tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 6.27.0
       which: 6.0.1
@@ -7797,7 +7787,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
 
 patchedDependencies:
   brace-expansion@5.0.8:
-    hash: b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b
+    hash: 7347bf8e7802be4a71c0da9c96727d77a22b3760b6af3d224721a600468d969b
     path: patches/brace-expansion@5.0.8.patch
 
 importers:
@@ -5300,7 +5300,7 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b):
+  brace-expansion@5.0.8(patch_hash=7347bf8e7802be4a71c0da9c96727d77a22b3760b6af3d224721a600468d969b):
     dependencies:
       balanced-match: 4.0.4
 
@@ -7056,19 +7056,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
+      brace-expansion: 5.0.8(patch_hash=7347bf8e7802be4a71c0da9c96727d77a22b3760b6af3d224721a600468d969b)
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
+      brace-expansion: 5.0.8(patch_hash=7347bf8e7802be4a71c0da9c96727d77a22b3760b6af3d224721a600468d969b)
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
+      brace-expansion: 5.0.8(patch_hash=7347bf8e7802be4a71c0da9c96727d77a22b3760b6af3d224721a600468d969b)
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8(patch_hash=b85cf360493d164449559fd672b1cf279270ff172291b1071f1d8b17dd64ea4b)
+      brace-expansion: 5.0.8(patch_hash=7347bf8e7802be4a71c0da9c96727d77a22b3760b6af3d224721a600468d969b)
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,24 @@ overrides:
   "form-data@>=4.0.0 <4.0.6": ">=4.0.6"
   "postcss@<8.5.10": ">=8.5.10"
   "js-yaml@<=4.1.1": ">=4.2.0"
+  "app-builder-lib@26.15.3>js-yaml": "5.2.2"
+  "@istanbuljs/load-nyc-config@1.1.0>js-yaml": "5.2.2"
+  "@eslint/eslintrc@3.3.5>js-yaml": "5.2.2"
+  "builder-util@26.15.3>js-yaml": "5.2.2"
+  "dmg-builder@26.15.3>js-yaml": "5.2.2"
   "undici@<6.27.0": "^6.27.0"
   "brace-expansion@<1.1.16": "^1.1.16"
   "brace-expansion@>=2.0.0 <2.1.2": "^2.1.2"
+  "minimatch@3.1.5>brace-expansion": "5.0.8"
+  "minimatch@5.1.9>brace-expansion": "5.0.8"
+  "minimatch@9.0.9>brace-expansion": "5.0.8"
+  "minimatch@10.2.5>brace-expansion": "5.0.8"
   "fast-uri@>=3.0.0 <=3.1.3": "3.1.4"
   "sharp@<0.35.0": "0.35.3"
+  "tar@<=7.5.20": "7.5.22"
+
+# brace-expansion v5 drops the callable CommonJS shape expected by the older
+# minimatch majors in electron-builder. Keep the named v5 API and restore that
+# legacy shape; the packaging glob regression test covers all four consumers.
+patchedDependencies:
+  brace-expansion@5.0.8: patches/brace-expansion@5.0.8.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,8 +28,9 @@ overrides:
   "sharp@<0.35.0": "0.35.3"
   "tar@<=7.5.20": "7.5.22"
 
-# brace-expansion v5 drops the callable CommonJS shape expected by the older
-# minimatch majors in electron-builder. Keep the named v5 API and restore that
-# legacy shape; the packaging glob regression test covers all four consumers.
+# brace-expansion v5 drops the callable CommonJS and default ESM shapes expected
+# by older minimatch majors in electron-builder. Keep the named v5 API and
+# restore both legacy shapes; the packaging glob regression test covers the
+# CommonJS consumers and @electron/universal's published ESM entry.
 patchedDependencies:
   brace-expansion@5.0.8: patches/brace-expansion@5.0.8.patch


### PR DESCRIPTION
## Intent

Eliminate the remaining Electron/tooling dependency advisories without upgrading legacy `minimatch` consumers across incompatible majors. This PR is intentionally stacked on #329 so its diff contains only the Electron/tooling remediation while CI evaluates the complete zero-advisory tree.

## Scope

- Path-specific `js-yaml@5.2.2` overrides for the five reachable consumers
- `tar@7.5.22` security floor
- `brace-expansion@5.0.8` for the four resolved `minimatch` majors used by packaging/tooling
- Small pnpm compatibility patch that preserves the legacy callable CommonJS shape and ESM default export while retaining the v5 named API
- Regression tests that resolve and exercise all four real Electron packaging consumers plus the `@electron/universal` Minimatch 9 ESM link
- Deterministic pnpm 10.33.0 lockfile refresh

FOKUS: Harden Electron dependencies

## Test Plan

- [x] Unit tests pass
- [x] Manual testing completed
- [ ] CI checks pass on the follow-up head

Local evidence on the combined #329 + this branch:
- Frozen offline install succeeds with pnpm 10.33.0
- `pnpm audit --audit-level=high`: **No known vulnerabilities found**
- Root Jest: 50/50 passed, including all four packaging consumers and the `@electron/universal` ESM dependency path
- UI tests: 23/23 passed
- Core verification: 452/452 pytest cases passed (104 existing deprecation warnings)
- Turbo typecheck, lint, and Next 16.2.11 production build: 4/4 tasks passed
- Governance: 14 workflows pass posture checks; 22 VOIDs in sync
- Real `electron-builder --linux dir --publish never` packaging succeeds and produces `dist/linux-unpacked/resources/app.asar` (325 MB unpacked tree)

## Risk

The nontrivial surface is the CommonJS compatibility shim for `brace-expansion@5.0.8`. A blind override was explicitly rejected after reproducing `TypeError: expand is not a function` in `minimatch` 3/5/9. The checked-in patch restores the removed callable CommonJS shape and the legacy ESM default while `minimatch` 10 continues to use the named `expand` export. Regression tests cover the actual `@electron/asar`, `@electron/universal`, `filelist`, and `app-builder-lib` dependency paths, and a real Linux packaging run passed.

Stack order: review this PR against `codex/remediate-js-high-advisories`; merge it into that branch first, then merge #329 to `main`.