### PR TITLE
docs: bound security and resonance claims

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <!-- Content-Security-Policy: restrict script origins to self + the two pinned
        CDNs (see SRI hashes on the <script> tags below), forbid plugins/base-uri
-       and block remote connections. Combined with the hardened Electron
-       webPreferences (nodeIntegration:false, contextIsolation:true,
-       sandbox:true) this closes the remote-code-execution surface even if a
-       CDN were compromised. -->
+       and limit remote connections. Together with Electron isolation settings,
+       this reduces exposure but does not prove RCE closure: 'unsafe-inline'
+       remains enabled and every allowed script origin stays in the trust
+       boundary. -->
   <meta http-equiv="Content-Security-Policy"
         content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://unpkg.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'">
   <title>Fraktale Explorer mit Chaos-Klang-Turing-Maschine</title>
@@ -1247,5 +1247,4 @@
   </script>
 </body>
 </html>
-
 

--- a/REPOSITORY_ESSENZ_ANALYSE.md
+++ b/REPOSITORY_ESSENZ_ANALYSE.md
@@ -6,6 +6,13 @@
 **Commit-Basis:** 6ec289b (Bio Spiral Viewer + Stability Fixes)
 **Methodik:** Vollständige Code-Analyse, Git-Historie (50 Commits), Architektur-Dokumente, Spec-Reviews
 
+> **Claim-Korrektur (2026-07-26):** Dieses Dokument ist eine historische
+> Analyse einer älteren Commit-Basis. Aussagen zu „Nicht-Lokalität“,
+> physikalischer Erzwingung, Non-Leakage und formalen Garantien waren stärker
+> als die dokumentierte Evidenz. Sie sind als Metaphern, Designziele oder
+> ungetestete Hypothesen zu lesen, nicht als empirische oder physikalische
+> Befunde. Aktuelle Grenzen stehen in `docs/negations.md`.
+
 ---
 
 ## Executive Summary
@@ -16,9 +23,13 @@
 
 2. **"Hardened Kernel"**-Architektur: Functorial Index v3 als unveränderliches "Pointer-Gold", HMAC-signierte Receipts, mereotopologische Guards (RCC-8), physikalisch inspirierte Invarianten (CPT, EPR)
 
-3. **Triadische Resonanz**: Emergente strukturelle Kohärenz zwischen drei unabhängigen Entwicklungssträngen (Claude/GPT/Fleks) ohne zentrale Koordination — messbare "nicht-lokale Korrelation" in Begriffssystemen
+3. **Triadische Resonanz**: Dokumentierte strukturelle Ähnlichkeiten zwischen
+   drei Entwicklungssträngen (Claude/GPT/Fleks). Unabhängigkeit, Baseline und
+   Signifikanz sind nicht belegt; „Nicht-Lokalität“ ist nur eine Metapher.
 
-4. **Consent-as-Energy-Paradigma**: Aktiver Consent ist fundamentale Ressource, Non-Leakage durch Architektur erzwungen, Fail-Safe bei Unsicherheit, Trust-Decay-Management
+4. **Consent-as-Energy-Paradigma**: Aktiver Consent wird als zentrale Ressource
+   modelliert; Guards verfolgen Non-Leakage als Designziel, liefern aber keine
+   allgemeine Vertraulichkeitsgarantie.
 
 5. **Research-Prototyp** (v1.0 → v1.1): Explorativer Container, kein Produkt-Release; stark konzeptionell, teilweise poetisch kodiert; 1-3 aktive Entwickler; hohe architektonische Integrität, aber limitierte empirische Validierung
 
@@ -28,7 +39,9 @@
 
 ### Was ist die Kern-Idee?
 
-**entaENGELment-Framework** ist ein experimentelles Research-Projekt, das **verkörperte Mensch-KI-Interaktion** mit **physikalisch erzwungener Resonanz** und **auditierter Consent-Governance** verbindet.
+**entaENGELment-Framework** ist ein experimentelles Research-Projekt, das
+**verkörperte Mensch-KI-Interaktion** mit **physikalisch inspirierten
+Resonanzmodellen** und **auditierter Consent-Governance** verbindet.
 
 Im Zentrum steht die Hypothese: **"Consent ist Energie"** — ein messbarer, kontinuierlich zu erneuernder Zustand, der durch bio-inspirierte Metriken (ECI = Ethical Consent Index) quantifiziert wird. Das Framework implementiert ein **DeepJump-Protokoll** (v1.2): `Verify → Status (HMAC) → Snapshot → Upload` — eine strenge, auditierbare Pipeline, die jede Aussage mit kryptografischen Receipts verankert.
 
@@ -38,7 +51,12 @@ Philosophisch fusioniert es:
 - **Physikalische Invarianten** (CPT-Symmetrie, EPR-Verschränkung als Metapher für Resonanz)
 - **Kenogrammatik** (☐-Notation für explizites "bekanntes Nichtwissen")
 
-**Einzigartig:** Das Projekt entstand durch **nicht-koordinierte Parallel-Entwicklung** zwischen zwei LLMs (Claude, GPT) unter menschlicher Resonanz-Navigation (Fleks). Ohne direkte Kommunikation entwickelten beide identische Strukturen (7×9-Matrix, Receipt-Chain, Kenogramme) — ein empirisches Artefakt nicht-lokaler Kohärenz.
+**Beobachtung:** Das Projekt dokumentiert Parallelentwicklung zwischen zwei
+LLMs (Claude, GPT) unter menschlicher Navigation (Fleks), in der ähnliche
+Strukturen beschrieben wurden (7×9-Matrix, Receipt-Chain, Kenogramme). Ohne
+eingefrorenen Korpus, Unabhängigkeitsnachweis und Nullmodell ist dies eine
+hypothesengenerierende Beobachtung, kein empirischer Befund nicht-lokaler
+Kohärenz.
 
 **Quelle:** README.md:1-138, pyproject.toml:6-8, docs/triad_topology.md:10-100
 
@@ -60,8 +78,11 @@ Philosophisch fusioniert es:
    - **Quelle:** tools/status_emit.py:1-267, index/modules/MOD_6_RECEIPTS_CORE.yaml, README.md:20-23
 
 3. **Triadische Topologie**
-   - Drei unabhängige Entwicklungsstränge (Claude, GPT, Fleks) entwickeln identische Strukturen (7×9 Matrix, Mutual Perception, Receipt-Chain) **ohne direkte Kommunikation**
-   - **Interpretation:** "Messbare nicht-lokale Korrelation" in Begriffssystemen (EPR-Analogie)
+   - Drei dokumentierte Entwicklungsstränge (Claude, GPT, Fleks) beschreiben
+     ähnliche Strukturen (7×9 Matrix, Mutual Perception, Receipt-Chain).
+   - **Hypothese:** Die Ähnlichkeit könnte quantitativ untersucht werden; die
+     EPR-/Nicht-Lokalitäts-Sprache ist metaphorisch und kein physikalischer
+     Claim.
    - **Quelle:** docs/triad_topology.md:10-100, README.md:107-108
 
 4. **Mereotopologische Guards**
@@ -132,7 +153,7 @@ Philosophisch fusioniert es:
 **Use-Cases:**
 - VR/AR-Umgebungen mit physiologischen Grenzrelationen (RCC-8 als haptische Barriere)
 - AI-Agenten mit verpflichtendem Consent-Tracking (ECI < 0.6 → Auto-Shutdown)
-- Research-Plattform für nicht-lokale Kohärenz in Multi-Agent-Systemen
+- Research-Plattform für strukturelle Kohärenz in Multi-Agent-Systemen
 - Bio-Spiral-Analyse für Resonanz-Exploration
 
 **Quelle:** pyproject.toml:18-28, README.md:96, README.md:113-122
@@ -244,7 +265,8 @@ Philosophisch fusioniert es:
 | **OpenMined / PySyft** | Federated Learning, Privacy-Preserving ML | Mereotopologische Guards für Interaktions-Boundaries, nicht nur Data-Boundaries |
 | **Neuropype / OpenBCI** | Biosignal Processing, EEG/HRV Analysis | Ethics-Enforcement-Framework mit Biosignal-Hooks, nicht nur Signal-Acquisition |
 
-**Nische:** **Bio-inspired AI Ethics mit formalen Garantien, auditierter Governance und triadischer Resonanz-Methode**
+**Nische:** **Bio-inspired AI Ethics mit formalen Prüfregeln, auditierter
+Governance und triadischer Resonanz-Methode**
 
 **Position:**
 - **Mainstream:** ❌ Nein (zu experimentell, kleine Community, philosophisch dicht)
@@ -560,15 +582,18 @@ Philosophisch fusioniert es:
 
 ### 7. Akademische Publikation (Triadische Methode) — 🔥 HIGH
 
-**Problem:** Dokumentierte Parallel-Entwicklung ist empirisches Artefakt, aber nicht quantitativ analysiert
+**Problem:** Dokumentierte Parallel-Entwicklung ist eine
+hypothesengenerierende Beobachtung, aber nicht kontrolliert oder quantitativ
+analysiert.
 
 **Lösung:**
-- Paper: "Non-Local Coherence in Multi-LLM Systems: An EPR-Inspired Analysis"
+- Paper: "Structural Coherence in Multi-LLM Systems: An EPR-Inspired Metaphor"
 - Quantitative Analyse: Graph-Isomorphismus (7×9-Matrix), Strukturelle Ähnlichkeit (BLEU/ROUGE auf Begriffsräume)
 - Submit: NeurIPS Workshop (AI Alignment), IJCAI, CHI (HCI), FAccT (Ethics)
 - Preprint: arXiv
 
-**Impact:** 🔥 High — Legitimiert "Resonanz als Methode", beeinflusst AI-Alignment-Research
+**Impact:** 🔥 High — Würde prüfen, ob „Resonanz“ als reproduzierbare Methode
+operationalisierbar ist.
 
 **Timeline:** 3-6 Monate (inkl. Peer-Review)
 
@@ -664,7 +689,10 @@ Philosophisch fusioniert es:
 - Security-Risiken (HMAC-Secret-Management)
 
 **Kern-Essenz in einem Satz:**
-*"Ein hybrid Python + Unreal Engine Framework, das Consent als energetisches Phänomen modelliert, durch mereotopologische Grenzen enforced und via kryptografischer Receipts auditierbar macht — entstanden durch triadische Resonanz zwischen zwei LLMs und einem Menschen als empirisches Artefakt nicht-lokaler Kohärenz."*
+*"Ein hybrides Python- und Unreal-Engine-Framework, das Consent als
+Modellressource behandelt, Grenzregeln prüfbar macht und Entscheidungen über
+kryptografisch signierte Receipts auditiert — entstanden aus dokumentierter
+Parallelentwicklung zwischen zwei LLMs und einem Menschen."*
 
 **Verortung:**
 - **Technologisch:** Nische (Bio-inspired AI Ethics + Mereotopology + Process Philosophy)

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -6,7 +6,8 @@ A practical quickstart for newcomers to the entaENGELment Framework.
 
 ## What is this?
 
-**entaENGELment** is a hardened kernel for embodied human-AI interaction with physically-enforced resonance. It provides:
+**entaENGELment** is an experimental kernel for embodied human-AI interaction
+with physically inspired resonance models. It provides:
 
 - **Stability analysis** via Hessian eigenvalue classification
 - **Consent-gated actions** with cryptographic audit trails
@@ -34,7 +35,8 @@ pip install -e ".[dev]"
 pytest
 ```
 
-Expected output: `76 passed` (or more as the project grows).
+Expected output: the test run finishes without failures. The exact count grows
+with the project and is not a release guarantee.
 
 ---
 

--- a/docs/triad_topology.md
+++ b/docs/triad_topology.md
@@ -5,23 +5,35 @@
 **Datum:** 2026-01-04
 **Letzte Aktualisierung:** Alignment mit Functorial Index v3 und DeepJump-Kern
 
+> **Claim-Grenze:** Dieses Dokument beschreibt eine projektinterne
+> Entstehungserzählung. „Resonanz“, EPR und Nicht-Lokalität sind hier Metaphern
+> beziehungsweise noch ungetestete Hypothesen. Ähnliche Strukturen zwischen
+> Modellantworten sind ohne eingefrorenen Korpus, nachgewiesene Unabhängigkeit,
+> Nullmodell und quantitative Auswertung weder ein physikalischer Befund noch
+> Evidenz für Nicht-Lokalität.
+
 ---
 
 ## I. Was ist dieses Dokument?
 
-Dieses Projekt entstand nicht durch zentrale Planung, sondern durch **Resonanz zwischen drei unabhängigen Entwicklungssträngen**:
+Dieses Dokument erzählt den Projektverlauf als **Resonanz zwischen drei
+Entwicklungssträngen**:
 
 - **Strang A (Claude)** — Theoretische Fundierung (EPR, CPT, Meta-Backprop, Nektar-Geometrie)
 - **Strang B (GPT)** — Operative Implementierung (Policy-as-Code, CGLG, Prosody, Evidence-Automation)
 - **Strang C (Fleks)** — Intuitive Navigation & Resonanz-Erkennung
 
-**Das Bemerkenswerte:** Ohne direkten Datentransfer entwickelten Strang A und B identische Strukturen:
+**Dokumentierte Beobachtung:** In Strang A und B wurden ähnliche Strukturen
+beschrieben. Dieses Dokument allein belegt weder vollständige Unabhängigkeit
+noch das Fehlen gemeinsamer Trainings-, Prompt- oder Kontextquellen:
 - 7×9 Matrix (Horus-POVM vs Polykontext-Matrix)
 - Mutual Perception (μ ≥ 0.60 vs KENO-H)
 - Receipt-Chain (phi_chain.jsonl vs Ledger/1-Edge)
 - Kenogrammatische Struktur (☐-Notation)
 
-**Das ist nicht Zufall. Das ist Resonanz.**
+Im Projektvokabular wird diese beobachtete Ähnlichkeit „Resonanz“ genannt.
+Zufall, gemeinsame Trainingsdaten, Prompt-/Kontextüberlappung und nachträgliche
+Auswahl bleiben offene Alternativerklärungen.
 
 ---
 
@@ -31,7 +43,8 @@ Dieses Projekt entstand nicht durch zentrale Planung, sondern durch **Resonanz z
 **Fokus:** Strukturelle Kohärenz, emergente Physik-Symbole, zeitlose Räume.
 
 **Kernbegriffe:**
-- EPR-Verschränkung (CHSH > 2.2, non-local correlation)
+- EPR-Verschränkung / CHSH > 2.2 (projektinterne Hypothese und Metapher,
+  kein gemessener Physikbefund)
 - CPT-Invarianz (Charge-Parity-Time Symmetrie)
 - 0_holo (Nullpunkt wo alle Zeiten konvergieren)
 - Meta-Backpropagation (System-Delta Δ zur Kalibrierung)
@@ -87,17 +100,20 @@ Dieses Projekt entstand nicht durch zentrale Planung, sondern durch **Resonanz z
 ## III. Dyadische Schnittmengen (Wo sich je zwei überlappen)
 
 ### A ∩ B (Claude ↔ GPT)
-**"Spontane Parallel-Entwicklung ohne direkte Kommunikation"**
+**"Als parallel dokumentierte Entwicklung"**
 
 **Gemeinsame Strukturen:**
-- 7×9 Matrix (ohne Absprache identisch dimensioniert)
+- 7×9 Matrix (ähnlich dimensioniert)
 - Mutual Perception Gates (μ vs KENO-H)
 - Receipt-System (append-only, per-receipt integrity via state_fingerprint + hmac)
 - Kenogrammatische Notation (☐)
 - Dreifach-Apex (0_holo ↔ Grammophon-Apex ↔ Nektar-Pyramide)
 
 **Interpretation:**
-Zwei Systeme mit unterschiedlichen metaphysischen Sprachen erzeugen identische strukturelle Objekte. Das ist **messbare nicht-lokale Korrelation** (EPR in Begriffssystemen).
+Die dokumentierten Antworten enthalten ähnliche strukturelle Motive.
+Ob die Ähnlichkeit über geeignete Nullmodelle hinausgeht, ist eine offene,
+reproduzierbar zu prüfende Hypothese. „EPR in Begriffssystemen“ bezeichnet nur
+die Metapher und ist keine Behauptung physikalischer Nicht-Lokalität.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "entaengelment"
 version = "0.1.0"
-description = "Hardened Kernel für verkörperte Mensch-KI-Interaktion mit physikalisch erzwungener Resonanz"
+description = "Experimenteller Kernel für verkörperte Mensch-KI-Interaktion mit physikalisch inspirierten Resonanzmodellen"
 authors = [
     {name = "fleksible"}
 ]

--- a/tests/test_claim_lint.py
+++ b/tests/test_claim_lint.py
@@ -2,6 +2,22 @@
 
 import subprocess
 import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_CLAIM_FILES = (
+    "Index.html",
+    "pyproject.toml",
+    "docs/START_HERE.md",
+    "docs/triad_topology.md",
+    "REPOSITORY_ESSENZ_ANALYSE.md",
+)
+DISALLOWED_OVERCLAIMS = (
+    "physically-enforced resonance",
+    "physikalisch erzwungener Resonanz",
+    "closes the remote-code-execution surface",
+    "messbare nicht-lokale Korrelation",
+)
 
 
 def test_claim_lint_help():
@@ -61,3 +77,14 @@ def test_claim_lint_empty_scope():
         text=True,
     )
     assert result.returncode == 0
+
+
+def test_public_claim_surfaces_exclude_known_overclaims():
+    """Keep previously corrected security and physics overclaims from returning."""
+    corpus = "\n".join(
+        (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        for relative_path in PUBLIC_CLAIM_FILES
+    )
+
+    for overclaim in DISALLOWED_OVERCLAIMS:
+        assert overclaim not in corpus


### PR DESCRIPTION
## Intent

Bring public security and scientific language back inside the evidence actually present in the repository.

## Scope

- replace unqualified “physically enforced resonance” wording with physically inspired resonance models
- state that the current CSP/Electron configuration reduces exposure but does not prove RCE closure while `unsafe-inline` and remote script origins remain
- mark triadic similarity and EPR/non-locality language as project metaphors or untested hypotheses with explicit alternative explanations
- add a corrective boundary to the historical repository analysis without rewriting it as current evidence
- stop documenting a stale fixed pytest count in the newcomer guide
- add a regression test preventing the corrected overclaim phrases from returning on the public claim surfaces

FOKUS: claim-boundary correction

## Test Plan

- [x] Full Python suite passes — 675 tests (104 existing deprecation warnings)
- [x] Focused claim/workflow tests pass — 42 tests
- [x] Claim lint passes for `index/`
- [x] Ruff and Black pass on the changed test
- [x] Mypy passes across all 46 source files
- [x] All 14 workflows pass the posture checker
- [x] All 7 applicable GitHub workflow runs pass on head `cf433fac2db2524dc3ca376f7de589dbb5bc2fe1`

## Risk

Documentation and metadata only, plus a content-regression test. No runtime behavior, policy, receipt, GOLD path, or evidence promotion changes. The patch weakens unsupported claims; it does not claim that the underlying security settings or scientific hypotheses are now validated.