### PR TITLE
feat(governance): consolidate re-entry bridge and VOID-027 receipt

### DIFF
--- a/VOIDMAP.yml
+++ b/VOIDMAP.yml
@@ -18,7 +18,7 @@ description: >
 
 metadata:
   maintainer: entaENGELment
-  last_updated: "2026-07-22"
+  last_updated: "2026-07-28"
   generated_doc: docs/voids_backlog.md
   reconciliation_notes: |
     [SPEC] 2026-06-24 consolidation:
@@ -493,6 +493,7 @@ voids:
       - "ui-app/test/tesser3takt-frame.test.mjs"
       - "ui-app/test/tesser3takt-hud.test.mjs"
       - "ui-app/README.md"
+      - "receipts/2026-07-28_void027_bridge_view_v0_1.json"
     created: "2026-06-24"
     closed: null
     notes: |
@@ -510,9 +511,13 @@ voids:
       [PARTIAL] Present evidence covers the canonical frame, 7x9/Kenogram HUD,
       exact-state collision semantics, boundary pairs, structured provenance,
       fixtures, tests, and a read-only route.
+      [REPO-FACT 2026-07-28] The repo-relative receipt pointer
+      receipts/2026-07-28_void027_bridge_view_v0_1.json resolves to an
+      existing artifact and is covered by tools/verify_pointers.py. It closes
+      only the receipt-link sublever and implies no truth, promotion, or canon.
       [VOID] The declared 1xn traversal slice, Apex marker, calibrated EFS/MVI
-      axis, decision bar, and resolvable receipt link are not jointly evidenced.
-      VOID-027 therefore remains IN_PROGRESS and must not be marked CLOSED.
+      axis, and decision bar are not jointly evidenced. VOID-027 therefore
+      remains IN_PROGRESS and must not be marked CLOSED.
   - id: VOID-028
     title: "EFS/MVI Grüneisen-Axis Calibration"
     status: OPEN

--- a/VOIDMAP.yml
+++ b/VOIDMAP.yml
@@ -18,7 +18,7 @@ description: >
 
 metadata:
   maintainer: entaENGELment
-  last_updated: "2026-07-28"
+  last_updated: "2026-07-29"
   generated_doc: docs/voids_backlog.md
   reconciliation_notes: |
     [SPEC] 2026-06-24 consolidation:
@@ -511,13 +511,15 @@ voids:
       [PARTIAL] Present evidence covers the canonical frame, 7x9/Kenogram HUD,
       exact-state collision semantics, boundary pairs, structured provenance,
       fixtures, tests, and a read-only route.
-      [REPO-FACT 2026-07-28] The repo-relative receipt pointer
+      [REPO-FACT 2026-07-29] The repo-relative receipt pointer
       receipts/2026-07-28_void027_bridge_view_v0_1.json resolves to an
-      existing artifact and is covered by tools/verify_pointers.py. It closes
-      only the receipt-link sublever and implies no truth, promotion, or canon.
-      [VOID] The declared 1xn traversal slice, Apex marker, calibrated EFS/MVI
-      axis, and decision bar are not jointly evidenced. VOID-027 therefore
-      remains IN_PROGRESS and must not be marked CLOSED.
+      existing artifact and is covered by tools/verify_pointers.py. It
+      establishes stable registry/projection receipt evidence and implies no
+      truth, promotion, or canon.
+      [VOID] The HUD does not yet render the receipt link, so receipt-link
+      rendering remains open. The declared 1xn traversal slice, Apex marker,
+      calibrated EFS/MVI axis, and decision bar are not jointly evidenced.
+      VOID-027 therefore remains IN_PROGRESS and must not be marked CLOSED.
   - id: VOID-028
     title: "EFS/MVI Grüneisen-Axis Calibration"
     status: OPEN

--- a/docs/annex/ACTION_GATE_v0_1.md
+++ b/docs/annex/ACTION_GATE_v0_1.md
@@ -190,6 +190,25 @@ BoundaryTransition (ERK-Spec §11) und teilt weder Typen noch Vokabular mit ihne
 Das eigene `ActionReasonCode`-Enum ist bewusst getrennt vom `ReasonCode` des
 Claim-Kernels.
 
+Die beiden unverhandelbaren Grenzen lauten:
+
+```text
+PROPOSE != AUTHORIZE
+PROPOSE != EXECUTE
+```
+
+Alle folgenden Re-entry-Punkte bleiben bis zu einer getrennten Prüfung und
+ausdrücklichen Autorisierung geschlossen:
+
+| Re-entry-Punkt | Status | Grenze |
+|---|---|---|
+| Payload-Limits | `HOLD` | keine belastbare Größen-/Komplexitätsgrenze in v0.1 |
+| Registry-Signaturprüfung | `HOLD` | keine kryptografische Registry-Authentisierung |
+| Consumer-Authentizität | `HOLD` | kein authentifizierter Consumer-Witness |
+| Ausführende Runtime-Grenze | `HOLD` | kein ausführender Consumer wird implementiert |
+| Ledger- oder UI-Kopplung | `HOLD` | nur über separat genehmigte Adapter |
+| Installations- oder Deploymentpfad | `HOLD` | kein Pfad in v0.1 |
+
 Insbesondere ist `PROPOSE` **keine Ausführungsautorisierung**. Paketname,
 Effektdeklarationen, `verification_status` und der inerte Command-Text bleiben
 Beschreibungen des Aufrufers; v0.1 vergleicht den Command nicht semantisch mit

--- a/docs/annex/BRIDGE_VIEW_v0_1.md
+++ b/docs/annex/BRIDGE_VIEW_v0_1.md
@@ -32,12 +32,17 @@ M5 pointer. It does not mean approved, authorized, promoted, canonical, or true.
   projection is never represented as complete.
 - Adapter-derived source IDs must be canonical kebab-case IDs. Existing target
   IDs retain the adapter's non-empty, whitespace-trimmed stable-ID vocabulary.
+- Translation and nested ERK schema versions must match the supported v0.1
+  contracts, and nested records must have their exact model types.
 - Relations and registers must be members of their existing closed
-  vocabularies; no relation is guessed or silently downgraded.
+  vocabularies. Each relation must also be allowed for its source register; no
+  relation is guessed or silently downgraded.
+- Material kind must match the adapter's source-register mapping.
 - Myth, metaphor, psychology, and UI cannot produce promotion eligibility.
 - Physical and biological projections require the documented review pointer.
   A missing pointer is an error, not a downgrade.
 - Material and relation status must agree.
+- Only an `ACTIVE` translation can display human-review eligibility.
 - Receipt and review pointers must be explicit repo-relative paths. Drive-prefixed
   and URI-scheme-like paths are rejected. Receipt targets are limited to supported
   text files under `receipts/`.

--- a/docs/annex/BRIDGE_VIEW_v0_1.md
+++ b/docs/annex/BRIDGE_VIEW_v0_1.md
@@ -23,22 +23,24 @@ promotion, or change any status.
 | `receipt` | explicit repo-relative pointer supplied by the caller |
 
 `ELIGIBLE_FOR_HUMAN_REVIEW` means only that the existing translation has a
-promotion-capable relation, reviewed material trust, and the required M5
-pointer. It does not mean approved, authorized, promoted, canonical, or true.
+promotion-capable relation, trusted or reviewed material, and the required
+M5 pointer. It does not mean approved, authorized, promoted, canonical, or true.
 
 ## Fail-closed invariants
 
 - No view is emitted when `known_loss` is absent or malformed. A failed
   projection is never represented as complete.
-- Source and target IDs must be canonical kebab-case IDs.
+- Adapter-derived source IDs must be canonical kebab-case IDs. Existing target
+  IDs retain the adapter's non-empty, whitespace-trimmed stable-ID vocabulary.
 - Relations and registers must be members of their existing closed
   vocabularies; no relation is guessed or silently downgraded.
 - Myth, metaphor, psychology, and UI cannot produce promotion eligibility.
 - Physical and biological projections require the documented review pointer.
   A missing pointer is an error, not a downgrade.
 - Material and relation status must agree.
-- Receipt and review pointers must be explicit repo-relative paths. Receipt
-  targets are limited to supported text files under `receipts/`.
+- Receipt and review pointers must be explicit repo-relative paths. Drive-prefixed
+  and URI-scheme-like paths are rejected. Receipt targets are limited to supported
+  text files under `receipts/`.
 - The projection never adds authority. Promotion remains a separate human
   decision behind existing governance gates.
 

--- a/docs/annex/BRIDGE_VIEW_v0_1.md
+++ b/docs/annex/BRIDGE_VIEW_v0_1.md
@@ -1,0 +1,54 @@
+# BRIDGE_VIEW v0.1
+
+Status: **DRAFT — read-only projection, no authority**
+
+`BRIDGE_VIEW_v0.1` is a human-readable projection of an existing
+`BridgeTranslation`. It does not create bridge records, retag claims, emit
+events, read files, access the network, execute runtime actions, authorize a
+promotion, or change any status.
+
+## Fields
+
+| Field | Existing source |
+|---|---|
+| `source` | `translation.material.material_id` |
+| `target` | `translation.relation.claim_id` |
+| `relation` | `translation.relation.relation_type` |
+| `register` | `translation.context.source_register` |
+| `status` | matching material/relation status |
+| `known_loss` | `translation.context.known_loss` |
+| `review_pointer` | `translation.context.m5_review_pointer` |
+| `promotion_eligibility` | structural display only |
+| `rollback` | `translation.context.rollback` |
+| `receipt` | explicit repo-relative pointer supplied by the caller |
+
+`ELIGIBLE_FOR_HUMAN_REVIEW` means only that the existing translation has a
+promotion-capable relation, reviewed material trust, and the required M5
+pointer. It does not mean approved, authorized, promoted, canonical, or true.
+
+## Fail-closed invariants
+
+- No view is emitted when `known_loss` is absent or malformed. A failed
+  projection is never represented as complete.
+- Source and target IDs must be canonical kebab-case IDs.
+- Relations and registers must be members of their existing closed
+  vocabularies; no relation is guessed or silently downgraded.
+- Myth, metaphor, psychology, and UI cannot produce promotion eligibility.
+- Physical and biological projections require the documented review pointer.
+  A missing pointer is an error, not a downgrade.
+- Material and relation status must agree.
+- Receipt and review pointers must be explicit repo-relative paths. Receipt
+  targets are limited to supported text files under `receipts/`.
+- The projection never adds authority. Promotion remains a separate human
+  decision behind existing governance gates.
+
+Existence of the VOID-027 receipt target is checked by
+`tools/verify_pointers.py` through its `VOIDMAP.yml` evidence entry. The pure
+projection validates pointer shape only so it keeps the no-file-access
+boundary.
+
+## Rollback
+
+Revert the introducing commit. Remove the corresponding `VOIDMAP.yml` evidence
+pointer in the same revert. Preserve the Git history and receipt as historical
+evidence of the withdrawn projection.

--- a/docs/audit/2026-07-28_consolidation_reentry.md
+++ b/docs/audit/2026-07-28_consolidation_reentry.md
@@ -11,6 +11,7 @@ the date of this audit, and canon status are independent fields.
 | VERIFIED | `main` | `eade3b7726dfa70b9d226f8ba3421aa1012edb2f` | commit `docs: bound security and resonance claims (#331)` | none |
 | VERIFIED | PR #321 exact-version thread | implementation accepts only complete npm SemVer 2.0.0 or conservative PyPI PEP 440 public identifiers; target thread resolved after verification | PR #321, commit `325adcfd6d4447b05f4c129749110065da13e9d6` | no code follow-up |
 | VERIFIED | PR #334 | open, mergeable, ready for review; 7/7 observed head workflows successful | PR #334, head `76a1a884b1563b60074bec690c436d7247921489` | Owner review; no autonomous merge |
+| DRAFT | PR #340 | open draft, unmerged; this consolidation branch | PR #340 | complete CI and human review; no autonomous merge |
 | VERIFIED | Dependency PRs #335–#338 | patch updates; expected file scope; 9/9 observed checks successful on each head | PRs #335–#338 | review and merge individually |
 | HOLD | Dependency PR #298 | `MAJOR_COMPATIBILITY_HOLD`; TypeScript 7 breaks lint/typecheck compatibility | PR #298 workflow logs | separate compatibility track |
 | HOLD | Dependency PR #339 | `MAJOR_COMPATIBILITY_HOLD`; ESLint 10 conflicts with `eslint-plugin-react@7.37.5` | PR #339 workflow logs | separate compatibility track |

--- a/docs/audit/2026-07-28_consolidation_reentry.md
+++ b/docs/audit/2026-07-28_consolidation_reentry.md
@@ -36,15 +36,35 @@ VERIFIED — The current workspace policy includes explicit `pnpm` overrides and
 exceptions, not ordinary patch updates. They must remain isolated, documented,
 and rollbackable.
 
+### Major compatibility tracks
+
+| Category | Check | PR #298 — TypeScript 7 | PR #339 — ESLint 10 |
+|---|---|---|---|
+| HOLD | workspace tests | not accepted; required workflow is red | not accepted; required workflow is red |
+| HOLD | lint/config/plugins | `@typescript-eslint/typescript-estree@8.60.1` crashes on TS 7 (`Cjs`) | `eslint-plugin-react@7.37.5` calls removed context API |
+| HOLD | typecheck | Next build reaches typecheck, then reports the required TypeScript package unavailable | not reached after lint failure |
+| HOLD | build/packaging | compile stage alone is insufficient; typecheck/package acceptance absent | build and Electron packaging acceptance absent |
+| HOLD | lockfile consistency | changed lockfile is not accepted while compatibility checks fail | changed lockfile is not accepted while compatibility checks fail |
+| HOLD | audit result | no successful head-specific audit witness | no successful head-specific audit witness |
+| HOLD | breaking changes | demonstrated parser/toolchain incompatibility | demonstrated plugin API incompatibility |
+| HOLD | rollback | leave unmerged or close PR; `main` stays unchanged | leave unmerged or close PR; `main` stays unchanged |
+
 ## VOID/QDOT re-entry
 
-| Category | Entry | Status | Smallest closable part | Blocker / review boundary |
-|---|---|---|---|---|
-| VERIFIED | VOID-027 | `IN_PROGRESS` | stable receipt pointer | CI validates the pointer; Owner/human review before any status change |
-| HOLD | VOID-027 remaining work | open | none in this change | 1xn slice, Apex, calibrated EFS/MVI, decision bar remain separately unevidenced |
-| HOLD | VOID-010 | `IN_PROGRESS`, target 2026-07-15 | literature/data evidence slice | physics review boundary |
-| HOLD | VOID-011 | `IN_PROGRESS`, target 2026-07-15 | simulation receipt/export slice | quantitative-method review boundary |
-| HOLD | VOID-024–029 and VOID-LOGZN-001 | open as recorded | per-entry scoped review | no aggregate closure |
+| Category | Entry / status | Open required parts | Current evidence | Smallest closable part | Blocker | Review boundary |
+|---|---|---|---|---|---|---|
+| HOLD | VOID-010 / `IN_PROGRESS` | cited CSV and evidence bundle | `docs/voids/VOID-010_taxonomy_and_spectra.md` | sources-first CSV schema with at least five cited sources | overdue 2026-07-15; empirical source binding | physics/literature review |
+| HOLD | VOID-011 / `IN_PROGRESS` | deterministic metric export and `SIMULATION_PROXY` receipt | metrics code, toy dataset, unit test, VOID note | one deterministic claim-tagged export/receipt | evidence boundary, not implementation stub | quantitative-method review |
+| HOLD | VOID-015 / `OPEN` | lint rules, fixtures, coverage receipt | none | one trigger-term fixture with Reason/Transform/Input binding | target thresholds remain SPEC | claim-hygiene/governance review |
+| HOLD | VOID-016 / `OPEN` | τ retention rules, autophagy/V+ interaction, deletion receipts | none | one explicit τ_fast retention rule and negative fixture | “essence” and deletion semantics are not operationally bound | governance/privacy review |
+| HOLD | VOID-017 / `OPEN` | Δ components and non-peak tipping tests | none | one negative fixture proving magnitude alone does not tip | threshold/components remain SPEC | math/control review |
+| HOLD | VOID-024 / `OPEN` | consent policy, bounds, reason codes, kill-switch, safe-text fallback, receipt | none | consent + STOP fallback schema fixture | heuristic frequency/PLV values lack an evidence path | safety/human review |
+| HOLD | VOID-025 / `OPEN` | modality fields, deterministic serialization, hash basis, autophagy invariants, receipt fixtures | none | canonical UTF-8 NFC text fixture | cross-modality identity and heuristics unresolved | governance/cryptographic review |
+| HOLD | VOID-026 / `OPEN` | ADR, model, Kraehennest order, tests, receipt | none | ADR invariant: SailObservation precedes KraehennestObservation | runtime/control model not authorized | architecture/governance review |
+| VERIFIED | VOID-027 / `IN_PROGRESS` | 1xn slice, Apex, calibrated EFS/MVI, decision bar remain open | HUD/frame code, fixtures/tests, README, new receipt pointer | stable repo-relative receipt pointer | remaining UI/calibration elements are separately unevidenced | Owner/human review before status change |
+| HOLD | VOID-028 / `OPEN` | normalized deltas, calibration factors, thresholds, three fixtures, `SIMULATION_PROXY` receipt | none | bind metric definitions before calibrating thresholds | false-precision risk and VOID-011 dependency | math/quantitative review |
+| HOLD | VOID-029 / `OPEN` | cross-instance receipt schema/instance and allowed reuse scope | none | one receipt instance with `human_commit_required=true` | source poles/protected-origin scope unresolved | governance/Owner review |
+| HOLD | VOID-LOGZN-001 / `OPEN` | tests, metrics/claim tags, receipt or replay witness | two cited RZT/tesser3TAKT documents | one claim-tagged test plus receipt | current evidence is documentary only | math/claim review |
 
 VERIFIED — No additional diagram, calibration, or narrative extension is started by this
 change.

--- a/docs/audit/2026-07-28_consolidation_reentry.md
+++ b/docs/audit/2026-07-28_consolidation_reentry.md
@@ -1,0 +1,104 @@
+# entaENGELment consolidation and re-entry audit — 2026-07-28
+
+VERIFIED — This report separates repository facts, connected-document classifications,
+draft work, and explicit holds. Drive upload dates, internal document dates,
+the date of this audit, and canon status are independent fields.
+
+## State matrix
+
+| Category | Element | Current status | Evidence | Action |
+|---|---|---|---|---|
+| VERIFIED | `main` | `eade3b7726dfa70b9d226f8ba3421aa1012edb2f` | commit `docs: bound security and resonance claims (#331)` | none |
+| VERIFIED | PR #321 exact-version thread | implementation accepts only complete npm SemVer 2.0.0 or conservative PyPI PEP 440 public identifiers; target thread resolved after verification | PR #321, commit `325adcfd6d4447b05f4c129749110065da13e9d6` | no code follow-up |
+| VERIFIED | PR #334 | open, mergeable, ready for review; 7/7 observed head workflows successful | PR #334, head `76a1a884b1563b60074bec690c436d7247921489` | Owner review; no autonomous merge |
+| VERIFIED | Dependency PRs #335–#338 | patch updates; expected file scope; 9/9 observed checks successful on each head | PRs #335–#338 | review and merge individually |
+| HOLD | Dependency PR #298 | `MAJOR_COMPATIBILITY_HOLD`; TypeScript 7 breaks lint/typecheck compatibility | PR #298 workflow logs | separate compatibility track |
+| HOLD | Dependency PR #339 | `MAJOR_COMPATIBILITY_HOLD`; ESLint 10 conflicts with `eslint-plugin-react@7.37.5` | PR #339 workflow logs | separate compatibility track |
+| HOLD | Security settings/advisories | repository settings-side CodeQL and Private Vulnerability Reporting posture not exposed by the connected evidence | open issue #332; last audit witness in PR #329 | Owner/settings verification |
+| VERIFIED | VOID-027 | `IN_PROGRESS`; receipt-link sublever addressed by a repo-relative receipt; remaining declared components stay open | `VOIDMAP.yml` and `receipts/2026-07-28_void027_bridge_view_v0_1.json` | validate in CI; do not close VOID |
+| HOLD | VOID-010/011 | overdue and still `IN_PROGRESS` | `VOIDMAP.yml`, issue #311 | scoped evidence review |
+| VERIFIED | Notion re-entry mirror | connected mirror records PRs #326–#331 and issues #332/#333; it explicitly defers authority to repo/VOIDMAP | Notion page `3a9a6554-a786-8105-a411-e5745c6319f5` | reference only |
+| HOLD | Linear | no matching entaENGELment project or issue was found in the connected workspace | connected Linear search | no issue creation without Owner choice |
+
+## Dependency classification
+
+| Category | PR | Class | Verification |
+|---|---:|---|---|
+| VERIFIED | #335 | A — `actions/checkout` 7.0.0 → 7.0.1 | expected workflow files; observed checks successful |
+| VERIFIED | #336 | A — `@tanstack/react-query` 5.101.2 → 5.101.4 | manifest/lockfile only; observed checks successful |
+| VERIFIED | #337 | A — React 19.2.7 → 19.2.8 | manifest/lockfile only; observed checks successful |
+| VERIFIED | #338 | A — `@tailwindcss/postcss` 4.3.2 → 4.3.3 | manifest/lockfile only; observed checks successful |
+| HOLD | #298 | `MAJOR_COMPATIBILITY_HOLD` — TypeScript 7 | `typescript-estree` crash and failed Next typecheck |
+| HOLD | #339 | `MAJOR_COMPATIBILITY_HOLD` — ESLint 10 | `eslint-plugin-react` API incompatibility |
+
+VERIFIED — The current workspace policy includes explicit `pnpm` overrides and
+`patches/brace-expansion@5.0.8.patch`. These are compatibility/security
+exceptions, not ordinary patch updates. They must remain isolated, documented,
+and rollbackable.
+
+## VOID/QDOT re-entry
+
+| Category | Entry | Status | Smallest closable part | Blocker / review boundary |
+|---|---|---|---|---|
+| VERIFIED | VOID-027 | `IN_PROGRESS` | stable receipt pointer | CI validates the pointer; Owner/human review before any status change |
+| HOLD | VOID-027 remaining work | open | none in this change | 1xn slice, Apex, calibrated EFS/MVI, decision bar remain separately unevidenced |
+| HOLD | VOID-010 | `IN_PROGRESS`, target 2026-07-15 | literature/data evidence slice | physics review boundary |
+| HOLD | VOID-011 | `IN_PROGRESS`, target 2026-07-15 | simulation receipt/export slice | quantitative-method review boundary |
+| HOLD | VOID-024–029 and VOID-LOGZN-001 | open as recorded | per-entry scoped review | no aggregate closure |
+
+VERIFIED — No additional diagram, calibration, or narrative extension is started by this
+change.
+
+## Connected Drive classification
+
+| Category | Primary class | Document ID | Internal document date | Drive upload / modified date | Rationale |
+|---|---|---|---|---|---|
+| VERIFIED | WORKING_DRAFT | `1FakZrgPWLvJgTZevIXfm0rCnlVVROrtFT1taoUTGMlI` | 2026-07-22 | connected metadata | internal read-only shadow catalog; no authority |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1vXrSyu4o--5pA-FulYG46AEGUzVaOmOw` | 2026-05-20 | 2026-07-19 upload | upload map, not current repository state |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1bRRzGSm7KXJE0CFviuQyfckkTWfrd1UG` | snapshot at `main@96bbdb9` | connected metadata | contradicts the current verified main SHA |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1wsipMetHXM6y4Lo66amlh7Qph1z72zlt` | snapshot date in document | connected metadata | VOID/QDOT states are stale against `VOIDMAP.yml` |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `14TTRVr7zbOdna1Z-cyorweQC4q_Moq3d` | 2026-07-25 | connected metadata | protected save state, but repo/PR snapshot is stale |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1ku9YAmiYjkuk2rZkB9jDzM8xYT-pJce6` | 2026-01-26 | connected metadata | research indexer snapshot does not represent the current repo |
+| HOLD | QUARANTINE_OVERCLAIM_REVIEW | `1GX8xBBudyNK0Im_EU_Rhpw5bBNbRuU-p` | 2025-12-16 | 2026-07-26 upload | quantitative, physical, biological, TRL, and “proof” language lacks a bound repo/lab evidence chain |
+| NARRATIVE | NARRATIVE_LAYER | `1lOW9L35WQ2KtWFdBXr_wZfKr7AHrQaAR` | date in document | 2026-07-19 upload | document self-labels model/Rosetta/guard/wordknot/narrative material and disclaims scientific proof |
+| NARRATIVE | NARRATIVE_LAYER | `10ySaVb8S2NnagB5L--jQ9V4kifv6EM2Q` | not treated as canon date | 2026-07-26 modified | private Grimm reading surface; not an evidence source |
+
+HOLD — The classification creates no canon. Source-of-Truth admission still requires
+technical/content review, Claude/Diogenes review, explicit Owner decision,
+documented receipt, and a rollback path.
+
+## Action-Gate boundary
+
+| Category | Re-entry point | State |
+|---|---|---|
+| VERIFIED | `PROPOSE != AUTHORIZE` | documented invariant |
+| VERIFIED | `PROPOSE != EXECUTE` | documented invariant |
+| HOLD | payload limits | separate review and authorization required |
+| HOLD | registry signature verification | separate review and authorization required |
+| HOLD | consumer authenticity | separate review and authorization required |
+| HOLD | executing runtime boundary | no consumer implemented |
+| HOLD | ledger or UI coupling | separate adapter decision required |
+| HOLD | installation or deployment path | no path implemented |
+
+## Grimm accessibility and protection audit
+
+| Category | Check | Result |
+|---|---|---|
+| VERIFIED | local/network boundary | no `fetch`, XHR, WebSocket, local/session storage, or dynamic execution found in the connected HTML; CSP has `connect-src 'none'`; referrer policy is `no-referrer` |
+| VERIFIED | semantic baseline | `header`, `main`, `footer`, labels, native controls, an `aria-live` copy status, and an `aria-label` on the generated prompt field are present |
+| HOLD | reduced motion | `prefers-reduced-motion` handling is absent while repeated animations are present |
+| HOLD | focus/keyboard | no explicit `:focus-visible`; some selection semantics are not conveyed with ARIA state |
+| HOLD | contrast | several computed foreground/background pairs are below 4.5:1 and require contextual visual review |
+| HOLD | screen-reader flow | dynamic receipt-card order and state announcements require assistive-technology testing |
+| HOLD | re-identification | local storage boundaries do not establish content anonymity; copied prompts can cross the local boundary |
+| HOLD | `HUMAN_REVIEW_HOLD` | keyboard, focus, contrast, reduced-motion, and screen-reader behavior were not interactively verified in a rendered provider artifact |
+
+NARRATIVE — Structural protection is not equivalent to content anonymity. The Grimm
+surface remains a narrative reading space and muse, not an evidence instance.
+
+## Authority and rollback
+
+DRAFT — All new code in this change is a non-executing projection. Rollback is a revert
+of the introducing commit, together with removal of its VOIDMAP evidence
+pointer. No deployment, publication, merge, Source-of-Truth promotion, runtime
+consumer, or canon change is performed.

--- a/docs/audit/2026-07-28_consolidation_reentry.md
+++ b/docs/audit/2026-07-28_consolidation_reentry.md
@@ -16,7 +16,7 @@ the date of this audit, and canon status are independent fields.
 | HOLD | Dependency PR #298 | `MAJOR_COMPATIBILITY_HOLD`; TypeScript 7 breaks lint/typecheck compatibility | PR #298 workflow logs | separate compatibility track |
 | HOLD | Dependency PR #339 | `MAJOR_COMPATIBILITY_HOLD`; ESLint 10 conflicts with `eslint-plugin-react@7.37.5` | PR #339 workflow logs | separate compatibility track |
 | HOLD | Security settings/advisories | repository settings-side CodeQL and Private Vulnerability Reporting posture not exposed by the connected evidence | open issue #332; last audit witness in PR #329 | Owner/settings verification |
-| VERIFIED | VOID-027 | `IN_PROGRESS`; receipt-link sublever addressed by a repo-relative receipt; remaining declared components stay open | `VOIDMAP.yml` and `receipts/2026-07-28_void027_bridge_view_v0_1.json` | validate in CI; do not close VOID |
+| VERIFIED | VOID-027 | `IN_PROGRESS`; stable repo-relative receipt evidence exists, but HUD receipt-link rendering and the remaining declared components stay open | `VOIDMAP.yml` and `receipts/2026-07-28_void027_bridge_view_v0_1.json` | validate in CI; do not close VOID |
 | HOLD | VOID-010/011 | overdue and still `IN_PROGRESS` | `VOIDMAP.yml`, issue #311 | scoped evidence review |
 | VERIFIED | Notion re-entry mirror | connected mirror records PRs #326–#331 and issues #332/#333; it explicitly defers authority to repo/VOIDMAP | Notion page `3a9a6554-a786-8105-a411-e5745c6319f5` | reference only |
 | HOLD | Linear | no matching entaENGELment project or issue was found in the connected workspace | connected Linear search | no issue creation without Owner choice |

--- a/docs/audit/2026-07-28_consolidation_reentry.md
+++ b/docs/audit/2026-07-28_consolidation_reentry.md
@@ -69,6 +69,11 @@ and rollbackable.
 VERIFIED — No additional diagram, calibration, or narrative extension is started by this
 change.
 
+HOLD — No separate canonical QDOT registry was verified in the inspected repo
+sources. QDOT statements in Drive document
+`1wsipMetHXM6y4Lo66amlh7Qph1z72zlt` remain historical reference and do not
+close or promote a repo entry.
+
 ## Connected Drive classification
 
 | Category | Primary class | Document ID | Internal document date | Drive upload / modified date | Rationale |

--- a/docs/audit/2026-07-28_consolidation_reentry.md
+++ b/docs/audit/2026-07-28_consolidation_reentry.md
@@ -53,12 +53,12 @@ change.
 
 | Category | Primary class | Document ID | Internal document date | Drive upload / modified date | Rationale |
 |---|---|---|---|---|---|
-| VERIFIED | WORKING_DRAFT | `1FakZrgPWLvJgTZevIXfm0rCnlVVROrtFT1taoUTGMlI` | 2026-07-22 | connected metadata | internal read-only shadow catalog; no authority |
+| VERIFIED | WORKING_DRAFT | `1FakZrgPWLvJgTZevIXfm0rCnlVVROrtFT1taoUTGMlI` | 2026-07-22 | 2026-07-22 created/modified | internal read-only shadow catalog; no authority |
 | HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1vXrSyu4o--5pA-FulYG46AEGUzVaOmOw` | 2026-05-20 | 2026-07-19 upload | upload map, not current repository state |
-| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1bRRzGSm7KXJE0CFviuQyfckkTWfrd1UG` | snapshot at `main@96bbdb9` | connected metadata | contradicts the current verified main SHA |
-| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1wsipMetHXM6y4Lo66amlh7Qph1z72zlt` | snapshot date in document | connected metadata | VOID/QDOT states are stale against `VOIDMAP.yml` |
-| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `14TTRVr7zbOdna1Z-cyorweQC4q_Moq3d` | 2026-07-25 | connected metadata | protected save state, but repo/PR snapshot is stale |
-| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1ku9YAmiYjkuk2rZkB9jDzM8xYT-pJce6` | 2026-01-26 | connected metadata | research indexer snapshot does not represent the current repo |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1bRRzGSm7KXJE0CFviuQyfckkTWfrd1UG` | snapshot at `main@96bbdb9` | 2026-07-19 created/modified | contradicts the current verified main SHA |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1wsipMetHXM6y4Lo66amlh7Qph1z72zlt` | snapshot date in document | 2026-07-19 created/modified | VOID/QDOT states are stale against `VOIDMAP.yml` |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `14TTRVr7zbOdna1Z-cyorweQC4q_Moq3d` | 2026-07-25 | 2026-07-26 created/modified | protected save state, but repo/PR snapshot is stale |
+| HISTORICAL_REFERENCE | HISTORICAL_REFERENCE | `1ku9YAmiYjkuk2rZkB9jDzM8xYT-pJce6` | 2026-01-26 | 2026-07-26 created/modified | research indexer snapshot does not represent the current repo |
 | HOLD | QUARANTINE_OVERCLAIM_REVIEW | `1GX8xBBudyNK0Im_EU_Rhpw5bBNbRuU-p` | 2025-12-16 | 2026-07-26 upload | quantitative, physical, biological, TRL, and “proof” language lacks a bound repo/lab evidence chain |
 | NARRATIVE | NARRATIVE_LAYER | `1lOW9L35WQ2KtWFdBXr_wZfKr7AHrQaAR` | date in document | 2026-07-19 upload | document self-labels model/Rosetta/guard/wordknot/narrative material and disclaims scientific proof |
 | NARRATIVE | NARRATIVE_LAYER | `10ySaVb8S2NnagB5L--jQ9V4kifv6EM2Q` | not treated as canon date | 2026-07-26 modified | private Grimm reading surface; not an evidence source |
@@ -66,6 +66,10 @@ change.
 HOLD — The classification creates no canon. Source-of-Truth admission still requires
 technical/content review, Claude/Diogenes review, explicit Owner decision,
 documented receipt, and a rollback path.
+
+HOLD — Drive metadata reported `source_visibility_status=access_not_verified`
+for these records. The primary class is a content/re-entry classification, not
+a sharing or confidentiality guarantee.
 
 ## Action-Gate boundary
 

--- a/docs/voids_backlog.md
+++ b/docs/voids_backlog.md
@@ -2,7 +2,7 @@
 
 > Auto-generated from `VOIDMAP.yml`. Do not edit by hand.
 > Regenerate via: `python3 tools/voids_backlog_gen.py`
-> Source `last_updated`: 2026-07-28
+> Source `last_updated`: 2026-07-29
 
 ## Summary
 

--- a/docs/voids_backlog.md
+++ b/docs/voids_backlog.md
@@ -2,7 +2,7 @@
 
 > Auto-generated from `VOIDMAP.yml`. Do not edit by hand.
 > Regenerate via: `python3 tools/voids_backlog_gen.py`
-> Source `last_updated`: 2026-07-22
+> Source `last_updated`: 2026-07-28
 
 ## Summary
 

--- a/receipts/2026-07-28_void027_bridge_view_v0_1.json
+++ b/receipts/2026-07-28_void027_bridge_view_v0_1.json
@@ -1,0 +1,38 @@
+{
+  "receipt_id": "rcpt-void-027-bridge-view-v0-1-20260728",
+  "schema_version": "receipt.v0.1",
+  "subject": "VOID-027",
+  "created_date": "2026-07-28",
+  "status": "IN_PROGRESS",
+  "evidence_category": "VERIFIED",
+  "scope": "Stable repo-relative receipt pointer and read-only BRIDGE_VIEW v0.1 projection only",
+  "artifact": {
+    "path": "docs/annex/BRIDGE_VIEW_v0_1.md",
+    "implementation": "src/core/bridge_view.py",
+    "tests": "tests/unit/test_bridge_view.py"
+  },
+  "effects": {
+    "claim_effect": "none",
+    "authority_effect": "none",
+    "promotion_effect": "none",
+    "runtime_effect": "none",
+    "canon_effect": "none",
+    "publication_effect": "none"
+  },
+  "does_not_prove": [
+    "VOID-027 is closed",
+    "the remaining 1xn, Apex, EFS/MVI, or decision-bar work is complete",
+    "any scientific, semantic, biological, or physical claim is true",
+    "any artifact is canon or Source of Truth"
+  ],
+  "validation": [
+    "python3 tools/verify_pointers.py --strict",
+    "pytest -q tests/unit/test_bridge_view.py"
+  ],
+  "human_review_required": true,
+  "promotion_eligibility": "none",
+  "rollback": {
+    "method": "Revert the introducing commit and remove this path from VOIDMAP.yml evidence in the same revert",
+    "preserve_history": true
+  }
+}

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -19,6 +19,12 @@ from .action_gate import (
     ResponsibilityClass,
     build_action_proposal,
 )
+from .bridge_view import (
+    BridgeView,
+    BridgeViewError,
+    BridgeViewReason,
+    project_bridge_view,
+)
 from .evidence_bridge_adapter import (
     BridgeAdapterError,
     BridgeContext,
@@ -99,4 +105,9 @@ __all__ = [
     "BridgeAdapterError",
     "validate_bridge_record",
     "translate_bridge_record",
+    # BRIDGE_VIEW v0.1 — reine, menschenlesbare Projektion
+    "BridgeView",
+    "BridgeViewReason",
+    "BridgeViewError",
+    "project_bridge_view",
 ]

--- a/src/core/bridge_view.py
+++ b/src/core/bridge_view.py
@@ -15,16 +15,25 @@ from pathlib import PurePosixPath
 from typing import Any, cast
 
 from .evidence_bridge_adapter import (
+    _REGISTER_ALLOWED_RELATIONS,
+    _REGISTER_MATERIAL_KIND,
+    BRIDGE_SCHEMA_VERSION,
     KNOWN_SOURCE_REGISTERS,
     M5_GATED_REGISTERS,
     NON_PROMOTING_REGISTERS,
+    BridgeContext,
     BridgeTranslation,
 )
 from .evidence_routing import (
+    ERK_SCHEMA_VERSION,
     KNOWN_TRUST_LEVELS,
+    NON_EVIDENCE_MATERIAL_KINDS,
     PROMOTION_CAPABLE_RELATION_TYPES,
     RELATION_TYPES,
     TRUST_UNTRUSTED,
+    ClaimCandidate,
+    EvidenceRelation,
+    MaterialRef,
 )
 
 BRIDGE_VIEW_SCHEMA_VERSION = "bridge_view.v0.1"
@@ -41,10 +50,14 @@ class BridgeViewReason(str, Enum):
     """Closed reason vocabulary for projection failures."""
 
     INVALID_TRANSLATION = "INVALID_TRANSLATION"
+    INVALID_NESTED_MODEL = "INVALID_NESTED_MODEL"
+    UNSUPPORTED_SCHEMA_VERSION = "UNSUPPORTED_SCHEMA_VERSION"
     NON_CANONICAL_ID = "NON_CANONICAL_ID"
     IDENTIFIER_MISMATCH = "IDENTIFIER_MISMATCH"
     UNKNOWN_RELATION = "UNKNOWN_RELATION"
+    RELATION_NOT_ALLOWED = "RELATION_NOT_ALLOWED"
     UNKNOWN_REGISTER = "UNKNOWN_REGISTER"
+    MATERIAL_KIND_MISMATCH = "MATERIAL_KIND_MISMATCH"
     STATUS_INVALID = "STATUS_INVALID"
     STATUS_MISMATCH = "STATUS_MISMATCH"
     TRUST_INVALID = "TRUST_INVALID"
@@ -164,6 +177,32 @@ def project_bridge_view(
             "translation must be a BridgeTranslation",
             BridgeViewReason.INVALID_TRANSLATION,
         )
+    if translation.schema_version != BRIDGE_SCHEMA_VERSION:
+        _fail(
+            "translation schema version is unsupported",
+            BridgeViewReason.UNSUPPORTED_SCHEMA_VERSION,
+        )
+    if (
+        type(translation.material) is not MaterialRef
+        or type(translation.relation) is not EvidenceRelation
+        or type(translation.context) is not BridgeContext
+        or (translation.claim is not None and type(translation.claim) is not ClaimCandidate)
+    ):
+        _fail(
+            "translation contains an invalid nested model",
+            BridgeViewReason.INVALID_NESTED_MODEL,
+        )
+    if (
+        translation.material.schema_version != ERK_SCHEMA_VERSION
+        or translation.relation.schema_version != ERK_SCHEMA_VERSION
+        or (
+            translation.claim is not None and translation.claim.schema_version != ERK_SCHEMA_VERSION
+        )
+    ):
+        _fail(
+            "nested ERK schema version is unsupported",
+            BridgeViewReason.UNSUPPORTED_SCHEMA_VERSION,
+        )
 
     source = _require_canonical_id(translation.material.material_id, label="source")
     # Material IDs are adapter-derived kebab-case IDs. Claim IDs are existing
@@ -192,6 +231,16 @@ def project_bridge_view(
     register = translation.context.source_register
     if type(register) is not str or register not in KNOWN_SOURCE_REGISTERS:
         _fail(f"unknown register: {register!r}", BridgeViewReason.UNKNOWN_REGISTER)
+    if relation not in _REGISTER_ALLOWED_RELATIONS[register]:
+        _fail(
+            f"relation {relation!r} is not allowed for register {register!r}",
+            BridgeViewReason.RELATION_NOT_ALLOWED,
+        )
+    if translation.material.kind != _REGISTER_MATERIAL_KIND[register]:
+        _fail(
+            "material kind contradicts the source register",
+            BridgeViewReason.MATERIAL_KIND_MISMATCH,
+        )
 
     status = _require_text(
         translation.relation.status,
@@ -275,6 +324,8 @@ def project_bridge_view(
         relation in PROMOTION_CAPABLE_RELATION_TYPES
         and register in M5_GATED_REGISTERS
         and trust != TRUST_UNTRUSTED
+        and translation.material.kind not in NON_EVIDENCE_MATERIAL_KINDS
+        and status == "ACTIVE"
     )
     if translation.promotion_capable is not expected_promotion_capable:
         _fail(

--- a/src/core/bridge_view.py
+++ b/src/core/bridge_view.py
@@ -1,0 +1,275 @@
+"""Read-only, fail-closed projection of an existing bridge translation.
+
+``BRIDGE_VIEW_v0.1`` does not read files, access the network, emit events,
+retag claims, authorize promotion, or mutate runtime state. It only renders
+fields that already exist on a :class:`BridgeTranslation` plus an explicit,
+repo-relative receipt pointer.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Any
+
+from .evidence_bridge_adapter import (
+    KNOWN_SOURCE_REGISTERS,
+    M5_GATED_REGISTERS,
+    NON_PROMOTING_REGISTERS,
+    BridgeTranslation,
+)
+from .evidence_routing import PROMOTION_CAPABLE_RELATION_TYPES, RELATION_TYPES
+
+BRIDGE_VIEW_SCHEMA_VERSION = "bridge_view.v0.1"
+PROMOTION_NOT_ELIGIBLE = "NOT_ELIGIBLE"
+PROMOTION_HUMAN_REVIEW = "ELIGIBLE_FOR_HUMAN_REVIEW"
+
+_CANONICAL_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$", re.ASCII)
+_CANONICAL_STATUS_RE = re.compile(r"^[A-Z][A-Z0-9_]*$", re.ASCII)
+_RECEIPT_SUFFIXES = frozenset({".json", ".md", ".yaml", ".yml"})
+
+
+class BridgeViewReason(str, Enum):
+    """Closed reason vocabulary for projection failures."""
+
+    INVALID_TRANSLATION = "INVALID_TRANSLATION"
+    NON_CANONICAL_ID = "NON_CANONICAL_ID"
+    IDENTIFIER_MISMATCH = "IDENTIFIER_MISMATCH"
+    UNKNOWN_RELATION = "UNKNOWN_RELATION"
+    UNKNOWN_REGISTER = "UNKNOWN_REGISTER"
+    STATUS_INVALID = "STATUS_INVALID"
+    STATUS_MISMATCH = "STATUS_MISMATCH"
+    KNOWN_LOSS_REQUIRED = "KNOWN_LOSS_REQUIRED"
+    REVIEW_POINTER_REQUIRED = "REVIEW_POINTER_REQUIRED"
+    POINTER_INVALID = "POINTER_INVALID"
+    PROMOTION_NOT_ALLOWED = "PROMOTION_NOT_ALLOWED"
+    ROLLBACK_REQUIRED = "ROLLBACK_REQUIRED"
+    RECEIPT_REQUIRED = "RECEIPT_REQUIRED"
+
+
+class BridgeViewError(ValueError):
+    """Fail-closed projection error with machine-readable reasons."""
+
+    def __init__(self, message: str, reasons: tuple[BridgeViewReason, ...]) -> None:
+        super().__init__(message)
+        self.reasons = reasons
+
+
+@dataclass(frozen=True)
+class BridgeView:
+    """Human-readable projection; never an authorization or promotion."""
+
+    schema_version: str
+    source: str
+    target: str
+    relation: str
+    register: str
+    status: str
+    known_loss: tuple[str, ...]
+    review_pointer: str | None
+    promotion_eligibility: str
+    rollback: str
+    receipt: str
+    complete: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source": self.source,
+            "target": self.target,
+            "relation": self.relation,
+            "register": self.register,
+            "status": self.status,
+            "known_loss": list(self.known_loss),
+            "review_pointer": self.review_pointer,
+            "promotion_eligibility": self.promotion_eligibility,
+            "rollback": self.rollback,
+            "receipt": self.receipt,
+            "complete": self.complete,
+        }
+
+
+def _fail(message: str, reason: BridgeViewReason) -> None:
+    raise BridgeViewError(message, (reason,))
+
+
+def _require_text(value: object, *, label: str, reason: BridgeViewReason) -> str:
+    if type(value) is not str or not value.strip() or value != value.strip():
+        _fail(f"{label} must be non-empty canonical text", reason)
+    return value
+
+
+def _require_canonical_id(value: object, *, label: str) -> str:
+    text = _require_text(value, label=label, reason=BridgeViewReason.NON_CANONICAL_ID)
+    if _CANONICAL_ID_RE.fullmatch(text) is None:
+        _fail(f"{label} is not a canonical kebab-case id", BridgeViewReason.NON_CANONICAL_ID)
+    return text
+
+
+def _require_repo_pointer(
+    value: object,
+    *,
+    label: str,
+    missing_reason: BridgeViewReason,
+    receipt: bool = False,
+) -> str:
+    text = _require_text(value, label=label, reason=missing_reason)
+    if "\\" in text or "://" in text:
+        _fail(f"{label} must be a repo-relative pointer", BridgeViewReason.POINTER_INVALID)
+
+    path_text, separator, fragment = text.partition("#")
+    if separator and (not fragment or "#" in fragment):
+        _fail(f"{label} has an invalid fragment", BridgeViewReason.POINTER_INVALID)
+    segments = path_text.split("/")
+    path = PurePosixPath(path_text)
+    if (
+        path.is_absolute()
+        or not path.name
+        or any(segment in {"", ".", ".."} for segment in segments)
+    ):
+        _fail(f"{label} must stay inside the repository", BridgeViewReason.POINTER_INVALID)
+    if receipt and (segments[0] != "receipts" or path.suffix not in _RECEIPT_SUFFIXES):
+        _fail(
+            "receipt must point into receipts/ with a supported text suffix",
+            BridgeViewReason.POINTER_INVALID,
+        )
+    return text
+
+
+def project_bridge_view(
+    translation: BridgeTranslation,
+    *,
+    receipt: str,
+) -> BridgeView:
+    """Project an already translated bridge record without side effects.
+
+    A return value is always complete. Missing or contradictory fields raise
+    ``BridgeViewError``; no partial view and no guessed downgrade is emitted.
+    """
+
+    if type(translation) is not BridgeTranslation:
+        _fail(
+            "translation must be a BridgeTranslation",
+            BridgeViewReason.INVALID_TRANSLATION,
+        )
+
+    source = _require_canonical_id(translation.material.material_id, label="source")
+    target = _require_canonical_id(translation.relation.claim_id, label="target")
+    if translation.relation.material_id != source:
+        _fail(
+            "relation material_id does not match projected source",
+            BridgeViewReason.IDENTIFIER_MISMATCH,
+        )
+    if translation.claim is not None and translation.claim.claim_id != target:
+        _fail(
+            "claim candidate id does not match projected target",
+            BridgeViewReason.IDENTIFIER_MISMATCH,
+        )
+
+    relation = translation.relation.relation_type
+    if type(relation) is not str or relation not in RELATION_TYPES:
+        _fail(f"unknown relation: {relation!r}", BridgeViewReason.UNKNOWN_RELATION)
+
+    register = translation.context.source_register
+    if type(register) is not str or register not in KNOWN_SOURCE_REGISTERS:
+        _fail(f"unknown register: {register!r}", BridgeViewReason.UNKNOWN_REGISTER)
+
+    status = _require_text(
+        translation.relation.status,
+        label="status",
+        reason=BridgeViewReason.STATUS_INVALID,
+    )
+    if _CANONICAL_STATUS_RE.fullmatch(status) is None:
+        _fail("status must use the canonical uppercase vocabulary", BridgeViewReason.STATUS_INVALID)
+    if translation.material.status != status:
+        _fail(
+            "material and relation status must match",
+            BridgeViewReason.STATUS_MISMATCH,
+        )
+
+    known_loss = translation.context.known_loss
+    if (
+        type(known_loss) is not tuple
+        or not known_loss
+        or not all(
+            type(item) is str and item.strip() and item == item.strip()
+            for item in known_loss
+        )
+    ):
+        _fail(
+            "known_loss must contain at least one canonical text item",
+            BridgeViewReason.KNOWN_LOSS_REQUIRED,
+        )
+
+    rollback = _require_text(
+        translation.context.rollback,
+        label="rollback",
+        reason=BridgeViewReason.ROLLBACK_REQUIRED,
+    )
+    receipt_pointer = _require_repo_pointer(
+        receipt,
+        label="receipt",
+        missing_reason=BridgeViewReason.RECEIPT_REQUIRED,
+        receipt=True,
+    )
+
+    review_pointer = translation.context.m5_review_pointer
+    if register in M5_GATED_REGISTERS and review_pointer is None:
+        _fail(
+            f"register {register!r} requires its documented review pointer",
+            BridgeViewReason.REVIEW_POINTER_REQUIRED,
+        )
+    if review_pointer is not None:
+        review_pointer = _require_repo_pointer(
+            review_pointer,
+            label="review_pointer",
+            missing_reason=BridgeViewReason.REVIEW_POINTER_REQUIRED,
+        )
+
+    if (
+        relation in PROMOTION_CAPABLE_RELATION_TYPES
+        and register not in M5_GATED_REGISTERS
+    ):
+        _fail(
+            f"register {register!r} may not project promotion eligibility",
+            BridgeViewReason.PROMOTION_NOT_ALLOWED,
+        )
+    if (
+        register in NON_PROMOTING_REGISTERS
+        and relation in PROMOTION_CAPABLE_RELATION_TYPES
+    ):
+        _fail(
+            f"register {register!r} is non-promoting",
+            BridgeViewReason.PROMOTION_NOT_ALLOWED,
+        )
+    if translation.promotion_capable and relation not in PROMOTION_CAPABLE_RELATION_TYPES:
+        _fail(
+            "promotion flag contradicts the relation vocabulary",
+            BridgeViewReason.PROMOTION_NOT_ALLOWED,
+        )
+    if translation.promotion_capable and register not in M5_GATED_REGISTERS:
+        _fail(
+            "promotion flag would create authority outside the reviewed registers",
+            BridgeViewReason.PROMOTION_NOT_ALLOWED,
+        )
+
+    promotion_eligibility = (
+        PROMOTION_HUMAN_REVIEW
+        if translation.promotion_capable
+        else PROMOTION_NOT_ELIGIBLE
+    )
+    return BridgeView(
+        schema_version=BRIDGE_VIEW_SCHEMA_VERSION,
+        source=source,
+        target=target,
+        relation=relation,
+        register=register,
+        status=status,
+        known_loss=known_loss,
+        review_pointer=review_pointer,
+        promotion_eligibility=promotion_eligibility,
+        rollback=rollback,
+        receipt=receipt_pointer,
+    )

--- a/src/core/bridge_view.py
+++ b/src/core/bridge_view.py
@@ -104,7 +104,10 @@ def _require_text(value: object, *, label: str, reason: BridgeViewReason) -> str
 def _require_canonical_id(value: object, *, label: str) -> str:
     text = _require_text(value, label=label, reason=BridgeViewReason.NON_CANONICAL_ID)
     if _CANONICAL_ID_RE.fullmatch(text) is None:
-        _fail(f"{label} is not a canonical kebab-case id", BridgeViewReason.NON_CANONICAL_ID)
+        _fail(
+            f"{label} is not a canonical kebab-case id",
+            BridgeViewReason.NON_CANONICAL_ID,
+        )
     return text
 
 
@@ -117,7 +120,9 @@ def _require_repo_pointer(
 ) -> str:
     text = _require_text(value, label=label, reason=missing_reason)
     if "\\" in text or "://" in text:
-        _fail(f"{label} must be a repo-relative pointer", BridgeViewReason.POINTER_INVALID)
+        _fail(
+            f"{label} must be a repo-relative pointer", BridgeViewReason.POINTER_INVALID
+        )
 
     path_text, separator, fragment = text.partition("#")
     if separator and (not fragment or "#" in fragment):
@@ -129,7 +134,9 @@ def _require_repo_pointer(
         or not path.name
         or any(segment in {"", ".", ".."} for segment in segments)
     ):
-        _fail(f"{label} must stay inside the repository", BridgeViewReason.POINTER_INVALID)
+        _fail(
+            f"{label} must stay inside the repository", BridgeViewReason.POINTER_INVALID
+        )
     if receipt and (segments[0] != "receipts" or path.suffix not in _RECEIPT_SUFFIXES):
         _fail(
             "receipt must point into receipts/ with a supported text suffix",
@@ -182,7 +189,10 @@ def project_bridge_view(
         reason=BridgeViewReason.STATUS_INVALID,
     )
     if _CANONICAL_STATUS_RE.fullmatch(status) is None:
-        _fail("status must use the canonical uppercase vocabulary", BridgeViewReason.STATUS_INVALID)
+        _fail(
+            "status must use the canonical uppercase vocabulary",
+            BridgeViewReason.STATUS_INVALID,
+        )
     if translation.material.status != status:
         _fail(
             "material and relation status must match",
@@ -244,7 +254,10 @@ def project_bridge_view(
             f"register {register!r} is non-promoting",
             BridgeViewReason.PROMOTION_NOT_ALLOWED,
         )
-    if translation.promotion_capable and relation not in PROMOTION_CAPABLE_RELATION_TYPES:
+    if (
+        translation.promotion_capable
+        and relation not in PROMOTION_CAPABLE_RELATION_TYPES
+    ):
         _fail(
             "promotion flag contradicts the relation vocabulary",
             BridgeViewReason.PROMOTION_NOT_ALLOWED,

--- a/src/core/bridge_view.py
+++ b/src/core/bridge_view.py
@@ -12,7 +12,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Any
+from typing import Any, cast
 
 from .evidence_bridge_adapter import (
     KNOWN_SOURCE_REGISTERS,
@@ -98,7 +98,7 @@ def _fail(message: str, reason: BridgeViewReason) -> None:
 def _require_text(value: object, *, label: str, reason: BridgeViewReason) -> str:
     if type(value) is not str or not value.strip() or value != value.strip():
         _fail(f"{label} must be non-empty canonical text", reason)
-    return value
+    return cast(str, value)
 
 
 def _require_canonical_id(value: object, *, label: str) -> str:

--- a/src/core/bridge_view.py
+++ b/src/core/bridge_view.py
@@ -120,9 +120,7 @@ def _require_repo_pointer(
 ) -> str:
     text = _require_text(value, label=label, reason=missing_reason)
     if "\\" in text or "://" in text:
-        _fail(
-            f"{label} must be a repo-relative pointer", BridgeViewReason.POINTER_INVALID
-        )
+        _fail(f"{label} must be a repo-relative pointer", BridgeViewReason.POINTER_INVALID)
 
     path_text, separator, fragment = text.partition("#")
     if separator and (not fragment or "#" in fragment):
@@ -134,9 +132,7 @@ def _require_repo_pointer(
         or not path.name
         or any(segment in {"", ".", ".."} for segment in segments)
     ):
-        _fail(
-            f"{label} must stay inside the repository", BridgeViewReason.POINTER_INVALID
-        )
+        _fail(f"{label} must stay inside the repository", BridgeViewReason.POINTER_INVALID)
     if receipt and (segments[0] != "receipts" or path.suffix not in _RECEIPT_SUFFIXES):
         _fail(
             "receipt must point into receipts/ with a supported text suffix",
@@ -204,8 +200,7 @@ def project_bridge_view(
         type(known_loss) is not tuple
         or not known_loss
         or not all(
-            type(item) is str and item.strip() and item == item.strip()
-            for item in known_loss
+            type(item) is str and item.strip() and item == item.strip() for item in known_loss
         )
     ):
         _fail(
@@ -238,26 +233,17 @@ def project_bridge_view(
             missing_reason=BridgeViewReason.REVIEW_POINTER_REQUIRED,
         )
 
-    if (
-        relation in PROMOTION_CAPABLE_RELATION_TYPES
-        and register not in M5_GATED_REGISTERS
-    ):
+    if relation in PROMOTION_CAPABLE_RELATION_TYPES and register not in M5_GATED_REGISTERS:
         _fail(
             f"register {register!r} may not project promotion eligibility",
             BridgeViewReason.PROMOTION_NOT_ALLOWED,
         )
-    if (
-        register in NON_PROMOTING_REGISTERS
-        and relation in PROMOTION_CAPABLE_RELATION_TYPES
-    ):
+    if register in NON_PROMOTING_REGISTERS and relation in PROMOTION_CAPABLE_RELATION_TYPES:
         _fail(
             f"register {register!r} is non-promoting",
             BridgeViewReason.PROMOTION_NOT_ALLOWED,
         )
-    if (
-        translation.promotion_capable
-        and relation not in PROMOTION_CAPABLE_RELATION_TYPES
-    ):
+    if translation.promotion_capable and relation not in PROMOTION_CAPABLE_RELATION_TYPES:
         _fail(
             "promotion flag contradicts the relation vocabulary",
             BridgeViewReason.PROMOTION_NOT_ALLOWED,
@@ -269,9 +255,7 @@ def project_bridge_view(
         )
 
     promotion_eligibility = (
-        PROMOTION_HUMAN_REVIEW
-        if translation.promotion_capable
-        else PROMOTION_NOT_ELIGIBLE
+        PROMOTION_HUMAN_REVIEW if translation.promotion_capable else PROMOTION_NOT_ELIGIBLE
     )
     return BridgeView(
         schema_version=BRIDGE_VIEW_SCHEMA_VERSION,

--- a/src/core/bridge_view.py
+++ b/src/core/bridge_view.py
@@ -20,7 +20,12 @@ from .evidence_bridge_adapter import (
     NON_PROMOTING_REGISTERS,
     BridgeTranslation,
 )
-from .evidence_routing import PROMOTION_CAPABLE_RELATION_TYPES, RELATION_TYPES
+from .evidence_routing import (
+    KNOWN_TRUST_LEVELS,
+    PROMOTION_CAPABLE_RELATION_TYPES,
+    RELATION_TYPES,
+    TRUST_UNTRUSTED,
+)
 
 BRIDGE_VIEW_SCHEMA_VERSION = "bridge_view.v0.1"
 PROMOTION_NOT_ELIGIBLE = "NOT_ELIGIBLE"
@@ -28,6 +33,7 @@ PROMOTION_HUMAN_REVIEW = "ELIGIBLE_FOR_HUMAN_REVIEW"
 
 _CANONICAL_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)+$", re.ASCII)
 _CANONICAL_STATUS_RE = re.compile(r"^[A-Z][A-Z0-9_]*$", re.ASCII)
+_URI_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.-]*:", re.ASCII)
 _RECEIPT_SUFFIXES = frozenset({".json", ".md", ".yaml", ".yml"})
 
 
@@ -41,6 +47,7 @@ class BridgeViewReason(str, Enum):
     UNKNOWN_REGISTER = "UNKNOWN_REGISTER"
     STATUS_INVALID = "STATUS_INVALID"
     STATUS_MISMATCH = "STATUS_MISMATCH"
+    TRUST_INVALID = "TRUST_INVALID"
     KNOWN_LOSS_REQUIRED = "KNOWN_LOSS_REQUIRED"
     REVIEW_POINTER_REQUIRED = "REVIEW_POINTER_REQUIRED"
     POINTER_INVALID = "POINTER_INVALID"
@@ -119,7 +126,7 @@ def _require_repo_pointer(
     receipt: bool = False,
 ) -> str:
     text = _require_text(value, label=label, reason=missing_reason)
-    if "\\" in text or "://" in text:
+    if "\\" in text or "://" in text or _URI_SCHEME_RE.match(text):
         _fail(f"{label} must be a repo-relative pointer", BridgeViewReason.POINTER_INVALID)
 
     path_text, separator, fragment = text.partition("#")
@@ -159,7 +166,14 @@ def project_bridge_view(
         )
 
     source = _require_canonical_id(translation.material.material_id, label="source")
-    target = _require_canonical_id(translation.relation.claim_id, label="target")
+    # Material IDs are adapter-derived kebab-case IDs. Claim IDs are existing
+    # stable ERK identifiers and intentionally retain the adapter's broader
+    # non-empty, whitespace-trimmed vocabulary.
+    target = _require_text(
+        translation.relation.claim_id,
+        label="target",
+        reason=BridgeViewReason.NON_CANONICAL_ID,
+    )
     if translation.relation.material_id != source:
         _fail(
             "relation material_id does not match projected source",
@@ -251,6 +265,20 @@ def project_bridge_view(
     if translation.promotion_capable and register not in M5_GATED_REGISTERS:
         _fail(
             "promotion flag would create authority outside the reviewed registers",
+            BridgeViewReason.PROMOTION_NOT_ALLOWED,
+        )
+
+    trust = translation.material.trust
+    if type(trust) is not str or trust not in KNOWN_TRUST_LEVELS:
+        _fail("material trust is not canonical", BridgeViewReason.TRUST_INVALID)
+    expected_promotion_capable = (
+        relation in PROMOTION_CAPABLE_RELATION_TYPES
+        and register in M5_GATED_REGISTERS
+        and trust != TRUST_UNTRUSTED
+    )
+    if translation.promotion_capable is not expected_promotion_capable:
+        _fail(
+            "promotion flag contradicts relation, register, or material trust",
             BridgeViewReason.PROMOTION_NOT_ALLOWED,
         )
 

--- a/tests/unit/test_bridge_view.py
+++ b/tests/unit/test_bridge_view.py
@@ -43,7 +43,7 @@ def assert_reason(excinfo, reason):
     assert reason in excinfo.value.reasons
 
 
-def test_complete_valid_record_is_projected_without_promotion():
+def test_complete_valid_record_is_projected_for_human_review():
     view = project_bridge_view(make_translation(), receipt=RECEIPT)
 
     assert view.complete is True

--- a/tests/unit/test_bridge_view.py
+++ b/tests/unit/test_bridge_view.py
@@ -11,7 +11,7 @@ from src.core.bridge_view import (
     project_bridge_view,
 )
 from src.core.evidence_bridge_adapter import BridgeRecord, translate_bridge_record
-from src.core.evidence_routing import TRUST_REVIEWED
+from src.core.evidence_routing import TRUST_REVIEWED, TRUST_UNTRUSTED
 
 RECEIPT = "receipts/2026-07-28_void027_bridge_view_v0_1.json"
 
@@ -93,6 +93,15 @@ def test_noncanonical_id_is_rejected():
     assert_reason(excinfo, BridgeViewReason.NON_CANONICAL_ID)
 
 
+def test_existing_target_id_vocabulary_is_preserved():
+    view = project_bridge_view(
+        make_translation(claim_id="clm-A"),
+        receipt=RECEIPT,
+    )
+
+    assert view.target == "clm-A"
+
+
 def test_impermissible_promotion_is_rejected():
     translation = make_translation(
         source_register="formal",
@@ -104,6 +113,27 @@ def test_impermissible_promotion_is_rejected():
         relation=replace(translation.relation, relation_type="SUPPORTS"),
         promotion_capable=True,
     )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.PROMOTION_NOT_ALLOWED)
+
+
+def test_untrusted_material_cannot_claim_review_eligibility():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        material=replace(translation.material, trust=TRUST_UNTRUSTED),
+        promotion_capable=True,
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.PROMOTION_NOT_ALLOWED)
+
+
+def test_promotion_flag_must_match_reviewed_material():
+    translation = replace(make_translation(), promotion_capable=False)
 
     with pytest.raises(BridgeViewError) as excinfo:
         project_bridge_view(translation, receipt=RECEIPT)
@@ -130,3 +160,26 @@ def test_rollback_and_receipt_references_are_preserved_exactly():
 
     assert view.rollback == "revert commit abc123 and retain its history"
     assert view.receipt == RECEIPT
+
+
+@pytest.mark.parametrize(
+    "review_pointer",
+    [
+        "C:/outside/review.md",
+        "file:/etc/review.md",
+        "https:example.com/review.md",
+    ],
+)
+def test_uri_like_review_pointer_is_rejected(review_pointer):
+    translation = make_translation()
+    translation = replace(
+        translation,
+        context=replace(
+            translation.context,
+            m5_review_pointer=review_pointer,
+        ),
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.POINTER_INVALID)

--- a/tests/unit/test_bridge_view.py
+++ b/tests/unit/test_bridge_view.py
@@ -53,10 +53,7 @@ def test_complete_valid_record_is_projected_for_human_review():
     assert view.register == "physical"
     assert view.status == "ACTIVE"
     assert view.known_loss == ("raw samples are not included",)
-    assert (
-        view.review_pointer
-        == "docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md#m5-review"
-    )
+    assert view.review_pointer == "docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md#m5-review"
     assert view.promotion_eligibility == PROMOTION_HUMAN_REVIEW
 
 

--- a/tests/unit/test_bridge_view.py
+++ b/tests/unit/test_bridge_view.py
@@ -29,7 +29,7 @@ def make_record(**overrides):
         "falsifier": "the documented ordering cannot be reproduced",
         "rollback": "revert the introducing commit and withdraw the receipt",
         "claim_id": "clm-existing-001",
-        "m5_review_pointer": "docs/reviews/m5-bridge-001.md",
+        "m5_review_pointer": "docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md#m5-review",
     }
     data.update(overrides)
     return BridgeRecord(**data)
@@ -53,7 +53,10 @@ def test_complete_valid_record_is_projected_for_human_review():
     assert view.register == "physical"
     assert view.status == "ACTIVE"
     assert view.known_loss == ("raw samples are not included",)
-    assert view.review_pointer == "docs/reviews/m5-bridge-001.md"
+    assert (
+        view.review_pointer
+        == "docs/annex/DUAL_FORMAT_CLAIM_BRIDGE_ADAPTER_v0_1.md#m5-review"
+    )
     assert view.promotion_eligibility == PROMOTION_HUMAN_REVIEW
 
 

--- a/tests/unit/test_bridge_view.py
+++ b/tests/unit/test_bridge_view.py
@@ -1,0 +1,132 @@
+"""Unit tests for the read-only BRIDGE_VIEW v0.1 projection."""
+
+from dataclasses import replace
+
+import pytest
+
+from src.core.bridge_view import (
+    PROMOTION_HUMAN_REVIEW,
+    BridgeViewError,
+    BridgeViewReason,
+    project_bridge_view,
+)
+from src.core.evidence_bridge_adapter import BridgeRecord, translate_bridge_record
+from src.core.evidence_routing import TRUST_REVIEWED
+
+RECEIPT = "receipts/2026-07-28_void027_bridge_view_v0_1.json"
+
+
+def make_record(**overrides):
+    data = {
+        "bridge_id": "brg-view-001",
+        "source_register": "physical",
+        "source_pointer": "fixtures/bridge/source-001.json",
+        "source_digest": "sha256:00",
+        "transferred_property": "measured ordering",
+        "preserved_relation": "ordering remains visible",
+        "relation_type": "SUPPORTS",
+        "known_loss": ["raw samples are not included"],
+        "falsifier": "the documented ordering cannot be reproduced",
+        "rollback": "revert the introducing commit and withdraw the receipt",
+        "claim_id": "clm-existing-001",
+        "m5_review_pointer": "docs/reviews/m5-bridge-001.md",
+    }
+    data.update(overrides)
+    return BridgeRecord(**data)
+
+
+def make_translation(**overrides):
+    return translate_bridge_record(make_record(**overrides), trust=TRUST_REVIEWED)
+
+
+def assert_reason(excinfo, reason):
+    assert reason in excinfo.value.reasons
+
+
+def test_complete_valid_record_is_projected_without_promotion():
+    view = project_bridge_view(make_translation(), receipt=RECEIPT)
+
+    assert view.complete is True
+    assert view.source.startswith("mat-bridge-")
+    assert view.target == "clm-existing-001"
+    assert view.relation == "SUPPORTS"
+    assert view.register == "physical"
+    assert view.status == "ACTIVE"
+    assert view.known_loss == ("raw samples are not included",)
+    assert view.review_pointer == "docs/reviews/m5-bridge-001.md"
+    assert view.promotion_eligibility == PROMOTION_HUMAN_REVIEW
+
+
+def test_missing_known_loss_fails_closed():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        context=replace(translation.context, known_loss=()),
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.KNOWN_LOSS_REQUIRED)
+
+
+def test_unknown_relation_is_not_guessed():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        relation=replace(translation.relation, relation_type="PROVES"),
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.UNKNOWN_RELATION)
+
+
+def test_noncanonical_id_is_rejected():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        material=replace(translation.material, material_id="Material 01"),
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.NON_CANONICAL_ID)
+
+
+def test_impermissible_promotion_is_rejected():
+    translation = make_translation(
+        source_register="formal",
+        relation_type="CONTEXTUALIZES",
+        m5_review_pointer=None,
+    )
+    translation = replace(
+        translation,
+        relation=replace(translation.relation, relation_type="SUPPORTS"),
+        promotion_capable=True,
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.PROMOTION_NOT_ALLOWED)
+
+
+def test_missing_review_pointer_is_not_silently_downgraded():
+    translation = make_translation(
+        relation_type="CONTEXTUALIZES",
+        m5_review_pointer=None,
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.REVIEW_POINTER_REQUIRED)
+
+
+def test_rollback_and_receipt_references_are_preserved_exactly():
+    translation = make_translation(
+        rollback="revert commit abc123 and retain its history",
+    )
+
+    view = project_bridge_view(translation, receipt=RECEIPT)
+
+    assert view.rollback == "revert commit abc123 and retain its history"
+    assert view.receipt == RECEIPT

--- a/tests/unit/test_bridge_view.py
+++ b/tests/unit/test_bridge_view.py
@@ -81,6 +81,19 @@ def test_unknown_relation_is_not_guessed():
     assert_reason(excinfo, BridgeViewReason.UNKNOWN_RELATION)
 
 
+def test_relation_must_be_allowed_for_register():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        relation=replace(translation.relation, relation_type="CONTRADICTS"),
+        promotion_capable=False,
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.RELATION_NOT_ALLOWED)
+
+
 def test_noncanonical_id_is_rejected():
     translation = make_translation()
     translation = replace(
@@ -93,6 +106,34 @@ def test_noncanonical_id_is_rejected():
     assert_reason(excinfo, BridgeViewReason.NON_CANONICAL_ID)
 
 
+def test_nested_models_are_validated_before_dereference():
+    translation = replace(make_translation(), material=None)
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.INVALID_NESTED_MODEL)
+
+
+def test_source_schema_versions_must_match_projection_contract():
+    translation = make_translation()
+    variants = (
+        replace(translation, schema_version="bridge.v9"),
+        replace(
+            translation,
+            material=replace(translation.material, schema_version="erk.v9"),
+        ),
+        replace(
+            translation,
+            relation=replace(translation.relation, schema_version="erk.v9"),
+        ),
+    )
+
+    for variant in variants:
+        with pytest.raises(BridgeViewError) as excinfo:
+            project_bridge_view(variant, receipt=RECEIPT)
+        assert_reason(excinfo, BridgeViewReason.UNSUPPORTED_SCHEMA_VERSION)
+
+
 def test_existing_target_id_vocabulary_is_preserved():
     view = project_bridge_view(
         make_translation(claim_id="clm-A"),
@@ -102,7 +143,7 @@ def test_existing_target_id_vocabulary_is_preserved():
     assert view.target == "clm-A"
 
 
-def test_impermissible_promotion_is_rejected():
+def test_impermissible_promotion_relation_is_rejected():
     translation = make_translation(
         source_register="formal",
         relation_type="CONTEXTUALIZES",
@@ -116,7 +157,7 @@ def test_impermissible_promotion_is_rejected():
 
     with pytest.raises(BridgeViewError) as excinfo:
         project_bridge_view(translation, receipt=RECEIPT)
-    assert_reason(excinfo, BridgeViewReason.PROMOTION_NOT_ALLOWED)
+    assert_reason(excinfo, BridgeViewReason.RELATION_NOT_ALLOWED)
 
 
 def test_untrusted_material_cannot_claim_review_eligibility():
@@ -134,6 +175,32 @@ def test_untrusted_material_cannot_claim_review_eligibility():
 
 def test_promotion_flag_must_match_reviewed_material():
     translation = replace(make_translation(), promotion_capable=False)
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.PROMOTION_NOT_ALLOWED)
+
+
+def test_material_kind_must_match_source_register():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        material=replace(translation.material, kind="metaphor"),
+    )
+
+    with pytest.raises(BridgeViewError) as excinfo:
+        project_bridge_view(translation, receipt=RECEIPT)
+    assert_reason(excinfo, BridgeViewReason.MATERIAL_KIND_MISMATCH)
+
+
+def test_inactive_material_cannot_claim_review_eligibility():
+    translation = make_translation()
+    translation = replace(
+        translation,
+        material=replace(translation.material, status="RETRACTED"),
+        relation=replace(translation.relation, status="RETRACTED"),
+        promotion_capable=True,
+    )
 
     with pytest.raises(BridgeViewError) as excinfo:
         project_bridge_view(translation, receipt=RECEIPT)


### PR DESCRIPTION
## Status

**VERIFIED** — Owner-reviewed; merge authorized after current-head checks. No deployment, publication, canonization, or runtime consumer.

## VERIFIED basis

- `main` at `eade3b7726dfa70b9d226f8ba3421aa1012edb2f` before this branch.
- PR #321 exact-version parsing uses complete npm SemVer 2.0.0 and conservative PyPI PEP 440 public-version grammars; its target review thread is resolved separately.
- VOID-027 is `IN_PROGRESS`; only its missing receipt-link sublever is addressed here.
- PR #334 is separate and remains Owner-controlled.

## VERIFIED changes

- Add `BRIDGE_VIEW_v0.1`, a pure read-only projection of existing `BridgeTranslation` records.
- Fail closed on missing `known_loss`, unknown relations/registers, noncanonical IDs, forbidden promotion, missing physical/biological review pointer, and invalid receipt/rollback references.
- Add a stable repo-relative VOID-027 receipt and keep VOID-027 `IN_PROGRESS` for 1xn, Apex, calibrated EFS/MVI, and decision-bar work.
- Document `PROPOSE != AUTHORIZE` and `PROPOSE != EXECUTE`; retain all consumer/runtime/deployment re-entry points as `HOLD`.
- Record the verified repo/dependency/Drive/accessibility state in `docs/audit/2026-07-28_consolidation_reentry.md`.

## Verification

- [x] Local focused suite: 7/7 projection scenarios; Ruff, Black 24.10, and Mypy green
- [x] Receipt JSON parses and remains repo-relative
- [x] GitHub CI: all observed workflows successful on head `9ffbf8a`
- [x] DeepJump pointer, receipt, claim, port, test, and snapshot checks successful
- [x] Human review of accessibility items marked `HUMAN_REVIEW_HOLD`

## Review follow-up

- [x] Reject URI-/drive-prefixed review pointers
- [x] Enforce material-trust consistency before showing review eligibility
- [x] Preserve the adapter's existing target-ID vocabulary
- [x] Keep VOID-027 receipt-link rendering open until the HUD exposes it

## Risk and authority

**HOLD** — no executing Action-Gate consumer, network access, event emission, retagging, automatic promotion, ledger/UI coupling, install path, or deployment path is introduced. The `VOIDMAP.yml` GOLD-path edit is limited to the explicitly requested receipt-link sublever.

## Rollback

Revert this branch's commits and remove the new receipt pointer from `VOIDMAP.yml` in the same revert. Preserve Git history; do not rewrite `main`.