### PR TITLE
fix(fractalsense): ResonanceEnhancer-Testanwendung wieder lauffähig machen

### DIFF
--- a/Fractalsense/color_generator.py
+++ b/Fractalsense/color_generator.py
@@ -219,6 +219,19 @@ class ColorGenerator:
             "mereotopological", mereotopological_colors
         )
 
+    def get_colormap(self, name: str):
+        """Gibt eine benutzerdefinierte Farbkarte zurück.
+
+        Args:
+            name: Name der Farbkarte
+
+        Returns:
+            LinearSegmentedColormap | None: Die Farbkarte, oder None wenn unter diesem
+            Namen keine benutzerdefinierte Farbkarte registriert ist. Aufrufer können
+            in dem Fall auf eine Matplotlib-Farbkarte zurückfallen.
+        """
+        return self.custom_colormaps.get(name)
+
     def create_dynamic_colormap(
         self, base_hsv: tuple[float, float, float], shift_factor: float, name: str = "dynamic"
     ) -> LinearSegmentedColormap:

--- a/Fractalsense/sound_generator.py
+++ b/Fractalsense/sound_generator.py
@@ -408,7 +408,11 @@ class SoundGenerator:
         self.current_thread.start()
 
     def stop_sound(self) -> None:
-        """Stoppt den aktuell abgespielten Sound."""
-        if pygame is not None:
+        """Stoppt den aktuell abgespielten Sound.
+
+        Ist der Mixer nie initialisiert worden (kein Audiogerät, headless), gibt es
+        nichts zu stoppen — pygame.mixer.stop() würde dann werfen.
+        """
+        if pygame is not None and pygame.mixer.get_init() is not None:
             pygame.mixer.stop()
         self.is_playing = False

--- a/Fractalsense/test_resonance.py
+++ b/Fractalsense/test_resonance.py
@@ -373,5 +373,26 @@ class TestApp:
     
     def on_send_sensor_data(self):
         """Event-Handler für den Sensordaten-senden-Button."""
-        # TODO: Implement sensor data sending
-        pass
+        # Aktuelle Slider-Werte als Sensordaten einsammeln
+        sensor_data = {
+            "accel_x": self.accel_x_var.get(),
+            "accel_y": self.accel_y_var.get(),
+            "accel_z": self.accel_z_var.get(),
+            "gyro_x": self.gyro_x_var.get(),
+            "gyro_y": self.gyro_y_var.get(),
+            "gyro_z": self.gyro_z_var.get(),
+        }
+
+        # Event senden — integration.py mappt daraus die Resonanz-Parameter
+        self.event_system.emit_event("sensor_data_updated", sensor_data)
+
+        accel_magnitude = (
+            sensor_data["accel_x"] ** 2 + sensor_data["accel_y"] ** 2 + sensor_data["accel_z"] ** 2
+        ) ** 0.5
+        gyro_magnitude = (
+            sensor_data["gyro_x"] ** 2 + sensor_data["gyro_y"] ** 2 + sensor_data["gyro_z"] ** 2
+        ) ** 0.5
+
+        self.status_label.config(
+            text=f"Sensordaten gesendet (|a|={accel_magnitude:.2f}, |ω|={gyro_magnitude:.2f})"
+        )

--- a/Fractalsense/test_resonance.py
+++ b/Fractalsense/test_resonance.py
@@ -286,12 +286,51 @@ class TestApp:
         })
         self.status_label.config(text=f"Lautstärke auf {volume:.2f} gesetzt")
     
+    def _ensure_audio_ready(self):
+        """Initialisiert den pygame-Mixer, falls noch nicht geschehen.
+
+        Returns:
+            bool: True, wenn Audio verfügbar ist. False, wenn kein Audiogerät
+            existiert (headless/CI) — die Handler überspringen dann die Wiedergabe,
+            statt die UI mit einer Exception abzubrechen.
+        """
+        if pygame.mixer.get_init() is not None:
+            return True
+
+        try:
+            pygame.mixer.init(frequency=44100, size=-16, channels=1, buffer=1024)
+        except pygame.error as exc:
+            print(f"Audio nicht verfügbar: {exc}")
+            return False
+
+        return True
+
+    def _render_colormap(self, cmap, title):
+        """Zeichnet eine Farbkarte als Gradient in die Matplotlib-Achse.
+
+        Args:
+            cmap: Anzuzeigende Farbkarte
+            title: Titel über der Achse
+        """
+        self.ax.clear()
+
+        gradient = np.linspace(0, 1, 256)
+        gradient = np.vstack((gradient, gradient))
+
+        self.ax.imshow(gradient, aspect='auto', cmap=cmap)
+        self.ax.set_title(title)
+        self.ax.set_yticks([])
+        self.ax.set_xticks([])
+
+        self.canvas.draw()
+
     def on_test_sound(self):
         """Event-Handler für den Testton-Button."""
         # Erzeuge einen Testton mit dem SoundGenerator
-        if pygame.mixer.get_init() is None:
-            pygame.mixer.init(frequency=44100, size=-16, channels=1, buffer=1024)
-        
+        if not self._ensure_audio_ready():
+            self.status_label.config(text="Audio nicht verfügbar — kein Testton")
+            return
+
         # Erzeuge verschiedene Testtöne je nach ausgewähltem Modus
         if hasattr(self, 'test_sound_mode'):
             self.test_sound_mode = (self.test_sound_mode + 1) % 5
@@ -343,27 +382,14 @@ class TestApp:
     def on_show_colormap(self):
         """Event-Handler für den Farbkarte-anzeigen-Button."""
         color_mode = self.color_mode_var.get()
-        
-        # Achse leeren
-        self.ax.clear()
-        
-        # Farbkarte abrufen
+
+        # Farbkarte abrufen — Fallback auf die Matplotlib-Farbkarte gleichen Namens
         cmap = self.color_generator.get_colormap(color_mode)
         if cmap is None:
             cmap = plt.get_cmap(color_mode)
-        
-        # Farbkarte anzeigen
-        gradient = np.linspace(0, 1, 256)
-        gradient = np.vstack((gradient, gradient))
-        
-        self.ax.imshow(gradient, aspect='auto', cmap=cmap)
-        self.ax.set_title(f"Farbkarte: {color_mode}")
-        self.ax.set_yticks([])
-        self.ax.set_xticks([])
-        
-        # Canvas aktualisieren
-        self.canvas.draw()
-        
+
+        self._render_colormap(cmap, f"Farbkarte: {color_mode}")
+
         self.status_label.config(text=f"Farbkarte '{color_mode}' angezeigt")
     
     def on_sensor_changed(self, event):
@@ -396,3 +422,118 @@ class TestApp:
         self.status_label.config(
             text=f"Sensordaten gesendet (|a|={accel_magnitude:.2f}, |ω|={gyro_magnitude:.2f})"
         )
+
+    def on_fractal_changed(self, event):
+        """Event-Handler für Änderungen an den Fraktal-Parametern."""
+        # Fraktaldaten werden erst beim Klicken auf den Button gesendet
+        pass
+
+    def on_send_fractal_data(self):
+        """Event-Handler für den Fraktaldaten-senden-Button."""
+        center = complex(self.center_real_var.get(), self.center_imag_var.get())
+        zoom = self.zoom_var.get()
+
+        # Event senden — integration.py leitet daraus die Klangparameter ab
+        self.event_system.emit_event("fractal_updated", {"center": center, "zoom": zoom})
+
+        self.status_label.config(
+            text=(
+                f"Fraktaldaten gesendet (Zentrum={center.real:.2f}{center.imag:+.2f}i, "
+                f"Zoom={zoom:.2f})"
+            )
+        )
+
+    def on_colormap_updated(self, event_type, event_data):
+        """Event-Handler für aktualisierte Farbkarten.
+
+        Args:
+            event_type: Typ des Events
+            event_data: Event-Daten
+        """
+        colormap = event_data.get("colormap", self.color_mode_var.get())
+
+        # UI-Auswahl nachziehen und Farbkarte anzeigen
+        self.color_mode_var.set(colormap)
+        self.on_show_colormap()
+
+        self.status_label.config(text=f"Farbkarte '{colormap}' aus Event übernommen")
+
+    def on_generate_fractal_sound(self, event_type, event_data):
+        """Event-Handler für die fraktale Klangerzeugung.
+
+        Args:
+            event_type: Typ des Events
+            event_data: Event-Daten
+        """
+        if self.audio_var.get() != "Ein":
+            self.status_label.config(text="Fraktaler Klang unterdrückt (Audio aus)")
+            return
+
+        base_frequency = event_data.get("base_frequency", 220.0)
+        modulation_index = event_data.get("modulation_index", 1.0)
+        volume = self.volume_var.get()
+
+        if not self._ensure_audio_ready():
+            self.status_label.config(text="Audio nicht verfügbar — kein fraktaler Klang")
+            return
+
+        # base_frequency/modulation_index stammen aus den Fraktal-Parametern
+        wave = self.sound_generator.generate_fm_wave(
+            base_frequency, base_frequency / 4.0, modulation_index, 1.0, volume
+        )
+        wave = self.sound_generator.apply_envelope(wave, 0.1, 0.2, 0.7, 0.3)
+        self.sound_generator.play_sound_async(wave)
+
+        self.status_label.config(
+            text=(
+                f"Fraktaler Klang: {base_frequency:.1f} Hz, "
+                f"Modulationsindex {modulation_index:.2f}"
+            )
+        )
+
+    def on_update_resonance_parameters(self, event_type, event_data):
+        """Event-Handler für aktualisierte Resonanz-Parameter (aus Sensordaten).
+
+        Args:
+            event_type: Typ des Events
+            event_data: Event-Daten
+        """
+        sensor_data = {
+            key: event_data.get(key, 0.0)
+            for key in ("accel_x", "accel_y", "accel_z", "gyro_x", "gyro_y", "gyro_z")
+        }
+        accel_magnitude = event_data.get("accel_magnitude", 0.0)
+        gyro_magnitude = event_data.get("gyro_magnitude", 0.0)
+
+        # Sensorbasierte Farbkarte erzeugen und anzeigen
+        cmap = self.color_generator.create_sensor_based_colormap(
+            sensor_data, self.zoom_var.get()
+        )
+        self._render_colormap(cmap, "Farbkarte: sensorbasiert")
+
+        self.status_label.config(
+            text=(
+                f"Resonanz aktualisiert (|a|={accel_magnitude:.2f}, "
+                f"|ω|={gyro_magnitude:.2f})"
+            )
+        )
+
+    def on_close(self):
+        """Räumt beim Schließen des Fensters auf."""
+        self.sound_generator.stop_sound()
+
+        if pygame.mixer.get_init() is not None:
+            pygame.mixer.quit()
+
+        plt.close(self.fig)
+        self.root.destroy()
+
+
+def main():
+    """Startet die ResonanceEnhancer-Testanwendung."""
+    app = TestApp()
+    app.root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/Fractalsense/tests/unit/test_color_generator.py
+++ b/Fractalsense/tests/unit/test_color_generator.py
@@ -438,3 +438,22 @@ class TestEdgeCases:
         # Should still produce valid colors
         color = cmap(0.5)
         assert all(0 <= c <= 1 for c in color)
+
+
+class TestGetColormap:
+    """Tests for colormap lookup."""
+
+    def test_returns_registered_colormap(self, color_generator):
+        """Should return a colormap created by create_default_colormaps."""
+        cmap = color_generator.get_colormap("resonant")
+        assert cmap is not None
+        assert len(cmap(0.5)) == 4  # RGBA
+
+    def test_returns_none_for_unknown_name(self, color_generator):
+        """Should return None so callers can fall back to a matplotlib colormap."""
+        assert color_generator.get_colormap("definitely_not_a_colormap") is None
+
+    def test_finds_all_default_colormaps(self, color_generator):
+        """All default colormaps should be retrievable by name."""
+        for name in ("resonant", "harmonic", "spectral", "fractal", "mereotopological"):
+            assert color_generator.get_colormap(name) is not None, name

--- a/Fractalsense/tests/unit/test_resonance_app.py
+++ b/Fractalsense/tests/unit/test_resonance_app.py
@@ -24,13 +24,14 @@ from modular_app_structure import EventSystem
 # Abhängigkeiten (headless CI), wird nur ihre Import-Oberfläche gestubbt, damit die
 # Logik trotzdem geprüft wird.
 _GUI_STUBS = {
-    "tkinter": ("tkinter", "tkinter.ttk"),
+    # backend_tkagg ist ein Tk-Backend — ohne tkinter nicht importierbar, auch wenn
+    # matplotlib selbst vorhanden ist.
+    "tkinter": ("tkinter", "tkinter.ttk", "matplotlib.backends.backend_tkagg"),
     "matplotlib": (
         "matplotlib",
         "matplotlib.pyplot",
         "matplotlib.figure",
         "matplotlib.backends",
-        "matplotlib.backends.backend_tkagg",
     ),
     "pygame": ("pygame",),
 }

--- a/Fractalsense/tests/unit/test_resonance_app.py
+++ b/Fractalsense/tests/unit/test_resonance_app.py
@@ -1,0 +1,147 @@
+"""
+Tests für die Sensordaten-Weitergabe der ResonanceEnhancer-Testanwendung.
+
+Deckt ab:
+- TestApp.on_send_sensor_data emittiert 'sensor_data_updated'
+- Payload-Keys passen zu integration._on_sensor_data_updated_for_resonance
+"""
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from modular_app_structure import EventSystem
+
+# test_resonance ist ein GUI-Skript und importiert tkinter/matplotlib/pygame auf
+# Modulebene. Der hier getestete Handler berührt nichts davon — fehlt eine dieser
+# Abhängigkeiten (headless CI), wird nur ihre Import-Oberfläche gestubbt, damit die
+# Logik trotzdem geprüft wird.
+_GUI_STUBS = {
+    "tkinter": ("tkinter", "tkinter.ttk"),
+    "matplotlib": (
+        "matplotlib",
+        "matplotlib.pyplot",
+        "matplotlib.figure",
+        "matplotlib.backends",
+        "matplotlib.backends.backend_tkagg",
+    ),
+    "pygame": ("pygame",),
+}
+
+
+@pytest.fixture
+def test_resonance(monkeypatch):
+    """Importiert test_resonance, ggf. mit gestubbten GUI-Abhängigkeiten."""
+    stubbed = False
+    for package, module_names in _GUI_STUBS.items():
+        if importlib.util.find_spec(package) is not None:
+            continue
+        for name in module_names:
+            monkeypatch.setitem(sys.modules, name, MagicMock())
+        stubbed = True
+
+    if stubbed:
+        # Frischer Import, damit die Stubs greifen (und danach zurückgerollt werden).
+        monkeypatch.delitem(sys.modules, "test_resonance", raising=False)
+
+    return importlib.import_module("test_resonance")
+
+
+class _FakeVar:
+    """Minimaler Ersatz für tk.DoubleVar."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def get(self):
+        return self._value
+
+
+class _FakeLabel:
+    """Minimaler Ersatz für ttk.Label — merkt sich den zuletzt gesetzten Text."""
+
+    def __init__(self):
+        self.text = None
+
+    def config(self, text=None, **kwargs):
+        self.text = text
+
+
+class _StubApp:
+    """Trägt nur die Attribute, die on_send_sensor_data tatsächlich liest."""
+
+    def __init__(self, event_system, **values):
+        self.event_system = event_system
+        self.status_label = _FakeLabel()
+        for name, value in values.items():
+            setattr(self, f"{name}_var", _FakeVar(value))
+
+
+@pytest.fixture
+def sensor_app():
+    """Stub-App mit bekannten Sensorwerten und echtem EventSystem."""
+    return _StubApp(
+        EventSystem(),
+        accel_x=1.0,
+        accel_y=2.0,
+        accel_z=2.0,
+        gyro_x=0.0,
+        gyro_y=3.0,
+        gyro_z=4.0,
+    )
+
+
+class TestSendSensorData:
+    """Tests für TestApp.on_send_sensor_data."""
+
+    def test_emits_sensor_data_updated(self, sensor_app, test_resonance):
+        """Should emit 'sensor_data_updated' with the current slider values."""
+        received = []
+        sensor_app.event_system.register_handler(
+            "sensor_data_updated", lambda event_type, data: received.append(data)
+        )
+
+        test_resonance.TestApp.on_send_sensor_data(sensor_app)
+
+        assert len(received) == 1
+        assert received[0] == {
+            "accel_x": 1.0,
+            "accel_y": 2.0,
+            "accel_z": 2.0,
+            "gyro_x": 0.0,
+            "gyro_y": 3.0,
+            "gyro_z": 4.0,
+        }
+
+    def test_payload_matches_integration_contract(self, sensor_app, test_resonance):
+        """Should use exactly the keys integration.py reads for the resonance mapping."""
+        received = []
+        sensor_app.event_system.register_handler(
+            "sensor_data_updated", lambda event_type, data: received.append(data)
+        )
+
+        test_resonance.TestApp.on_send_sensor_data(sensor_app)
+
+        import integration
+
+        # Keys, die integration erwartet, sind alle im Payload vorhanden
+        for key in ("accel_x", "accel_y", "accel_z", "gyro_x", "gyro_y", "gyro_z"):
+            assert key in received[0]
+
+        # Der Consumer verarbeitet das Payload ohne Fehler
+        integration._on_sensor_data_updated_for_resonance("sensor_data_updated", received[0])
+
+    def test_updates_status_label(self, sensor_app, test_resonance):
+        """Should report the accel/gyro magnitudes in the status bar."""
+        test_resonance.TestApp.on_send_sensor_data(sensor_app)
+
+        # |a| = sqrt(1+4+4) = 3.0, |w| = sqrt(0+9+16) = 5.0
+        assert "3.00" in sensor_app.status_label.text
+        assert "5.00" in sensor_app.status_label.text

--- a/Fractalsense/tests/unit/test_resonance_app.py
+++ b/Fractalsense/tests/unit/test_resonance_app.py
@@ -1,9 +1,12 @@
 """
-Tests für die Sensordaten-Weitergabe der ResonanceEnhancer-Testanwendung.
+Tests für die Event-Handler der ResonanceEnhancer-Testanwendung (TestApp).
 
 Deckt ab:
-- TestApp.on_send_sensor_data emittiert 'sensor_data_updated'
-- Payload-Keys passen zu integration._on_sensor_data_updated_for_resonance
+- on_send_sensor_data / on_send_fractal_data emittieren ihre Events
+- Payload-Keys passen zu den Consumern in integration.py
+- on_colormap_updated / on_generate_fractal_sound / on_update_resonance_parameters
+- on_fractal_changed (sendet bewusst nicht), on_close (Aufräumen)
+- Hilfsmethoden _ensure_audio_ready (Audio-Fallback) und _render_colormap
 """
 
 import importlib
@@ -56,13 +59,16 @@ def test_resonance(monkeypatch):
 
 
 class _FakeVar:
-    """Minimaler Ersatz für tk.DoubleVar."""
+    """Minimaler Ersatz für tk.DoubleVar / tk.StringVar."""
 
     def __init__(self, value):
         self._value = value
 
     def get(self):
         return self._value
+
+    def set(self, value):
+        self._value = value
 
 
 class _FakeLabel:
@@ -76,13 +82,29 @@ class _FakeLabel:
 
 
 class _StubApp:
-    """Trägt nur die Attribute, die on_send_sensor_data tatsächlich liest."""
+    """Trägt nur die Attribute, die die getesteten Handler tatsächlich anfassen.
+
+    Widgets (ax/canvas/fig/root) und die Generatoren sind MagicMocks — die Handler
+    sollen auf Event-Payload und Statusmeldung geprüft werden, nicht auf Rendering.
+    """
 
     def __init__(self, event_system, **values):
         self.event_system = event_system
         self.status_label = _FakeLabel()
+        self.ax = MagicMock()
+        self.canvas = MagicMock()
+        self.fig = MagicMock()
+        self.root = MagicMock()
+        self.color_generator = MagicMock()
+        self.sound_generator = MagicMock()
         for name, value in values.items():
             setattr(self, f"{name}_var", _FakeVar(value))
+
+    def _ensure_audio_ready(self):
+        return True
+
+    def _render_colormap(self, cmap, title):
+        self.rendered = (cmap, title)
 
 
 @pytest.fixture
@@ -96,6 +118,20 @@ def sensor_app():
         gyro_x=0.0,
         gyro_y=3.0,
         gyro_z=4.0,
+    )
+
+
+@pytest.fixture
+def fractal_app():
+    """Stub-App mit Fraktal-Parametern und Farb-/Audio-Auswahl."""
+    return _StubApp(
+        EventSystem(),
+        zoom=4.0,
+        center_real=-0.75,
+        center_imag=0.1,
+        color_mode="resonant",
+        audio="Ein",
+        volume=0.5,
     )
 
 
@@ -146,3 +182,244 @@ class TestSendSensorData:
         # |a| = sqrt(1+4+4) = 3.0, |w| = sqrt(0+9+16) = 5.0
         assert "3.00" in sensor_app.status_label.text
         assert "5.00" in sensor_app.status_label.text
+
+
+class TestSendFractalData:
+    """Tests für TestApp.on_send_fractal_data."""
+
+    def test_emits_fractal_updated(self, fractal_app, test_resonance):
+        """Should emit 'fractal_updated' with center as complex and zoom."""
+        received = []
+        fractal_app.event_system.register_handler(
+            "fractal_updated", lambda event_type, data: received.append(data)
+        )
+
+        test_resonance.TestApp.on_send_fractal_data(fractal_app)
+
+        assert len(received) == 1
+        assert received[0]["center"] == complex(-0.75, 0.1)
+        assert received[0]["zoom"] == 4.0
+
+    def test_payload_matches_integration_contract(self, fractal_app, test_resonance):
+        """The consumer in integration.py should accept the payload."""
+        received = []
+        fractal_app.event_system.register_handler(
+            "fractal_updated", lambda event_type, data: received.append(data)
+        )
+
+        test_resonance.TestApp.on_send_fractal_data(fractal_app)
+
+        import integration
+
+        integration._on_fractal_updated_for_sound("fractal_updated", received[0])
+
+    def test_updates_status_label(self, fractal_app, test_resonance):
+        """Should report center and zoom in the status bar."""
+        test_resonance.TestApp.on_send_fractal_data(fractal_app)
+
+        assert "-0.75+0.10i" in fractal_app.status_label.text
+        assert "4.00" in fractal_app.status_label.text
+
+
+class TestFractalChanged:
+    """Tests für TestApp.on_fractal_changed."""
+
+    def test_does_not_emit(self, fractal_app, test_resonance):
+        """Slider moves should not emit — data is sent via the button."""
+        received = []
+        fractal_app.event_system.register_handler(
+            "fractal_updated", lambda event_type, data: received.append(data)
+        )
+
+        test_resonance.TestApp.on_fractal_changed(fractal_app, None)
+
+        assert received == []
+
+
+class TestColormapUpdated:
+    """Tests für TestApp.on_colormap_updated."""
+
+    def test_applies_colormap_from_event(self, fractal_app, test_resonance):
+        """Should adopt the colormap from the event and refresh the display."""
+        shown = []
+        fractal_app.on_show_colormap = lambda: shown.append(fractal_app.color_mode_var.get())
+
+        test_resonance.TestApp.on_colormap_updated(
+            fractal_app, "colormap_updated", {"colormap": "spectral"}
+        )
+
+        assert fractal_app.color_mode_var.get() == "spectral"
+        assert shown == ["spectral"]
+        assert "spectral" in fractal_app.status_label.text
+
+    def test_falls_back_to_current_selection(self, fractal_app, test_resonance):
+        """Without a colormap in the payload the current selection is kept."""
+        fractal_app.on_show_colormap = lambda: None
+
+        test_resonance.TestApp.on_colormap_updated(fractal_app, "colormap_updated", {})
+
+        assert fractal_app.color_mode_var.get() == "resonant"
+
+
+class TestGenerateFractalSound:
+    """Tests für TestApp.on_generate_fractal_sound."""
+
+    def test_plays_fm_wave_from_event_parameters(self, fractal_app, test_resonance):
+        """Should build an FM wave from base_frequency/modulation_index and play it."""
+        test_resonance.TestApp.on_generate_fractal_sound(
+            fractal_app,
+            "generate_fractal_sound",
+            {"base_frequency": 440.0, "modulation_index": 2.0},
+        )
+
+        gen = fractal_app.sound_generator
+        gen.generate_fm_wave.assert_called_once_with(440.0, 110.0, 2.0, 1.0, 0.5)
+        gen.apply_envelope.assert_called_once()
+        gen.play_sound_async.assert_called_once()
+        assert "440.0 Hz" in fractal_app.status_label.text
+
+    def test_skips_when_audio_disabled(self, fractal_app, test_resonance):
+        """Should not touch the sound generator when audio is switched off."""
+        fractal_app.audio_var.set("Aus")
+
+        test_resonance.TestApp.on_generate_fractal_sound(
+            fractal_app, "generate_fractal_sound", {"base_frequency": 440.0}
+        )
+
+        fractal_app.sound_generator.play_sound_async.assert_not_called()
+        assert "Audio aus" in fractal_app.status_label.text
+
+    def test_skips_when_no_audio_device(self, fractal_app, test_resonance):
+        """Should degrade gracefully when the mixer cannot be initialized."""
+        fractal_app._ensure_audio_ready = lambda: False
+
+        test_resonance.TestApp.on_generate_fractal_sound(
+            fractal_app, "generate_fractal_sound", {"base_frequency": 440.0}
+        )
+
+        fractal_app.sound_generator.play_sound_async.assert_not_called()
+        assert "nicht verfügbar" in fractal_app.status_label.text
+
+
+class TestUpdateResonanceParameters:
+    """Tests für TestApp.on_update_resonance_parameters."""
+
+    def test_renders_sensor_based_colormap(self, fractal_app, test_resonance):
+        """Should build a sensor-based colormap from the event payload."""
+        payload = {
+            "accel_magnitude": 3.0,
+            "gyro_magnitude": 5.0,
+            "accel_x": 1.0,
+            "accel_y": 2.0,
+            "accel_z": 2.0,
+            "gyro_x": 0.0,
+            "gyro_y": 3.0,
+            "gyro_z": 4.0,
+        }
+
+        test_resonance.TestApp.on_update_resonance_parameters(
+            fractal_app, "update_resonance_parameters", payload
+        )
+
+        sensor_data, zoom = fractal_app.color_generator.create_sensor_based_colormap.call_args[0]
+        assert sensor_data == {
+            "accel_x": 1.0,
+            "accel_y": 2.0,
+            "accel_z": 2.0,
+            "gyro_x": 0.0,
+            "gyro_y": 3.0,
+            "gyro_z": 4.0,
+        }
+        assert zoom == 4.0
+        assert fractal_app.rendered[1] == "Farbkarte: sensorbasiert"
+        assert "3.00" in fractal_app.status_label.text
+        assert "5.00" in fractal_app.status_label.text
+
+    def test_tolerates_missing_keys(self, fractal_app, test_resonance):
+        """Missing sensor axes should default to 0.0 rather than raise."""
+        test_resonance.TestApp.on_update_resonance_parameters(
+            fractal_app, "update_resonance_parameters", {}
+        )
+
+        sensor_data, _ = fractal_app.color_generator.create_sensor_based_colormap.call_args[0]
+        assert set(sensor_data.values()) == {0.0}
+
+
+class TestClose:
+    """Tests für TestApp.on_close."""
+
+    def test_stops_audio_and_destroys_window(self, fractal_app, test_resonance, monkeypatch):
+        """Should stop playback, close the figure and destroy the window."""
+        fake_pygame = MagicMock()
+        fake_pygame.mixer.get_init.return_value = (44100, -16, 1)
+        monkeypatch.setattr(test_resonance, "pygame", fake_pygame)
+        fake_plt = MagicMock()
+        monkeypatch.setattr(test_resonance, "plt", fake_plt)
+
+        test_resonance.TestApp.on_close(fractal_app)
+
+        fractal_app.sound_generator.stop_sound.assert_called_once()
+        fake_pygame.mixer.quit.assert_called_once()
+        fake_plt.close.assert_called_once_with(fractal_app.fig)
+        fractal_app.root.destroy.assert_called_once()
+
+    def test_skips_mixer_quit_when_not_initialized(self, fractal_app, test_resonance, monkeypatch):
+        """Should not quit a mixer that was never initialized."""
+        fake_pygame = MagicMock()
+        fake_pygame.mixer.get_init.return_value = None
+        monkeypatch.setattr(test_resonance, "pygame", fake_pygame)
+        monkeypatch.setattr(test_resonance, "plt", MagicMock())
+
+        test_resonance.TestApp.on_close(fractal_app)
+
+        fake_pygame.mixer.quit.assert_not_called()
+        fractal_app.root.destroy.assert_called_once()
+
+
+class TestEnsureAudioReady:
+    """Tests für TestApp._ensure_audio_ready."""
+
+    def test_returns_true_when_already_initialized(self, fractal_app, test_resonance, monkeypatch):
+        """Should not re-initialize an already running mixer."""
+        fake_pygame = MagicMock()
+        fake_pygame.mixer.get_init.return_value = (44100, -16, 1)
+        monkeypatch.setattr(test_resonance, "pygame", fake_pygame)
+
+        assert test_resonance.TestApp._ensure_audio_ready(fractal_app) is True
+        fake_pygame.mixer.init.assert_not_called()
+
+    def test_initializes_when_needed(self, fractal_app, test_resonance, monkeypatch):
+        """Should initialize the mixer on first use."""
+        fake_pygame = MagicMock()
+        fake_pygame.mixer.get_init.return_value = None
+        monkeypatch.setattr(test_resonance, "pygame", fake_pygame)
+
+        assert test_resonance.TestApp._ensure_audio_ready(fractal_app) is True
+        fake_pygame.mixer.init.assert_called_once()
+
+    def test_returns_false_without_audio_device(self, fractal_app, test_resonance, monkeypatch):
+        """Should report failure instead of raising when there is no audio device."""
+        fake_pygame = MagicMock()
+        fake_pygame.error = RuntimeError
+        fake_pygame.mixer.get_init.return_value = None
+        fake_pygame.mixer.init.side_effect = RuntimeError("no device")
+        monkeypatch.setattr(test_resonance, "pygame", fake_pygame)
+
+        assert test_resonance.TestApp._ensure_audio_ready(fractal_app) is False
+
+
+class TestRenderColormap:
+    """Tests für TestApp._render_colormap."""
+
+    def test_draws_gradient_and_clears_ticks(self, fractal_app, test_resonance):
+        """Should clear the axis, draw the gradient and refresh the canvas."""
+        cmap = object()
+
+        test_resonance.TestApp._render_colormap(fractal_app, cmap, "Farbkarte: test")
+
+        fractal_app.ax.clear.assert_called_once()
+        assert fractal_app.ax.imshow.call_args.kwargs["cmap"] is cmap
+        fractal_app.ax.set_title.assert_called_once_with("Farbkarte: test")
+        fractal_app.ax.set_xticks.assert_called_once_with([])
+        fractal_app.ax.set_yticks.assert_called_once_with([])
+        fractal_app.canvas.draw.assert_called_once()

--- a/Fractalsense/tests/unit/test_sound_generator.py
+++ b/Fractalsense/tests/unit/test_sound_generator.py
@@ -14,6 +14,7 @@ Tests cover:
 
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -391,3 +392,33 @@ class TestEdgeCases:
         wave = sound_generator.generate_sine_wave(0.0, 0.1)
         # All values should be zero (sin(0) = 0)
         assert np.allclose(wave, 0)
+
+
+class TestStopSound:
+    """Tests for stop_sound."""
+
+    def test_no_error_when_mixer_never_initialized(self, sound_generator, monkeypatch):
+        """Should be a no-op instead of raising when the mixer was never initialized."""
+        import sound_generator as sg_module
+
+        fake_pygame = MagicMock()
+        fake_pygame.mixer.get_init.return_value = None
+        fake_pygame.mixer.stop.side_effect = AssertionError("stop() must not be called")
+        monkeypatch.setattr(sg_module, "pygame", fake_pygame)
+
+        sound_generator.stop_sound()
+
+        assert sound_generator.is_playing is False
+
+    def test_stops_when_mixer_initialized(self, sound_generator, monkeypatch):
+        """Should stop playback when the mixer is up."""
+        import sound_generator as sg_module
+
+        fake_pygame = MagicMock()
+        fake_pygame.mixer.get_init.return_value = (44100, -16, 1)
+        monkeypatch.setattr(sg_module, "pygame", fake_pygame)
+
+        sound_generator.stop_sound()
+
+        fake_pygame.mixer.stop.assert_called_once()
+        assert sound_generator.is_playing is False

--- a/OUT/todo_sensor_data_sending_2026-07-29.md
+++ b/OUT/todo_sensor_data_sending_2026-07-29.md
@@ -23,39 +23,75 @@ Sensor-Slider der Test-UI waren damit wirkungslos.
 - [x] Statusleiste meldet die resultierenden Magnituden (`|a|`, `|ω|`) — analog zu den
       Nachbar-Handlern `on_volume_changed` / `on_color_mode_changed`
 - [x] Unit-Tests ergänzt: `Fractalsense/tests/unit/test_resonance_app.py` (3 Tests)
-- [x] `make verify` grün; Fractalsense-Suite grün (143 passed)
+- [x] `make verify` grün; Fractalsense-Suite grün (165 passed)
+
+## Nachtrag: fehlende Methoden ergänzt (auf Anweisung)
+
+Der zunächst als „nicht getan" dokumentierte Folgedefekt wurde auf ausdrückliche
+Anweisung mitbehoben. `TestApp` referenzierte sechs nie definierte Methoden; die
+Klasse brach bereits in `__init__` mit `AttributeError` ab.
+
+- [x] `on_colormap_updated` — übernimmt Farbkarte aus Event, zieht UI-Auswahl nach
+- [x] `on_generate_fractal_sound` — FM-Klang aus `base_frequency`/`modulation_index`
+- [x] `on_update_resonance_parameters` — sensorbasierte Farbkarte aus Magnituden
+- [x] `on_fractal_changed` — sendet bewusst nicht (Button-getrieben, wie beim Sensor)
+- [x] `on_send_fractal_data` — emittiert `fractal_updated` (Consumer: `integration.py`)
+- [x] `on_close` — stoppt Audio, schließt Figur, zerstört Fenster
+- [x] `main()` + `__main__`-Guard — die Anwendung ist wieder startbar
+
+Dabei fielen drei weitere blockierende Defekte auf, die mitbehoben wurden:
+
+- [x] **`ColorGenerator.get_colormap` fehlte komplett** — das bereits vorhandene
+      `on_show_colormap` rief die Methode auf. Ergänzt in `color_generator.py`.
+- [x] **`SoundGenerator.stop_sound` warf ohne initialisierten Mixer** —
+      `pygame.mixer.stop()` ohne `get_init()`-Prüfung; ließ `on_close` abstürzen.
+- [x] **`pygame.mixer.init()` ohne Audiogerät warf** (headless) — die Audio-Pfade
+      degradieren jetzt kontrolliert statt die UI abzubrechen.
+
+Zwei kleine Helfer entkoppeln Wiederverwendetes: `_ensure_audio_ready()` und
+`_render_colormap()`; `on_test_sound` und `on_show_colormap` nutzen sie mit.
+
+**Verifikation:** Die Anwendung wurde real unter Xvfb gebaut (`TestApp()`, echtes
+Tk-Fenster) und jeder Handler durchlaufen, inkl. Dispatch über das EventSystem und
+sauberem `on_close`. Suite: 165 passed — sowohl mit gestubbten als auch mit echten
+GUI-Abhängigkeiten (letzteres entspricht der CI-Konfiguration).
 
 ## Nicht getan
 
-- **Fehlende Handler in `test_resonance.py` nicht ergänzt.** Die Datei referenziert
-  sechs Methoden, die nie definiert wurden: `on_colormap_updated`,
-  `on_generate_fractal_sound`, `on_update_resonance_parameters` (via
-  `register_handler` in `__init__`) sowie `on_fractal_changed`,
-  `on_send_fractal_data`, `on_close`. `TestApp()` ist dadurch nicht
-  instanziierbar — die Datei bricht bereits in `__init__` mit `AttributeError` ab.
-  Das ist ein eigener Defekt, kein Teil dieses TODOs → G4 (Fokus-Switch): nicht
-  angefasst, hier dokumentiert.
-- Kein `main()`-Entrypoint ergänzt (die Datei endet ohne einen solchen).
-- Bestehende Lint-Befunde in `test_resonance.py` (unsortierte Imports, ungenutzte
-  Importe `time`, `threading`, `Figure`) nicht behoben — vorbestehend und außerhalb
-  des Fokus.
+- **`integration.py` erzeugt pro Event ein neues `EventSystem()`.** Da die
+  Handler-Registry instanzgebunden ist (`EventSystem.__init__` setzt ein eigenes
+  `_event_handlers`), laufen die Weiterleitungen dort ins Leere: die Kette
+  UI → `integration` → zurück in die App schließt sich nicht. Die App-seitigen
+  Handler funktionieren (über den gemeinsamen Bus verifiziert), aber die
+  Integrationsschicht bleibt inert. Das ist eine architektonische Änderung
+  (Singleton oder Injektion des geteilten Bus) → G0/G4: nicht ohne Rücksprache.
+- Bestehende Lint-Befunde (unsortierte Imports, ungenutzte Importe `time`,
+  `threading`, `Figure` in `test_resonance.py`; `C401` in
+  `tests/unit/test_color_generator.py:188`) nicht behoben — vorbestehend und
+  außerhalb des Fokus.
 
 ## Risiken
 
-- **Gering.** Die Änderung ist additiv und auf einen bisher leeren Handler begrenzt.
-- Der Handler ist im laufenden GUI nicht erreichbar, solange die oben genannten
-  fehlenden Methoden `TestApp.__init__` scheitern lassen. Die Logik selbst ist durch
-  die neuen Tests abgedeckt.
+- **Gering–mittel.** Überwiegend additiv (zuvor fehlende Methoden). Angefasst wurde
+  bestehender Code nur an drei Stellen: `on_test_sound` und `on_show_colormap` nutzen
+  jetzt die neuen Helfer, und `stop_sound` prüft zusätzlich `get_init()`.
+- `on_test_sound` bricht bei fehlendem Audiogerät nun früh mit Statusmeldung ab,
+  statt bis zur Wiedergabe zu laufen (dort wurde der Fehler vorher verschluckt) —
+  bewusste Verhaltensänderung zugunsten einer sichtbaren Rückmeldung.
 - `Fractalsense/` liegt außerhalb der `testpaths` des Root-`pytest` — die neuen Tests
   laufen über `npm run test:py`, nicht über `make verify`.
 
 ## Offene Punkte
 
-- [ ] ☐ Fehlende `TestApp`-Methoden und `main()` ergänzen, damit die Testanwendung
-      wieder startfähig ist
+- [ ] ☐ `integration.py`: geteiltes `EventSystem` statt Neuinstanziierung pro Event
+      (blockiert die Rückkopplung UI → Integration → UI)
 - [ ] ☐ Prüfen, ob `Fractalsense/tests/` in ein CI-Gate aufgenommen werden soll
 
 ## Artefakte
 
 - `Fractalsense/test_resonance.py`
+- `Fractalsense/color_generator.py`
+- `Fractalsense/sound_generator.py`
 - `Fractalsense/tests/unit/test_resonance_app.py`
+- `Fractalsense/tests/unit/test_color_generator.py`
+- `Fractalsense/tests/unit/test_sound_generator.py`

--- a/OUT/todo_sensor_data_sending_2026-07-29.md
+++ b/OUT/todo_sensor_data_sending_2026-07-29.md
@@ -1,0 +1,61 @@
+# Report: TODO "Implement sensor data sending" umgesetzt
+
+**Datum:** 2026-07-29
+**Fokus:** Sensordaten-Event implementieren
+
+## Ziel
+
+Den einzigen offenen Code-TODO im Repository schließen:
+`Fractalsense/test_resonance.py:376 — "TODO: Implement sensor data sending"`.
+
+Der Button "Sensordaten senden" der ResonanceEnhancer-Testanwendung war an einen
+leeren Handler (`pass`) gebunden. Gleichzeitig registriert
+[`Fractalsense/integration.py:65`](../Fractalsense/integration.py) einen Consumer für das
+Event `sensor_data_updated` — dieses Event wurde von keiner Stelle emittiert. Die
+Sensor-Slider der Test-UI waren damit wirkungslos.
+
+## Aktionen
+
+- [x] `TestApp.on_send_sensor_data` implementiert: liest die sechs Sensor-Slider
+      (`accel_x/y/z`, `gyro_x/y/z`) und emittiert `sensor_data_updated`
+- [x] Payload-Keys exakt am Consumer-Kontrakt von
+      `integration._on_sensor_data_updated_for_resonance` ausgerichtet
+- [x] Statusleiste meldet die resultierenden Magnituden (`|a|`, `|ω|`) — analog zu den
+      Nachbar-Handlern `on_volume_changed` / `on_color_mode_changed`
+- [x] Unit-Tests ergänzt: `Fractalsense/tests/unit/test_resonance_app.py` (3 Tests)
+- [x] `make verify` grün; Fractalsense-Suite grün (143 passed)
+
+## Nicht getan
+
+- **Fehlende Handler in `test_resonance.py` nicht ergänzt.** Die Datei referenziert
+  sechs Methoden, die nie definiert wurden: `on_colormap_updated`,
+  `on_generate_fractal_sound`, `on_update_resonance_parameters` (via
+  `register_handler` in `__init__`) sowie `on_fractal_changed`,
+  `on_send_fractal_data`, `on_close`. `TestApp()` ist dadurch nicht
+  instanziierbar — die Datei bricht bereits in `__init__` mit `AttributeError` ab.
+  Das ist ein eigener Defekt, kein Teil dieses TODOs → G4 (Fokus-Switch): nicht
+  angefasst, hier dokumentiert.
+- Kein `main()`-Entrypoint ergänzt (die Datei endet ohne einen solchen).
+- Bestehende Lint-Befunde in `test_resonance.py` (unsortierte Imports, ungenutzte
+  Importe `time`, `threading`, `Figure`) nicht behoben — vorbestehend und außerhalb
+  des Fokus.
+
+## Risiken
+
+- **Gering.** Die Änderung ist additiv und auf einen bisher leeren Handler begrenzt.
+- Der Handler ist im laufenden GUI nicht erreichbar, solange die oben genannten
+  fehlenden Methoden `TestApp.__init__` scheitern lassen. Die Logik selbst ist durch
+  die neuen Tests abgedeckt.
+- `Fractalsense/` liegt außerhalb der `testpaths` des Root-`pytest` — die neuen Tests
+  laufen über `npm run test:py`, nicht über `make verify`.
+
+## Offene Punkte
+
+- [ ] ☐ Fehlende `TestApp`-Methoden und `main()` ergänzen, damit die Testanwendung
+      wieder startfähig ist
+- [ ] ☐ Prüfen, ob `Fractalsense/tests/` in ein CI-Gate aufgenommen werden soll
+
+## Artefakte
+
+- `Fractalsense/test_resonance.py`
+- `Fractalsense/tests/unit/test_resonance_app.py`


### PR DESCRIPTION
## Intent

Startpunkt war der einzige offene Code-TODO im Repository —
`Fractalsense/test_resonance.py:376 — "TODO: Implement sensor data sending"`.
Beim Umsetzen zeigte sich, dass die Testanwendung insgesamt nicht lauffähig war; auf Anweisung wurde das mitbehoben.

**1. Der ursprüngliche TODO.** Der Button „Sensordaten senden" war an einen leeren Handler (`pass`) gebunden, während `integration.py:65` einen Consumer für `sensor_data_updated` registriert — ein Event, das **niemand** emittierte. Die sechs Sensor-Slider waren wirkungslos. `on_send_sensor_data` liest sie jetzt und emittiert mit exakt den Keys, die `integration._on_sensor_data_updated_for_resonance` liest.

**2. Sechs nie definierte Methoden.** `TestApp` referenzierte `on_colormap_updated`, `on_generate_fractal_sound`, `on_update_resonance_parameters` (als Event-Handler in `__init__`) sowie `on_fractal_changed`, `on_send_fractal_data`, `on_close` (als Widget-Callbacks). Die Klasse brach dadurch bereits in `__init__` mit `AttributeError` ab; ein `main()`-Entrypoint fehlte ebenfalls. Alle ergänzt — die Anwendung ist wieder startbar.

**3. Drei weitere blockierende Defekte** auf dem Weg dorthin:

| Defekt | Wirkung | Fix |
|---|---|---|
| `ColorGenerator.get_colormap` existierte nicht | das vorhandene `on_show_colormap` rief sie auf | in `color_generator.py` ergänzt |
| `SoundGenerator.stop_sound` ohne `get_init()`-Prüfung | `pygame.mixer.stop()` warf, wenn nie Audio lief → `on_close` stürzte ab | Mixer-Status geprüft |
| `pygame.mixer.init()` ohne Audiogerät | Exception mitten im UI-Handler (headless/CI) | Statusmeldung statt Absturz |

`_ensure_audio_ready()` und `_render_colormap()` bündeln das Wiederverwendete; `on_test_sound` und `on_show_colormap` nutzen sie mit.

## Scope

FOKUS: Testanwendung lauffähig machen

- `Fractalsense/test_resonance.py` — TODO umgesetzt, 6 Methoden + `main()` ergänzt, 2 Helfer
- `Fractalsense/color_generator.py` — `get_colormap` ergänzt
- `Fractalsense/sound_generator.py` — `stop_sound` gegen nicht initialisierten Mixer abgesichert
- `Fractalsense/tests/unit/` — 20 neue Testfälle in drei Dateien
- `OUT/todo_sensor_data_sending_2026-07-29.md` — Report nach Repo-Schema

Kein GOLD (`index/`, `policies/`, `VOIDMAP.yml`, `spec/`) und keine Receipts berührt.

## Test Plan

- [x] Unit tests pass — 20 neue Fälle: Event-Payloads, Payload-Kontrakte gegen `integration.py`, Statusmeldungen, Audio-Fallback, Aufräumen in `on_close`, `get_colormap`, `stop_sound`
- [x] Fractalsense-Suite grün: **165 passed** — in **beiden** Umgebungen, mit gestubbten *und* mit echten GUI-Abhängigkeiten (letzteres entspricht der CI-Konfiguration aus `Fractalsense/requirements-dev.txt`)
- [x] `make verify` grün (port-lint · pytest · verify-pointers --strict · claim-lint)
- [x] `ruff` und `black --line-length 100` sauber auf allen geänderten/neuen Zeilen
- [x] **Manual testing completed** — die Anwendung wurde real unter Xvfb gebaut: `TestApp()` erzeugt ein echtes Tk-Fenster, jeder zuvor fehlende Handler läuft durch, inkl. Dispatch über das `EventSystem` und sauberem `on_close`:

```
[1] TestApp() instanziiert  -> TestApp
[2] on_show_colormap        -> Farbkarte 'resonant' angezeigt
[3] on_send_sensor_data     -> Sensordaten gesendet (|a|=3.00, |ω|=5.00)
[4] on_send_fractal_data    -> Fraktaldaten gesendet (Zentrum=-0.75+0.10i, Zoom=4.00)
[5] on_colormap_updated     -> Farbkarte 'spectral' aus Event übernommen
[6] on_generate_fractal_sound -> Audio nicht verfügbar — kein fraktaler Klang
[7] on_update_resonance_parameters -> Resonanz aktualisiert (|a|=3.00, |ω|=5.00)
[8] Bus -> on_colormap_updated / on_update_resonance_parameters / on_generate_fractal_sound
[9] on_close                -> Fenster zerstört, Mixer/Figur aufgeräumt
```

- [x] **CI checks pass** — alle 44 Check-Runs auf `0170777` grün bzw. übersprungen: `All Checks Passed`, `All Tests Pass`, `Build (Test & Coverage)` 3.9–3.12, `Python Tests` 3.10–3.12, `Verify (Lint & Type Check)` 3.10–3.12, `Verify Pointers & Lint (blocking)`, `deepjump-audit`, `Gate Policy Validation`, `Security Scan`, CodeQL (4 Sprachen), `Lint · Format · Types · SAST`, `UI Build`, `JavaScript Tests`, FOKUS-Marker. `mergeable_state: clean`. (Ein früherer `Check PR for FOKUS marker`-Lauf steht auf `cancelled` — von der Concurrency-Group abgelöst; der nachfolgende Lauf desselben Checks ist grün.)

## Risk

**Gering–mittel.** Überwiegend additiv (zuvor fehlende Methoden). Bestehender Code wurde nur an drei Stellen angefasst: `on_test_sound` und `on_show_colormap` nutzen jetzt die neuen Helfer, `stop_sound` prüft zusätzlich `get_init()`.

Punkte fürs Review:

1. **Bewusste Verhaltensänderung:** `on_test_sound` bricht bei fehlendem Audiogerät früh mit Statusmeldung ab, statt bis zur Wiedergabe zu laufen — dort wurde der Fehler vorher in `play_sound` verschluckt und nur auf stdout gedruckt.
2. **Inzwischen adressiert, nicht in diesem PR:** `integration.py` erzeugte in jedem Forwarding-Handler ein **neues** `EventSystem()`, sodass die Kette UI → `integration` → zurück in die App sich nicht schloss. Dieser PR lässt das bewusst unangetastet (G0/G4); der Fix liegt separat in **#342** (injizierter Bus, ADR-0004). Die hier ergänzten App-seitigen Handler funktionieren unabhängig davon — über den gemeinsamen Bus verifiziert. Beide PRs sind von `main` aus unabhängig mergebar, die Reihenfolge ist egal.
3. **`Fractalsense/` liegt außerhalb der `testpaths` des Root-`pytest`.** Die neuen Tests laufen über den `Python Tests`-Job (`npm run test:py`), nicht über `make verify`.