### PR TITLE
fix(fractalsense): Forwarding auf den injizierten Event-Bus statt neuer Instanzen

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,9 @@
       "Bash(git push:*)",
       "Bash(git fetch:*)",
       "Bash(git pull:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__Claude_Code_Remote__send_later"
     ]
   }
 }

--- a/Fractalsense/integration.py
+++ b/Fractalsense/integration.py
@@ -2,31 +2,56 @@
 FractalSense EntaENGELment - Integration des ResonanceEnhancer-Moduls
 
 Dieses Modul integriert den ResonanceEnhancer mit den bestehenden Modulen.
+
+Architektur: Der Event-Bus gehört der Anwendung und wird explizit injiziert
+(ADR-0004). `integrate_resonance_enhancer()` erhält ihn über
+`app_context["event_system"]`; jeder Forwarding-Handler emittiert auf genau dieser
+Instanz. Kein Singleton, kein Modulzustand — die Weiterleitung entsteht als Closure
+über den übergebenen Bus.
+
+Die `_on_*`-Funktionen sind reine Abbildungen: sie berechnen aus einem Quell-Event
+`(Ziel-Event, Payload)` und emittieren selbst nicht. Den Transport übernimmt
+`_make_forwarder()`. Dadurch bleibt die Abbildungslogik ohne Bus testbar.
 """
 
-import os
-import sys
-import importlib
-from typing import Any
+from typing import Any, Callable
 
 # Importiere das modulare Framework
-from modular_app_structure import ModuleInterface, EventSystem
+from modular_app_structure import EventSystem
+
+# Marker auf der Bus-Instanz: verhindert doppelte Registrierung bei wiederholter
+# Integration. Bewusst pro Instanz (setattr auf dem übergebenen Bus), nicht global —
+# zwei EventSystem-Instanzen bleiben vollständig unabhängig.
+_CONNECTED_FLAG = "_resonance_enhancer_connected"
+
+# Typalias für die reinen Abbildungsfunktionen: (event_type, event_data) -> (ziel, payload)
+EventMapper = Callable[[str, dict[str, Any]], "tuple[str, dict[str, Any]]"]
+
 
 def integrate_resonance_enhancer(app_context: dict[str, Any]) -> bool:
     """Integriert das ResonanceEnhancer-Modul mit den bestehenden Modulen.
 
+    Die Registrierung ist idempotent: ein zweiter Aufruf mit demselben Bus
+    registriert die Forwarding-Handler nicht erneut und gibt True zurück.
+
     Args:
-        app_context: Dictionary mit dem App-Kontext
+        app_context: Dictionary mit dem App-Kontext; muss unter "event_system"
+            den Event-Bus der Anwendung enthalten
 
     Returns:
-        bool: True, wenn die Integration erfolgreich war, sonst False
+        bool: True, wenn die Integration erfolgreich war (oder bereits bestand),
+        sonst False
     """
     try:
-        # Event-System aus dem App-Kontext holen
+        # Event-System aus dem App-Kontext holen — dieser Bus trägt den gesamten Kreis
         event_system = app_context.get("event_system")
         if event_system is None:
             print("Fehler: Event-System nicht im App-Kontext gefunden.")
             return False
+
+        if getattr(event_system, _CONNECTED_FLAG, False):
+            print("ResonanceEnhancer ist mit diesem Event-Bus bereits verbunden.")
+            return True
 
         # Verbindung zwischen Fractal Visualization und ResonanceEnhancer herstellen
         _connect_fractal_to_resonance(event_system)
@@ -37,11 +62,33 @@ def integrate_resonance_enhancer(app_context: dict[str, Any]) -> bool:
         # Verbindung zwischen Hypergraph Visualization und ResonanceEnhancer herstellen
         _connect_hypergraph_to_resonance(event_system)
 
+        setattr(event_system, _CONNECTED_FLAG, True)
+
         print("ResonanceEnhancer erfolgreich mit bestehenden Modulen integriert.")
         return True
     except Exception as e:
         print(f"Fehler bei der Integration des ResonanceEnhancer-Moduls: {str(e)}")
         return False
+
+
+def _make_forwarder(event_system: EventSystem, mapper: EventMapper) -> Callable[..., None]:
+    """Baut einen Forwarding-Handler, der auf dem übergebenen Bus emittiert.
+
+    Args:
+        event_system: Der Bus, auf dem das Ziel-Event emittiert wird
+        mapper: Reine Abbildung (event_type, event_data) -> (ziel_event, payload)
+
+    Returns:
+        Callable: Handler mit der vom EventSystem erwarteten Signatur
+        (event_type, event_data)
+    """
+
+    def _forward(event_type: str, event_data: dict[str, Any]) -> None:
+        target_event, payload = mapper(event_type, event_data)
+        event_system.emit_event(target_event, payload)
+
+    return _forward
+
 
 def _connect_fractal_to_resonance(event_system: EventSystem) -> None:
     """Verbindet das Fractal Visualization Modul mit dem ResonanceEnhancer.
@@ -50,10 +97,15 @@ def _connect_fractal_to_resonance(event_system: EventSystem) -> None:
         event_system: Event-System für die Kommunikation zwischen Modulen
     """
     # Event-Handler für Farbkarten-Updates registrieren
-    event_system.register_handler("colormap_updated", _on_colormap_updated)
+    event_system.register_handler(
+        "colormap_updated", _make_forwarder(event_system, _on_colormap_updated)
+    )
 
     # Event-Handler für Fraktal-Updates registrieren
-    event_system.register_handler("fractal_updated", _on_fractal_updated_for_sound)
+    event_system.register_handler(
+        "fractal_updated", _make_forwarder(event_system, _on_fractal_updated_for_sound)
+    )
+
 
 def _connect_sensor_to_resonance(event_system: EventSystem) -> None:
     """Verbindet das Sensor Integration Modul mit dem ResonanceEnhancer.
@@ -62,7 +114,11 @@ def _connect_sensor_to_resonance(event_system: EventSystem) -> None:
         event_system: Event-System für die Kommunikation zwischen Modulen
     """
     # Event-Handler für Sensordaten-Updates registrieren
-    event_system.register_handler("sensor_data_updated", _on_sensor_data_updated_for_resonance)
+    event_system.register_handler(
+        "sensor_data_updated",
+        _make_forwarder(event_system, _on_sensor_data_updated_for_resonance),
+    )
+
 
 def _connect_hypergraph_to_resonance(event_system: EventSystem) -> None:
     """Verbindet das Hypergraph Visualization Modul mit dem ResonanceEnhancer.
@@ -71,29 +127,41 @@ def _connect_hypergraph_to_resonance(event_system: EventSystem) -> None:
         event_system: Event-System für die Kommunikation zwischen Modulen
     """
     # Event-Handler für Hypergraph-Updates registrieren
-    event_system.register_handler("hypergraph_updated", _on_hypergraph_updated)
+    event_system.register_handler(
+        "hypergraph_updated", _make_forwarder(event_system, _on_hypergraph_updated)
+    )
 
-def _on_colormap_updated(event_type: str, event_data: dict[str, Any]) -> None:
-    """Event-Handler für aktualisierte Farbkarten.
+
+def _on_colormap_updated(
+    event_type: str, event_data: dict[str, Any]
+) -> "tuple[str, dict[str, Any]]":
+    """Bildet ein Farbkarten-Update auf das Fractal-Visualization-Event ab.
 
     Args:
         event_type: Typ des Events
         event_data: Event-Daten
+
+    Returns:
+        tuple: (Ziel-Event, Payload) — emittiert wird in _make_forwarder
     """
     # Extrahiere Farbkarte
     colormap = event_data.get("colormap", "viridis")
 
-    # Sende Event an Fractal Visualization Modul
-    from modular_app_structure import EventSystem
-    event_system = EventSystem()
-    event_system.emit_event("update_fractal_colormap", {"colormap": colormap})
+    # Ziel: Fractal Visualization Modul
+    return "update_fractal_colormap", {"colormap": colormap}
 
-def _on_fractal_updated_for_sound(event_type: str, event_data: dict[str, Any]) -> None:
-    """Event-Handler für aktualisiertes Fraktal (für Klangerzeugung).
+
+def _on_fractal_updated_for_sound(
+    event_type: str, event_data: dict[str, Any]
+) -> "tuple[str, dict[str, Any]]":
+    """Bildet ein Fraktal-Update auf die Klangparameter ab.
 
     Args:
         event_type: Typ des Events
         event_data: Event-Daten
+
+    Returns:
+        tuple: (Ziel-Event, Payload) — emittiert wird in _make_forwarder
     """
     # Extrahiere Fraktal-Parameter
     center = event_data.get("center", complex(-0.75, 0))
@@ -101,24 +169,29 @@ def _on_fractal_updated_for_sound(event_type: str, event_data: dict[str, Any]) -
 
     # Berechne Klangparameter basierend auf Fraktal-Parametern
     base_frequency = 220.0 * (1.0 + zoom / 10.0)  # Höhere Frequenz bei höherem Zoom
-    modulation_index = abs(center.real) * 5.0  # Modulationsindex basierend auf Realteil des Zentrums
+    # Modulationsindex basierend auf Realteil des Zentrums
+    modulation_index = abs(center.real) * 5.0
 
-    # Sende Event an ResonanceEnhancer
-    from modular_app_structure import EventSystem
-    event_system = EventSystem()
-    event_system.emit_event("generate_fractal_sound", {
+    # Ziel: ResonanceEnhancer
+    return "generate_fractal_sound", {
         "base_frequency": base_frequency,
         "modulation_index": modulation_index,
         "center": center,
-        "zoom": zoom
-    })
+        "zoom": zoom,
+    }
 
-def _on_sensor_data_updated_for_resonance(event_type: str, event_data: dict[str, Any]) -> None:
-    """Event-Handler für aktualisierte Sensordaten (für ResonanceEnhancer).
+
+def _on_sensor_data_updated_for_resonance(
+    event_type: str, event_data: dict[str, Any]
+) -> "tuple[str, dict[str, Any]]":
+    """Bildet Sensordaten auf die Resonanz-Parameter ab.
 
     Args:
         event_type: Typ des Events
         event_data: Event-Daten
+
+    Returns:
+        tuple: (Ziel-Event, Payload) — emittiert wird in _make_forwarder
     """
     # Extrahiere Sensordaten
     accel_x = event_data.get("accel_x", 0)
@@ -129,13 +202,11 @@ def _on_sensor_data_updated_for_resonance(event_type: str, event_data: dict[str,
     gyro_z = event_data.get("gyro_z", 0)
 
     # Berechne Magnitudes
-    accel_magnitude = (accel_x**2 + accel_y**2 + accel_z**2)**0.5
-    gyro_magnitude = (gyro_x**2 + gyro_y**2 + gyro_z**2)**0.5
+    accel_magnitude = (accel_x**2 + accel_y**2 + accel_z**2) ** 0.5
+    gyro_magnitude = (gyro_x**2 + gyro_y**2 + gyro_z**2) ** 0.5
 
-    # Sende Event an ResonanceEnhancer
-    from modular_app_structure import EventSystem
-    event_system = EventSystem()
-    event_system.emit_event("update_resonance_parameters", {
+    # Ziel: ResonanceEnhancer
+    return "update_resonance_parameters", {
         "accel_magnitude": accel_magnitude,
         "gyro_magnitude": gyro_magnitude,
         "accel_x": accel_x,
@@ -143,15 +214,21 @@ def _on_sensor_data_updated_for_resonance(event_type: str, event_data: dict[str,
         "accel_z": accel_z,
         "gyro_x": gyro_x,
         "gyro_y": gyro_y,
-        "gyro_z": gyro_z
-    })
+        "gyro_z": gyro_z,
+    }
 
-def _on_hypergraph_updated(event_type: str, event_data: dict[str, Any]) -> None:
-    """Event-Handler für aktualisierten Hypergraphen.
+
+def _on_hypergraph_updated(
+    event_type: str, event_data: dict[str, Any]
+) -> "tuple[str, dict[str, Any]]":
+    """Bildet ein Hypergraph-Update auf die Klangparameter ab.
 
     Args:
         event_type: Typ des Events
         event_data: Event-Daten
+
+    Returns:
+        tuple: (Ziel-Event, Payload) — emittiert wird in _make_forwarder
     """
     # Extrahiere Hypergraph-Parameter
     nodes_count = event_data.get("nodes_count", 0)
@@ -160,11 +237,9 @@ def _on_hypergraph_updated(event_type: str, event_data: dict[str, Any]) -> None:
     # Berechne Klangparameter basierend auf Hypergraph-Struktur
     chord_complexity = min(5, max(1, edges_count // 2))  # 1-5 basierend auf Kantenanzahl
 
-    # Sende Event an ResonanceEnhancer
-    from modular_app_structure import EventSystem
-    event_system = EventSystem()
-    event_system.emit_event("generate_hypergraph_sound", {
+    # Ziel: ResonanceEnhancer
+    return "generate_hypergraph_sound", {
         "nodes_count": nodes_count,
         "edges_count": edges_count,
-        "chord_complexity": chord_complexity
-    })
+        "chord_complexity": chord_complexity,
+    }

--- a/Fractalsense/tests/integration/__init__.py
+++ b/Fractalsense/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integrationstests über den geteilten Event-Bus."""

--- a/Fractalsense/tests/integration/test_integration_event_bus.py
+++ b/Fractalsense/tests/integration/test_integration_event_bus.py
@@ -1,0 +1,254 @@
+"""
+Integrationstests für den geteilten Event-Bus (ADR-0004).
+
+Der Bus gehört der Anwendung und wird über `app_context["event_system"]` injiziert.
+Diese Tests prüfen, dass die Weiterleitungen genau auf dieser Instanz landen — also
+dass ein Abonnent auf dem geteilten Bus die abgeleiteten Events tatsächlich empfängt.
+
+Sie schlagen mit der früheren Implementierung fehl, die in jedem Handler ein neues
+`EventSystem()` konstruiert hat: dessen Emits liefen in eine weggeworfene Registry,
+der Kreis UI -> integration -> UI schloss sich nie.
+
+Abgedeckte Ketten:
+- colormap_updated     -> update_fractal_colormap
+- fractal_updated      -> generate_fractal_sound
+- sensor_data_updated  -> update_resonance_parameters
+- hypergraph_updated   -> generate_hypergraph_sound
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import integration
+from modular_app_structure import EventSystem
+
+# Quell-Event -> abgeleitetes Ziel-Event
+FORWARDING_CHAINS = [
+    ("colormap_updated", "update_fractal_colormap"),
+    ("fractal_updated", "generate_fractal_sound"),
+    ("sensor_data_updated", "update_resonance_parameters"),
+    ("hypergraph_updated", "generate_hypergraph_sound"),
+]
+
+
+@pytest.fixture
+def bus():
+    """Ein frischer, anwendungseigener Event-Bus."""
+    return EventSystem()
+
+
+@pytest.fixture
+def integrated_bus(bus):
+    """Ein Bus, auf dem der ResonanceEnhancer integriert wurde."""
+    assert integration.integrate_resonance_enhancer({"event_system": bus}) is True
+    return bus
+
+
+def collect(bus, event_type):
+    """Registriert einen Sammler für event_type und gibt dessen Liste zurück."""
+    received = []
+    bus.register_handler(event_type, lambda event_type, data: received.append(data))
+    return received
+
+
+class TestForwardingOnSharedBus:
+    """Die abgeleiteten Events müssen auf dem injizierten Bus ankommen."""
+
+    @pytest.mark.parametrize("source_event,target_event", FORWARDING_CHAINS)
+    def test_chain_reaches_subscriber_on_shared_bus(
+        self, integrated_bus, source_event, target_event
+    ):
+        """Ein Abonnent auf dem geteilten Bus erhält das weitergeleitete Event."""
+        received = collect(integrated_bus, target_event)
+
+        integrated_bus.emit_event(source_event, {})
+
+        assert (
+            len(received) == 1
+        ), f"{source_event} -> {target_event} kam nicht auf dem geteilten Bus an"
+
+    def test_all_chains_share_one_bus_instance(self, integrated_bus):
+        """Alle vier Ketten laufen über dieselbe Instanz — kein zweiter Bus im Spiel."""
+        collectors = {target: collect(integrated_bus, target) for _, target in FORWARDING_CHAINS}
+
+        for source, _ in FORWARDING_CHAINS:
+            integrated_bus.emit_event(source, {})
+
+        assert {target: len(items) for target, items in collectors.items()} == {
+            target: 1 for _, target in FORWARDING_CHAINS
+        }
+
+
+class TestPayloadShapes:
+    """Die Payloads bleiben unverändert (keine Vertragsänderung)."""
+
+    def test_colormap_payload(self, integrated_bus):
+        """colormap_updated reicht den Farbkartennamen durch."""
+        received = collect(integrated_bus, "update_fractal_colormap")
+
+        integrated_bus.emit_event("colormap_updated", {"colormap": "spectral"})
+
+        assert received == [{"colormap": "spectral"}]
+
+    def test_colormap_payload_default(self, integrated_bus):
+        """Ohne Farbkarte im Payload greift der Default."""
+        received = collect(integrated_bus, "update_fractal_colormap")
+
+        integrated_bus.emit_event("colormap_updated", {})
+
+        assert received == [{"colormap": "viridis"}]
+
+    def test_fractal_sound_payload(self, integrated_bus):
+        """fractal_updated leitet Klangparameter aus Zentrum und Zoom ab."""
+        received = collect(integrated_bus, "generate_fractal_sound")
+        center = complex(-0.75, 0.1)
+
+        integrated_bus.emit_event("fractal_updated", {"center": center, "zoom": 4.0})
+
+        assert received == [
+            {
+                "base_frequency": 220.0 * 1.4,
+                "modulation_index": 0.75 * 5.0,
+                "center": center,
+                "zoom": 4.0,
+            }
+        ]
+
+    def test_resonance_payload(self, integrated_bus):
+        """sensor_data_updated ergänzt die Magnituden und reicht die Achsen durch."""
+        received = collect(integrated_bus, "update_resonance_parameters")
+
+        integrated_bus.emit_event(
+            "sensor_data_updated",
+            {
+                "accel_x": 1.0,
+                "accel_y": 2.0,
+                "accel_z": 2.0,
+                "gyro_x": 0.0,
+                "gyro_y": 3.0,
+                "gyro_z": 4.0,
+            },
+        )
+
+        assert received == [
+            {
+                "accel_magnitude": 3.0,
+                "gyro_magnitude": 5.0,
+                "accel_x": 1.0,
+                "accel_y": 2.0,
+                "accel_z": 2.0,
+                "gyro_x": 0.0,
+                "gyro_y": 3.0,
+                "gyro_z": 4.0,
+            }
+        ]
+
+    def test_hypergraph_payload(self, integrated_bus):
+        """hypergraph_updated leitet die Akkordkomplexität aus der Kantenzahl ab."""
+        received = collect(integrated_bus, "generate_hypergraph_sound")
+
+        integrated_bus.emit_event("hypergraph_updated", {"nodes_count": 6, "edges_count": 7})
+
+        assert received == [{"nodes_count": 6, "edges_count": 7, "chord_complexity": 3}]
+
+
+class TestIdempotency:
+    """Wiederholte Integration darf keine doppelten Handler registrieren."""
+
+    def test_second_integration_is_a_noop(self, bus):
+        """Zweimal integrieren -> jedes Event wird trotzdem nur einmal weitergeleitet."""
+        assert integration.integrate_resonance_enhancer({"event_system": bus}) is True
+        assert integration.integrate_resonance_enhancer({"event_system": bus}) is True
+
+        collectors = {target: collect(bus, target) for _, target in FORWARDING_CHAINS}
+
+        for source, _ in FORWARDING_CHAINS:
+            bus.emit_event(source, {})
+
+        for target, items in collectors.items():
+            assert len(items) == 1, f"{target} wurde {len(items)}x weitergeleitet"
+
+    def test_repeated_integration_reports_success(self, bus):
+        """Auch der wiederholte Aufruf meldet Erfolg, nicht Fehler."""
+        integration.integrate_resonance_enhancer({"event_system": bus})
+
+        assert integration.integrate_resonance_enhancer({"event_system": bus}) is True
+
+
+class TestNoGlobalState:
+    """EventSystem bleibt unabhängig instanziierbar — kein Singleton."""
+
+    def test_instances_have_separate_registries(self):
+        """Zwei Busse teilen keine Handler."""
+        bus_a, bus_b = EventSystem(), EventSystem()
+        received_a = collect(bus_a, "ping")
+
+        bus_b.emit_event("ping", {})
+
+        assert received_a == []
+
+    def test_integrating_one_bus_does_not_wire_another(self, bus):
+        """Ein nicht integrierter Bus leitet nichts weiter."""
+        integration.integrate_resonance_enhancer({"event_system": bus})
+
+        other_bus = EventSystem()
+        received = collect(other_bus, "update_fractal_colormap")
+
+        other_bus.emit_event("colormap_updated", {"colormap": "spectral"})
+
+        assert received == []
+
+    def test_integration_flag_is_per_instance(self, bus):
+        """Der Idempotenz-Marker hängt am Bus, nicht an der Klasse."""
+        integration.integrate_resonance_enhancer({"event_system": bus})
+
+        fresh = EventSystem()
+        assert getattr(fresh, integration._CONNECTED_FLAG, False) is False
+
+    def test_forwarding_targets_the_injected_bus_only(self, bus):
+        """Weitergeleitet wird ausschließlich auf den injizierten Bus."""
+        integration.integrate_resonance_enhancer({"event_system": bus})
+
+        listener = EventSystem()
+        received_elsewhere = collect(listener, "update_resonance_parameters")
+        received_here = collect(bus, "update_resonance_parameters")
+
+        bus.emit_event("sensor_data_updated", {"accel_x": 1.0})
+
+        assert len(received_here) == 1
+        assert received_elsewhere == []
+
+
+class TestIntegrationEntryPoint:
+    """Verhalten von integrate_resonance_enhancer selbst."""
+
+    def test_returns_false_without_event_system(self):
+        """Fehlt der Bus im App-Kontext, schlägt die Integration fehl."""
+        assert integration.integrate_resonance_enhancer({}) is False
+
+    def test_returns_false_when_event_system_is_none(self):
+        """Ein explizites None ist ebenfalls ein Fehlerfall."""
+        assert integration.integrate_resonance_enhancer({"event_system": None}) is False
+
+
+class TestMappersArePure:
+    """Die _on_*-Funktionen bilden nur ab und emittieren nicht selbst."""
+
+    def test_mappers_return_target_and_payload(self):
+        """Jeder Mapper liefert (Ziel-Event, Payload)."""
+        mappers = {
+            integration._on_colormap_updated: "update_fractal_colormap",
+            integration._on_fractal_updated_for_sound: "generate_fractal_sound",
+            integration._on_sensor_data_updated_for_resonance: "update_resonance_parameters",
+            integration._on_hypergraph_updated: "generate_hypergraph_sound",
+        }
+
+        for mapper, expected_target in mappers.items():
+            target, payload = mapper("source_event", {})
+            assert target == expected_target
+            assert isinstance(payload, dict)

--- a/docs/decisions/ADR-0004-application-owned-event-bus.md
+++ b/docs/decisions/ADR-0004-application-owned-event-bus.md
@@ -1,0 +1,112 @@
+# ADR-0004: Application-Owned Event Bus, Explicitly Injected — No Singleton
+
+- **Status:** Accepted
+- **Datum:** 2026-07-29
+- **Kontext-Fokus:** Event-Bus-Besitz in `Fractalsense/integration.py`
+
+## Context
+
+`Fractalsense/integration.py` verbindet Fractal-Visualization, Sensor-Integration und
+Hypergraph-Visualization mit dem ResonanceEnhancer. Der Einstiegspunkt
+`integrate_resonance_enhancer(app_context)` erhält den Bus der Anwendung über
+`app_context["event_system"]` und registriert darauf vier Forwarding-Handler.
+
+Die Handler emittierten das abgeleitete Event jedoch **nicht** auf diesem Bus. Jeder
+von ihnen konstruierte lokal eine neue Instanz:
+
+```python
+from modular_app_structure import EventSystem
+event_system = EventSystem()
+event_system.emit_event("update_resonance_parameters", {...})
+```
+
+`EventSystem.__init__` legt ein eigenes `_event_handlers`-Dict an — die Registry ist
+instanzgebunden. Die Emits liefen daher in eine sofort verworfene Registry: der Kreis
+**UI → integration → UI schloss sich nie**. Die Integrationsschicht war inert, ohne
+dass ein Test das bemerkt hätte.
+
+Betroffen sind alle vier Ketten:
+
+| Quell-Event | abgeleitetes Event |
+|---|---|
+| `colormap_updated` | `update_fractal_colormap` |
+| `fractal_updated` | `generate_fractal_sound` |
+| `sensor_data_updated` | `update_resonance_parameters` |
+| `hypergraph_updated` | `generate_hypergraph_sound` |
+
+## Decision
+
+**Der Event-Bus gehört der Anwendung und wird explizit injiziert. Kein Singleton.**
+
+1. **Eine Instanz, ein Besitzer.** Die Instanz, die `integrate_resonance_enhancer()`
+   im `app_context` erhält, ist der explizite Besitzer des vollständigen Event-Kreises.
+   Alle weitergeleiteten Events werden auf genau dieser Instanz emittiert.
+2. **Injektion per Closure.** `_make_forwarder(event_system, mapper)` erzeugt einen
+   Handler, der den Bus als Closure-Variable trägt. Kein Modul-Global, keine
+   Registry, kein `functools.partial` nötig — der Bus wird zur Registrierungszeit
+   gebunden.
+3. **Abbildung von Transport getrennt.** Die `_on_*`-Funktionen sind reine
+   Abbildungen `(event_type, event_data) -> (ziel_event, payload)` und emittieren
+   nicht mehr selbst. Sie bleiben ohne Bus testbar; `_make_forwarder` übernimmt den
+   Transport.
+4. **`EventSystem` bleibt unverändert.** Kein globaler Zustand, keine Klassenattribute,
+   kein Singleton-Zugriffspunkt. Zwei Instanzen bleiben vollständig unabhängig.
+5. **Idempotente Registrierung.** `integrate_resonance_enhancer()` setzt den Marker
+   `_resonance_enhancer_connected` **auf der Bus-Instanz** und überspringt einen
+   zweiten Aufruf mit demselben Bus (Rückgabe weiterhin `True`). Der Marker hängt
+   pro Instanz, nicht an der Klasse — ein frischer Bus ist nie vorbelastet.
+6. **Verträge unverändert.** Event-Namen und Payload-Formen bleiben exakt wie zuvor;
+   dies ist ein Transport-Fix, keine Protokolländerung.
+
+## Consequences
+
+- (+) Die Kette UI → `integration` → UI schließt sich; Abonnenten auf dem geteilten
+  Bus erhalten die abgeleiteten Events tatsächlich.
+- (+) Kein verstecktes globales Gedächtnis: wer den Bus besitzt, ist im Code sichtbar.
+  Tests können beliebig viele unabhängige Busse aufbauen.
+- (+) Die Abbildungslogik ist ohne Bus prüfbar (reine Funktionen).
+- (+) Wiederholte Integration verdoppelt die Weiterleitung nicht mehr.
+- (−) Die `_on_*`-Funktionen geben jetzt zurück statt zu emittieren. Ihre Signatur
+  `(event_type, event_data)` bleibt, aber wer sie direkt aufruft, erhält ein Tupel
+  statt eines Seiteneffekts.
+- (−) Der Idempotenz-Marker wird per `setattr` auf einer fremden Instanz gesetzt.
+  Bewusst gewählt gegenüber einer Modul-Registry (die wäre globaler Zustand) und
+  gegenüber einer Listing-API auf `EventSystem` (die wäre eine Fremdänderung an
+  `modular_app_structure`).
+
+## Alternatives Considered
+
+1. **`EventSystem` als Singleton** (`get_instance()` / Modul-Global) — verworfen.
+   Löst das Symptom, führt aber globalen Zustand ein: Tests werden voneinander
+   abhängig, mehrere unabhängige Busse werden unmöglich, und der Besitz des Kreises
+   verschwindet aus dem Code. Ausdrücklich ausgeschlossen.
+2. **Bus als drittes Argument durch die `_on_*`-Handler reichen**
+   (`functools.partial(_on_x, event_system)`) — funktionsfähig, ändert aber die
+   Signatur der `_on_*`-Funktionen und damit bestehende Aufrufstellen. Die
+   Closure-Variante hält die Signatur stabil.
+3. **Modul-weite `WeakSet` bereits integrierter Busse** für die Idempotenz —
+   verworfen: das wäre erneut verstecktes globales Modulgedächtnis, genau die
+   Eigenschaft, die diese Entscheidung vermeidet.
+4. **Idempotenz nur dokumentieren statt erzwingen** — verworfen: eine doppelte
+   Integration wäre still und würde jedes Event doppelt weiterleiten. Ein
+   erzwungener No-Op ist billiger als eine Konvention.
+
+## Essence Preservation Note
+
+Die Entscheidung ändert **wer** ein Event zugestellt bekommt, nicht **was** zugestellt
+wird. Event-Namen, Payload-Schlüssel und Ableitungsformeln (Magnituden, Basisfrequenz,
+Modulationsindex, Akkordkomplexität) bleiben identisch — nachgewiesen durch
+`Fractalsense/tests/integration/test_integration_event_bus.py`.
+
+## Verification
+
+`Fractalsense/tests/integration/test_integration_event_bus.py` (19 Fälle) prüft:
+
+- alle vier Ketten auf **einem** geteilten Bus (Abonnent empfängt tatsächlich);
+- unveränderte Payload-Formen inkl. Defaults;
+- Idempotenz bei wiederholter Integration;
+- Unabhängigkeit zweier `EventSystem`-Instanzen (kein Singleton-Verhalten);
+- dass die Weiterleitung ausschließlich den injizierten Bus trifft.
+
+Gegen die frühere Implementierung schlagen 14 dieser 19 Fälle fehl — darunter alle
+vier Kettentests.


### PR DESCRIPTION
## Intent

`integration.py` registrierte seine vier Forwarding-Handler auf dem Bus aus `app_context["event_system"]`, emittierte die abgeleiteten Events aber auf **jeweils frisch konstruierten** `EventSystem()`-Instanzen:

```python
from modular_app_structure import EventSystem
event_system = EventSystem()          # neue, leere Registry
event_system.emit_event("update_resonance_parameters", {...})
```

Da `EventSystem.__init__` ein eigenes `_event_handlers` anlegt, ist die Registry instanzgebunden — diese Emits liefen in eine sofort verworfene Registry. **Der Kreis UI → `integration` → UI schloss sich nie**; die Integrationsschicht war inert, ohne dass ein Test das bemerkt hätte.

Der Bus gehört jetzt explizit der Anwendung und wird injiziert. `_make_forwarder(event_system, mapper)` bindet den übergebenen Bus als Closure; alle vier Ketten emittieren auf genau dieser Instanz:

| Quell-Event | abgeleitetes Event |
|---|---|
| `colormap_updated` | `update_fractal_colormap` |
| `fractal_updated` | `generate_fractal_sound` |
| `sensor_data_updated` | `update_resonance_parameters` |
| `hypergraph_updated` | `generate_hypergraph_sound` |

Die architektonische Entscheidung ist als **[ADR-0004: Application-Owned Event Bus, Explicitly Injected — No Singleton](docs/decisions/ADR-0004-application-owned-event-bus.md)** festgehalten.

### Vorgaben ↔ Umsetzung

| Vorgabe | Umsetzung |
|---|---|
| Alle Events auf dem exakt übergebenen Bus | Closure in `_make_forwarder`; `grep -c "EventSystem()" integration.py` → **0** |
| `EventSystem` unabhängig instanziierbar, kein Singleton/globaler Zustand | `modular_app_structure.py` **unverändert**; Tests belegen unabhängige Registries |
| Event-Namen und Payload-Formen unverändert | reiner Transport-Fix; Payload-Tests inkl. Defaults |
| Keine fremde Modularchitektur refaktoriert | Diff berührt nur `integration.py` + neue Tests + ADR |
| Integrationstests über einen geteilten Bus | `tests/integration/test_integration_event_bus.py`, 19 Fälle |
| Tests scheitern am alten Verhalten | **14 von 19 rot**, darunter alle vier Kettentests (Beleg unten) |
| Idempotenz geprüft | erzwungen + getestet (s. u.) |

## Scope

FOKUS: Event-Bus injizieren

- `Fractalsense/integration.py` — Forwarding per Closure, Idempotenz-Marker, vier tote Importe entfernt (`os`, `sys`, `importlib`, `ModuleInterface`)
- `Fractalsense/tests/integration/` — neu, 19 Fälle
- `docs/decisions/ADR-0004-application-owned-event-bus.md` — neu
- `.claude/settings.local.json` — Session-Permissions, von der Harness geschrieben; separater `chore`-Commit, ohne Bezug zum Event-Bus-Fix

Kein GOLD (`index/`, `policies/`, `VOIDMAP.yml`, `spec/`) und keine Receipts berührt. `modular_app_structure.py` bleibt unangetastet.

### Abbildung und Transport getrennt

Die `_on_*`-Funktionen sind jetzt reine Abbildungen `(event_type, event_data) -> (ziel_event, payload)` und emittieren nicht mehr selbst. Ihre Signatur bleibt **zweistellig**, damit bestehende Aufrufstellen nicht brechen — insbesondere die beiden in PR #341 (`_on_sensor_data_updated_for_resonance`, `_on_fractal_updated_for_sound`); beide wurden gegen diesen Stand geprüft und laufen unverändert durch.

### Idempotenz

War **nicht** gewährleistet: ein zweiter `integrate_resonance_enhancer()`-Aufruf hätte die Handler erneut registriert und jedes Event doppelt weitergeleitet. Jetzt erzwungen — der Marker `_resonance_enhancer_connected` wird **auf der Bus-Instanz** gesetzt (per `setattr`, bewusst pro Instanz statt als Modul-Registry, die wieder globaler Zustand wäre). Ein zweiter Aufruf ist ein No-Op und gibt weiterhin `True` zurück. Zwei Tests decken das ab.

## Test Plan

- [x] **19 neue Integrationstests**, alle grün: vier Ketten auf einem geteilten Bus · Payload-Formen inkl. Defaults · Idempotenz · Unabhängigkeit zweier Busse · Weiterleitung trifft ausschließlich den injizierten Bus · Mapper-Reinheit
- [x] **Rot-Beleg gegen das alte Verhalten** — `integration.py` auf `main`-Stand gestasht, dieselben Tests laufen lassen: **14 failed, 5 passed**, darunter alle vier Kettentests:

```
FAILED ...::test_chain_reaches_subscriber_on_shared_bus[colormap_updated-update_fractal_colormap]
FAILED ...::test_chain_reaches_subscriber_on_shared_bus[fractal_updated-generate_fractal_sound]
FAILED ...::test_chain_reaches_subscriber_on_shared_bus[sensor_data_updated-update_resonance_parameters]
FAILED ...::test_chain_reaches_subscriber_on_shared_bus[hypergraph_updated-generate_hypergraph_sound]
FAILED ...::TestForwardingOnSharedBus::test_all_chains_share_one_bus_instance
FAILED ...::TestPayloadShapes (5 Fälle)   FAILED ...::TestIdempotency::test_second_integration_is_a_noop
```

- [x] Fractalsense-Suite grün: **159 passed** (140 vorhandene + 19 neue)
- [x] `make verify` grün (port-lint · pytest · verify-pointers --strict · claim-lint)
- [x] `ruff` und `black --line-length 100` sauber auf allen geänderten/neuen Dateien
- [x] **Manual testing completed** — geschlossener Kreis auf einem anwendungseigenen Bus:

```
update_fractal_colormap        {'colormap': 'spectral'}
generate_fractal_sound         {'base_frequency': 308.0, 'modulation_index': 3.75, 'center': (-0.75+0.1j), 'zoom': 4.0}
update_resonance_parameters    {'accel_magnitude': 3.0, 'gyro_magnitude': 5.0, 'accel_x': 1.0, ...}
generate_hypergraph_sound      {'nodes_count': 6, 'edges_count': 7, 'chord_complexity': 3}

ResonanceEnhancer ist mit diesem Event-Bus bereits verbunden.   ← zweiter Aufruf
OK — 4 Ketten auf einem Bus; wiederholte Integration verdoppelt nicht
```

- [x] **CI checks pass** — alle 42 Check-Runs auf `485cc8d` grün bzw. übersprungen: `All Checks Passed`, `All Tests Pass`, `Build (Test & Coverage)` 3.9–3.12, `Python Tests` 3.10–3.12, `Verify (Lint & Type Check)` 3.10–3.12, `Verify Pointers & Lint (blocking)`, `deepjump-audit`, `Gate Policy Validation`, `Security Scan`, CodeQL (4 Sprachen), `Lint · Format · Types · SAST`, `UI Build`, `JavaScript Tests`, FOKUS-Marker. `mergeable_state: clean`.

## Risk

**Gering.** Der Diff ist auf `integration.py` begrenzt; auf `main` gibt es außerhalb der Datei selbst keine Aufrufer von `integrate_resonance_enhancer`, `_connect_*` oder `_on_*` (per grep geprüft).

Punkte fürs Review:

1. **Verhaltensänderung mit Absicht:** Wer `_on_*` direkt aufruft, bekommt jetzt ein Tupel zurück statt eines Seiteneffekts. Signatur und Payload-Inhalt bleiben gleich.
2. **`setattr` auf einer fremden Instanz** für den Idempotenz-Marker. Alternativen (Modul-`WeakSet`, Listing-API auf `EventSystem`) sind in ADR-0004 unter *Alternatives Considered* mit Begründung verworfen — die eine wäre globaler Zustand, die andere eine Fremdänderung an `modular_app_structure`.
3. **Überschneidung mit PR #341:** unabhängig, beide von `main` aus mergebar. #341 ruft zwei `_on_*`-Funktionen direkt auf; die Aufrufe wurden gegen diesen Branch verifiziert. Merge-Reihenfolge ist egal.