### PR TITLE
docs: bind README roadmap to VOIDMAP source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,24 +255,13 @@ pnpm --filter entaengelment-ui dev
 
 ## IX. Roadmap
 
-**Now:**
-- DeepJump v1.2 stabilisieren (Verify + Status + Snapshot)
-- Port-Matrix Linter (K0..K4) ausrollen
-- Guards-Integration in CI (Metatron, Annex)
+Der aktuelle Arbeitsstand wird in [`VOIDMAP.yml`](VOIDMAP.yml) geführt. Die Datei ist die Source of Truth für offene Lücken, Status, Prioritäten, Verantwortliche, Closing Paths und Evidence.
 
-**Next:**
-- Receipt-Viewer mit Signatur-Verifizierung
-- Resonanz-Metriken stabilisieren (VOID-011: MI, PLV, FD)
-- CI-Pipeline Integration (VOID-002)
+- [`VOIDMAP.yml`](VOIDMAP.yml) – verbindliche Status-Registry
+- [`docs/voids_backlog.md`](docs/voids_backlog.md) – lesbare, abgeleitete Backlog-Ansicht
+- [GitHub Issues](https://github.com/fleksible/entaENGELment-/issues) – Umsetzungs- und Review-Threads
 
-**Later:**
-- Sensor-Architektur (VOID-013, BOM + Protokoll)
-- Taxonomie & Spektren (VOID-010, Literatur-Scan)
-- Protein-Design Exploration (VOID-014, in-silico only)
-
-**Mehr:**
-- [GitHub Issues](https://github.com/fleksible/entaENGELment-/issues)
-- [`VOIDMAP.yml`](VOIDMAP.yml) für vollständigen Backlog
+Eine zweite statische `Now / Next / Later`-Liste wird hier bewusst nicht gepflegt, weil sie von der Registry abdriften kann. Narrative Orientierung bleibt in [`WELCOME.md`](WELCOME.md).
 
 ---
 


### PR DESCRIPTION
## Vorschlagsartefakt (authority: DERIVED)

### Befund
Die statische Roadmap in `README.md` war gegenüber `VOIDMAP.yml` abgedriftet: Unter anderem wurden VOID-002 und VOID-013 noch als zukünftige Arbeit geführt, obwohl die Registry sie als `CLOSED` ausweist; VOID-014 erschien unter „Later“, während die Registry `SUSPENDED` ausweist.

### Änderung
- statische `Now / Next / Later`-Liste entfernt
- `VOIDMAP.yml` als bestehende Source of Truth benannt
- auf die abgeleitete Ansicht `docs/voids_backlog.md`, GitHub Issues und `WELCOME.md` verwiesen

### Reichweite
Nur `README.md`. Keine Änderung an Code, Policies, Receipts, VOID-Status oder Governance. Keine Statuspromotion; Übernahme ausschließlich durch menschlichen Review und Merge.

### Prüfung
- geänderten Abschnitt nach dem Commit zurückgelesen
- alle drei lokalen Verweisziele (`VOIDMAP.yml`, `docs/voids_backlog.md`, `WELCOME.md`) auf dem Branch erfolgreich gelesen

### Exit
Ein einzelner Dokumentations-Commit; bei Nichtübernahme kann der Draft-PR geschlossen oder der Commit revertiert werden.